### PR TITLE
Fix add-server flow and async race conditions

### DIFF
--- a/app/src/main/java/com/stillshelf/app/playback/controller/PlaybackController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/controller/PlaybackController.kt
@@ -41,11 +41,14 @@ class PlaybackController @Inject constructor(
     private var lastSyncedPositionMs: Long = -1L
     private var syncInFlight = false
     private var cachedContinueListeningItem: ContinueListeningItem? = null
+    private var playRequestJob: Job? = null
+    private var playRequestToken: Long = 0L
 
     val uiState: StateFlow<PlaybackUiState> = mutableUiState.asStateFlow()
 
     fun playBook(bookId: String, startPositionMs: Long? = null) {
         if (bookId.isBlank()) return
+        val requestToken = beginPlayRequest()
         if (currentBookId == bookId && mediaPlayer != null) {
             if (startPositionMs != null) {
                 seekToPosition(startPositionMs)
@@ -55,11 +58,13 @@ class PlaybackController @Inject constructor(
         }
 
         mutableUiState.update { it.copy(isLoading = true, errorMessage = null) }
-        scope.launch {
+        playRequestJob = scope.launch {
             when (val sourceResult = sessionRepository.fetchPlaybackSource(bookId)) {
                 is AppResult.Success -> {
+                    if (isStalePlayRequest(requestToken)) return@launch
                     sessionRepository.setLastPlayedBookId(sourceResult.value.book.id)
                     val progressResult = sessionRepository.fetchPlaybackProgress(sourceResult.value.book.id)
+                    if (isStalePlayRequest(requestToken)) return@launch
                     val serverResumeMs = when (progressResult) {
                         is AppResult.Success -> {
                             ((progressResult.value?.currentTimeSeconds ?: 0.0) * 1000.0).toLong()
@@ -83,6 +88,7 @@ class PlaybackController @Inject constructor(
                         progressPercent = progressPercent,
                         currentTimeSeconds = currentTimeSeconds
                     )
+                    if (isStalePlayRequest(requestToken)) return@launch
                     prepareAndPlay(
                         sourceResult.value.book.id,
                         sourceResult.value.book,
@@ -91,6 +97,7 @@ class PlaybackController @Inject constructor(
                     )
                 }
                 is AppResult.Error -> {
+                    if (isStalePlayRequest(requestToken)) return@launch
                     mutableUiState.update {
                         it.copy(
                             isLoading = false,
@@ -100,6 +107,16 @@ class PlaybackController @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun beginPlayRequest(): Long {
+        playRequestJob?.cancel()
+        playRequestToken += 1L
+        return playRequestToken
+    }
+
+    private fun isStalePlayRequest(requestToken: Long): Boolean {
+        return requestToken != playRequestToken
     }
 
     fun playBookFromPosition(bookId: String, startPositionMs: Long) {

--- a/app/src/main/java/com/stillshelf/app/ui/navigation/MainNavGraph.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/navigation/MainNavGraph.kt
@@ -42,6 +42,9 @@ import com.stillshelf.app.ui.screens.ServersManagementScreen
 import com.stillshelf.app.ui.screens.SeriesDetailScreen
 import com.stillshelf.app.ui.screens.SeriesBrowseScreen
 import com.stillshelf.app.ui.screens.SettingsPlaceholderScreen
+import com.stillshelf.app.ui.screens.auth.AddServerRoute
+import com.stillshelf.app.ui.screens.auth.LibraryPickerRoute
+import com.stillshelf.app.ui.screens.auth.LoginRoute
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material.icons.outlined.CollectionsBookmark
@@ -261,7 +264,56 @@ private fun MainTabsNavHost(
         }
         composable(MainRoute.SERVERS) {
             ServersManagementScreen(
-                onBackClick = { navController.popBackStack() }
+                onBackClick = { navController.popBackStack() },
+                onAddServerClick = {
+                    navController.navigate(AuthRoute.ADD_SERVER) {
+                        launchSingleTop = true
+                    }
+                }
+            )
+        }
+        composable(AuthRoute.ADD_SERVER) {
+            AddServerRoute(
+                onContinue = { serverName, baseUrl ->
+                    navController.navigate(AuthRoute.loginRoute(serverName, baseUrl)) {
+                        launchSingleTop = true
+                    }
+                },
+                onBack = { navController.popBackStack() }
+            )
+        }
+        composable(
+            route = AuthRoute.LOGIN_PATTERN,
+            arguments = listOf(
+                navArgument(AuthRoute.SERVER_NAME_ARG) { type = NavType.StringType },
+                navArgument(AuthRoute.BASE_URL_ARG) { type = NavType.StringType }
+            )
+        ) {
+            LoginRoute(
+                onBack = { navController.popBackStack() },
+                onLoginSuccess = {
+                    navController.navigate(AuthRoute.LIBRARY_PICKER) {
+                        launchSingleTop = true
+                    }
+                }
+            )
+        }
+        composable(AuthRoute.LIBRARY_PICKER) {
+            LibraryPickerRoute(
+                onLibrarySelected = {
+                    if (!navController.popBackStack(MainRoute.SERVERS, inclusive = false)) {
+                        navController.navigate(MainRoute.SERVERS) {
+                            launchSingleTop = true
+                        }
+                    }
+                },
+                onManageServers = {
+                    if (!navController.popBackStack(MainRoute.SERVERS, inclusive = false)) {
+                        navController.navigate(MainRoute.SERVERS) {
+                            launchSingleTop = true
+                        }
+                    }
+                }
             )
         }
         composable(MainRoute.CUSTOMIZE) {

--- a/app/src/main/java/com/stillshelf/app/ui/screens/PlaceholderScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/PlaceholderScreens.kt
@@ -2036,7 +2036,7 @@ private fun SettingsRow(
 @Composable
 fun ServersManagementScreen(
     onBackClick: () -> Unit,
-    onAddServerClick: () -> Unit = {},
+    onAddServerClick: () -> Unit,
     viewModel: ServerManagementViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()

--- a/app/src/main/java/com/stillshelf/app/ui/screens/SearchViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/SearchViewModel.kt
@@ -35,6 +35,7 @@ class SearchViewModel @Inject constructor(
     private val mutableUiState = MutableStateFlow(SearchUiState())
     val uiState: StateFlow<SearchUiState> = mutableUiState.asStateFlow()
     private var searchJob: Job? = null
+    private var searchRequestToken: Long = 0L
 
     init {
         viewModelScope.launch {
@@ -84,18 +85,23 @@ class SearchViewModel @Inject constructor(
 
     private fun search(query: String, debounceMs: Long = 220L) {
         searchJob?.cancel()
+        val requestToken = nextSearchRequestToken()
+        val requestedQuery = query.trim()
+        if (requestedQuery.isBlank()) return
         searchJob = viewModelScope.launch {
             if (debounceMs > 0) delay(debounceMs)
-            val currentQuery = uiState.value.query.trim()
-            if (currentQuery.isBlank()) return@launch
+            if (isStaleSearchRequest(requestToken, requestedQuery)) return@launch
+            val activeQuery = uiState.value.query.trim()
+            if (activeQuery.isBlank()) return@launch
 
             mutableUiState.update { it.copy(isLoading = true, errorMessage = null) }
-            when (val result = sessionRepository.searchActiveLibrary(currentQuery)) {
+            when (val result = sessionRepository.searchActiveLibrary(activeQuery)) {
                 is AppResult.Success -> {
-                    val rankedBooks = rankBooks(currentQuery, result.value.books)
-                    val rankedAuthors = rankEntities(currentQuery, result.value.authors)
-                    val rankedSeries = rankEntities(currentQuery, result.value.series)
-                    val rankedNarrators = rankEntities(currentQuery, result.value.narrators)
+                    if (isStaleSearchRequest(requestToken, activeQuery)) return@launch
+                    val rankedBooks = rankBooks(activeQuery, result.value.books)
+                    val rankedAuthors = rankEntities(activeQuery, result.value.authors)
+                    val rankedSeries = rankEntities(activeQuery, result.value.series)
+                    val rankedNarrators = rankEntities(activeQuery, result.value.narrators)
                     mutableUiState.update {
                         it.copy(
                             isLoading = false,
@@ -108,6 +114,7 @@ class SearchViewModel @Inject constructor(
                 }
 
                 is AppResult.Error -> {
+                    if (isStaleSearchRequest(requestToken, activeQuery)) return@launch
                     mutableUiState.update {
                         it.copy(
                             isLoading = false,
@@ -121,6 +128,17 @@ class SearchViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun nextSearchRequestToken(): Long {
+        searchRequestToken += 1L
+        return searchRequestToken
+    }
+
+    private fun isStaleSearchRequest(requestToken: Long, expectedQuery: String? = null): Boolean {
+        if (requestToken != searchRequestToken) return true
+        val currentQuery = uiState.value.query.trim()
+        return expectedQuery != null && currentQuery != expectedQuery
     }
 
     private fun rankBooks(


### PR DESCRIPTION
## Summary
- wire Servers Management -> Add Server to a real add/login/library-picker flow in main navigation
- remove default no-op add-server callback to prevent silent regressions
- guard playback start requests with request tokens so stale in-flight requests cannot override newer selections
- guard search requests with request tokens/query checks so stale results are ignored
- ## Verification
- GRADLE_USER_HOME=/tmp/gradle ./gradlew :app:compileDebugKotlin --stacktrace
- ## Notes
-  This addresses the critical Add Server no-op and stale async result races for playback/search from bug backlog.