### PR TITLE
Fix session consistency, home-cache expiry, and mini-player overlap

### DIFF
--- a/app/src/main/java/com/stillshelf/app/core/database/ServerDao.kt
+++ b/app/src/main/java/com/stillshelf/app/core/database/ServerDao.kt
@@ -16,4 +16,7 @@ interface ServerDao {
 
     @Query("SELECT * FROM servers WHERE id = :serverId LIMIT 1")
     suspend fun getById(serverId: String): ServerEntity?
+
+    @Query("DELETE FROM servers WHERE id = :serverId")
+    suspend fun deleteById(serverId: String)
 }

--- a/app/src/main/java/com/stillshelf/app/data/repo/SessionRepository.kt
+++ b/app/src/main/java/com/stillshelf/app/data/repo/SessionRepository.kt
@@ -46,7 +46,7 @@ interface SessionRepository {
     suspend fun setLastPlayedBookId(bookId: String?): AppResult<Unit>
     suspend fun searchActiveLibrary(query: String, limit: Int = 60): AppResult<SearchResults>
     suspend fun fetchMiniPlayerItem(): AppResult<ContinueListeningItem?>
-    suspend fun fetchCachedHomeFeed(): AppResult<HomeFeed?>
+    suspend fun fetchCachedHomeFeed(maxAgeMs: Long? = null): AppResult<HomeFeed?>
     suspend fun fetchHomeFeed(
         continueLimit: Int = 10,
         recentlyAddedLimit: Int = 12

--- a/app/src/main/java/com/stillshelf/app/data/repo/SessionRepositoryImpl.kt
+++ b/app/src/main/java/com/stillshelf/app/data/repo/SessionRepositoryImpl.kt
@@ -52,6 +52,10 @@ class SessionRepositoryImpl @Inject constructor(
     private val secureTokenStorage: SecureTokenStorage,
     private val audiobookshelfApi: AudiobookshelfApi
 ) : SessionRepository {
+    companion object {
+        private const val HOME_FEED_CACHE_MAX_AGE_MS: Long = 10 * 60 * 1000L
+    }
+
     private data class ActiveConnection(
         val server: ServerEntity,
         val token: String,
@@ -178,8 +182,8 @@ class SessionRepositoryImpl @Inject constructor(
             return AppResult.Error("No libraries were returned for this account.")
         }
 
+        val serverId = UUID.randomUUID().toString()
         return try {
-            val serverId = UUID.randomUUID().toString()
             val serverEntity = ServerEntity(
                 id = serverId,
                 name = serverName.trim(),
@@ -195,6 +199,7 @@ class SessionRepositoryImpl @Inject constructor(
 
             AppResult.Success(Unit)
         } catch (t: Throwable) {
+            rollbackFailedServerSetup(serverId)
             AppResult.Error("Unable to save server session.", t)
         }
     }
@@ -829,12 +834,17 @@ class SessionRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun fetchCachedHomeFeed(): AppResult<HomeFeed?> {
+    override suspend fun fetchCachedHomeFeed(maxAgeMs: Long?): AppResult<HomeFeed?> {
         val activeLibraryId = sessionPreferences.state.first().activeLibraryId
             ?: return AppResult.Success(null)
         val cached = sessionPreferences.getCachedHomeFeed()
             ?: return AppResult.Success(null)
         if (cached.libraryId != activeLibraryId) {
+            return AppResult.Success(null)
+        }
+        val cacheAgeMs = (System.currentTimeMillis() - cached.savedAtMs).coerceAtLeast(0L)
+        val effectiveMaxAgeMs = maxAgeMs ?: HOME_FEED_CACHE_MAX_AGE_MS
+        if (cacheAgeMs > effectiveMaxAgeMs) {
             return AppResult.Success(null)
         }
 
@@ -1077,6 +1087,12 @@ class SessionRepositoryImpl @Inject constructor(
                 )
             }
         )
+    }
+
+    private suspend fun rollbackFailedServerSetup(serverId: String) {
+        runCatching { secureTokenStorage.clearToken(serverId) }
+        runCatching { libraryDao.deleteByServerId(serverId) }
+        runCatching { serverDao.deleteById(serverId) }
     }
 
     private suspend fun getActiveConnection(requireLibrary: Boolean): AppResult<ActiveConnection> {

--- a/app/src/main/java/com/stillshelf/app/ui/components/RootScaffold.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/components/RootScaffold.kt
@@ -27,7 +27,7 @@ fun RootScaffold(
     showMiniPlayer: Boolean = true,
     content: @Composable (PaddingValues) -> Unit
 ) {
-    val contentBottomInset = 0.dp
+    val contentBottomInset = if (showMiniPlayer) 88.dp else 0.dp
 
     Box(modifier = Modifier.fillMaxSize()) {
         Box(

--- a/app/src/main/java/com/stillshelf/app/ui/screens/HomeViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/HomeViewModel.kt
@@ -21,6 +21,10 @@ import kotlinx.coroutines.launch
 class HomeViewModel @Inject constructor(
     private val sessionRepository: SessionRepository
 ) : ViewModel() {
+    companion object {
+        private const val HOME_FEED_CACHE_MAX_AGE_MS: Long = 10 * 60 * 1000L
+    }
+
     private val mutableUiState = MutableStateFlow(HomeUiState())
     val uiState: StateFlow<HomeUiState> = mutableUiState.asStateFlow()
 
@@ -44,7 +48,9 @@ class HomeViewModel @Inject constructor(
     }
 
     private suspend fun loadCachedThenMaybeRefresh() {
-        val cachedResult = sessionRepository.fetchCachedHomeFeed()
+        val cachedResult = sessionRepository.fetchCachedHomeFeed(
+            maxAgeMs = HOME_FEED_CACHE_MAX_AGE_MS
+        )
         if (cachedResult is AppResult.Success && cachedResult.value != null) {
             val resolvedRecentSeries = resolveRecentSeries(
                 backendRecentSeries = cachedResult.value.recentSeries,


### PR DESCRIPTION
## Summary
- make server login persistence safer by rolling back partial writes if post-insert steps fail
- use cached-home timestamp with max-age policy so stale cache cannot persist indefinitely
- add bottom content inset when mini player is shown to avoid obscuring screen content
- ## Verification
- GRADLE_USER_HOME=/tmp/gradle ./gradlew :app:compileDebugKotlin --stacktrace
- ## Files
- ServerDao
- SessionRepository / SessionRepositoryImpl
- HomeViewModel
- RootScaffold