### PR TITLE
Harden transport security and remove token query auth

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:roundIcon="@android:drawable/sym_def_app_icon"
         android:supportsRtl="true"
         android:theme="@style/Theme.StillShelf"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="false">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/stillshelf/app/core/network/AuthenticatedUrl.kt
+++ b/app/src/main/java/com/stillshelf/app/core/network/AuthenticatedUrl.kt
@@ -1,0 +1,64 @@
+package com.stillshelf.app.core.network
+
+import android.util.Base64
+import java.nio.charset.StandardCharsets
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+
+private const val LEGACY_TOKEN_QUERY_KEY = "token"
+private const val AUTH_TOKEN_FRAGMENT_KEY = "stillshelf_token"
+data class AuthenticatedUrl(
+    val cleanUrl: String,
+    val authToken: String?
+)
+
+fun addAuthTokenFragment(url: String, authToken: String): String {
+    if (authToken.isBlank()) return url
+    val httpUrl = url.toHttpUrlOrNull() ?: return url
+    val encodedToken = Base64.encodeToString(
+        authToken.toByteArray(StandardCharsets.UTF_8),
+        Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING
+    )
+    return httpUrl.newBuilder()
+        .fragment("$AUTH_TOKEN_FRAGMENT_KEY=$encodedToken")
+        .build()
+        .toString()
+}
+
+fun splitAuthenticatedUrl(url: String): AuthenticatedUrl {
+    val httpUrl = url.toHttpUrlOrNull() ?: return AuthenticatedUrl(url, null)
+    val queryToken = httpUrl.queryParameter(LEGACY_TOKEN_QUERY_KEY)
+    val fragmentToken = parseTokenFromFragment(httpUrl.fragment)
+    val cleaned = httpUrl.newBuilder()
+        .removeAllQueryParameters(LEGACY_TOKEN_QUERY_KEY)
+        .fragment(null)
+        .build()
+        .toString()
+    return AuthenticatedUrl(
+        cleanUrl = cleaned,
+        authToken = fragmentToken ?: queryToken
+    )
+}
+
+fun authorizationHeaderValue(token: String): String {
+    return if (token.startsWith("Bearer ", ignoreCase = true)) token else "Bearer $token"
+}
+
+private fun parseTokenFromFragment(fragment: String?): String? {
+    if (fragment.isNullOrBlank()) return null
+    val parts = fragment.split("&")
+    val rawValue = parts.asSequence()
+        .mapNotNull { piece ->
+            val split = piece.split("=", limit = 2)
+            val key = split.firstOrNull().orEmpty()
+            if (key != AUTH_TOKEN_FRAGMENT_KEY) return@mapNotNull null
+            split.getOrElse(1) { "" }
+        }
+        .firstOrNull()
+        ?.trim()
+        ?: return null
+    if (rawValue.isBlank()) return null
+    return runCatching {
+        val decoded = Base64.decode(rawValue, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+        String(decoded, StandardCharsets.UTF_8)
+    }.getOrNull()
+}

--- a/app/src/main/java/com/stillshelf/app/data/api/AudiobookshelfApi.kt
+++ b/app/src/main/java/com/stillshelf/app/data/api/AudiobookshelfApi.kt
@@ -3,6 +3,8 @@ package com.stillshelf.app.data.api
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
+import com.stillshelf.app.core.network.addAuthTokenFragment
+import com.stillshelf.app.core.network.authorizationHeaderValue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -638,13 +640,13 @@ class AudiobookshelfApi @Inject constructor(
     ): String {
         val normalized = baseUrl.removeSuffix("/")
         val httpUrl = normalized.toHttpUrlOrNull()
-            ?: return "$normalized/api/items/$libraryItemId/cover?token=$authToken"
+            ?: return addAuthTokenFragment("$normalized/api/items/$libraryItemId/cover", authToken)
 
-        return httpUrl.newBuilder()
+        val rawUrl = httpUrl.newBuilder()
             .addPathSegments("api/items/$libraryItemId/cover")
-            .addQueryParameter("token", authToken)
             .build()
             .toString()
+        return addAuthTokenFragment(rawUrl, authToken)
     }
 
     fun buildPlaybackUrl(
@@ -654,14 +656,14 @@ class AudiobookshelfApi @Inject constructor(
     ): String {
         val normalized = baseUrl.removeSuffix("/")
         val baseHttpUrl = normalized.toHttpUrlOrNull()
-            ?: return "${normalized}/${streamPath.removePrefix("/")}?token=$authToken"
+            ?: return addAuthTokenFragment("${normalized}/${streamPath.removePrefix("/")}", authToken)
         val cleanedPath = streamPath.removePrefix("/")
 
-        return baseHttpUrl.newBuilder()
+        val rawUrl = baseHttpUrl.newBuilder()
             .addPathSegments(cleanedPath)
-            .addQueryParameter("token", authToken)
             .build()
             .toString()
+        return addAuthTokenFragment(rawUrl, authToken)
     }
 
     fun buildAuthorImageUrl(
@@ -671,18 +673,16 @@ class AudiobookshelfApi @Inject constructor(
     ): String {
         val normalized = baseUrl.removeSuffix("/")
         val httpUrl = normalized.toHttpUrlOrNull()
-            ?: return "$normalized/api/authors/$authorId/image?token=$authToken"
+            ?: return addAuthTokenFragment("$normalized/api/authors/$authorId/image", authToken)
 
-        return httpUrl.newBuilder()
+        val rawUrl = httpUrl.newBuilder()
             .addPathSegments("api/authors/$authorId/image")
-            .addQueryParameter("token", authToken)
             .build()
             .toString()
+        return addAuthTokenFragment(rawUrl, authToken)
     }
 
-    private fun authHeaderValue(token: String): String {
-        return if (token.startsWith(BEARER_PREFIX, ignoreCase = true)) token else "$BEARER_PREFIX$token"
-    }
+    private fun authHeaderValue(token: String): String = authorizationHeaderValue(token)
 
     private fun parseLibraries(rawJson: String): List<AudiobookshelfLibraryDto> {
         val trimmed = rawJson.trim()
@@ -1230,7 +1230,6 @@ class AudiobookshelfApi @Inject constructor(
 
     private companion object {
         val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
-        const val BEARER_PREFIX = "Bearer "
         const val MAX_429_RETRIES = 3
         const val ME_CACHE_TTL_MS = 2_500L
     }

--- a/app/src/main/java/com/stillshelf/app/data/repo/SessionRepositoryImpl.kt
+++ b/app/src/main/java/com/stillshelf/app/data/repo/SessionRepositoryImpl.kt
@@ -92,6 +92,9 @@ class SessionRepositoryImpl @Inject constructor(
     override suspend fun setActiveServer(serverId: String): AppResult<Unit> {
         val server = serverDao.getById(serverId)
             ?: return AppResult.Error("Server not found.")
+        if (!isHttpsUrl(server.baseUrl)) {
+            return AppResult.Error("Server URL must use https.")
+        }
 
         val token = secureTokenStorage.getToken(server.id)
             ?: return AppResult.Error("No saved session for this server. Please log in again.")
@@ -145,8 +148,8 @@ class SessionRepositoryImpl @Inject constructor(
         if (serverName.isBlank()) {
             return AppResult.Error("Server name is required.")
         }
-        if (!isHttpUrl(baseUrl)) {
-            return AppResult.Error("Base URL must use http or https.")
+        if (!isHttpsUrl(baseUrl)) {
+            return AppResult.Error("Base URL must use https.")
         }
         if (username.isBlank() || password.isBlank()) {
             return AppResult.Error("Username and password are required.")
@@ -205,8 +208,8 @@ class SessionRepositoryImpl @Inject constructor(
     }
 
     override suspend fun testServerConnection(baseUrl: String): AppResult<String> {
-        if (!isHttpUrl(baseUrl)) {
-            return AppResult.Error("Base URL must use http or https.")
+        if (!isHttpsUrl(baseUrl)) {
+            return AppResult.Error("Base URL must use https.")
         }
 
         val normalizedBaseUrl = normalizedBaseUrl(baseUrl)
@@ -1042,9 +1045,9 @@ class SessionRepositoryImpl @Inject constructor(
         }
     }
 
-    private fun isHttpUrl(value: String): Boolean {
+    private fun isHttpsUrl(value: String): Boolean {
         val uri = runCatching { URI(value.trim()) }.getOrNull() ?: return false
-        return uri.scheme == "http" || uri.scheme == "https"
+        return uri.scheme.equals("https", ignoreCase = true)
     }
 
     private suspend fun refreshLibrariesFromServer(
@@ -1101,6 +1104,9 @@ class SessionRepositoryImpl @Inject constructor(
             ?: return AppResult.Error("No active server selected.")
         val server = serverDao.getById(activeServerId)
             ?: return AppResult.Error("Active server not found.")
+        if (!isHttpsUrl(server.baseUrl)) {
+            return AppResult.Error("Server URL must use https.")
+        }
         val token = secureTokenStorage.getToken(server.id)
             ?: return AppResult.Error("No saved session for this server. Please log in again.")
 

--- a/app/src/main/java/com/stillshelf/app/playback/controller/PlaybackController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/controller/PlaybackController.kt
@@ -1,11 +1,16 @@
 package com.stillshelf.app.playback.controller
 
+import android.content.Context
 import android.media.MediaPlayer
+import android.net.Uri
+import com.stillshelf.app.core.network.authorizationHeaderValue
+import com.stillshelf.app.core.network.splitAuthenticatedUrl
 import com.stillshelf.app.core.model.BookSummary
 import com.stillshelf.app.core.model.ContinueListeningItem
 import com.stillshelf.app.core.util.AppResult
 import com.stillshelf.app.data.repo.SessionRepository
 import kotlin.math.abs
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
@@ -31,6 +36,7 @@ data class PlaybackUiState(
 
 @Singleton
 class PlaybackController @Inject constructor(
+    @param:ApplicationContext private val appContext: Context,
     private val sessionRepository: SessionRepository
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
@@ -240,7 +246,12 @@ class PlaybackController @Inject constructor(
         }
 
         runCatching {
-            player.setDataSource(streamUrl)
+            val resolvedStream = splitAuthenticatedUrl(streamUrl)
+            val headers = resolvedStream.authToken
+                ?.takeIf { it.isNotBlank() }
+                ?.let { token -> mapOf("Authorization" to authorizationHeaderValue(token)) }
+                .orEmpty()
+            player.setDataSource(appContext, Uri.parse(resolvedStream.cleanUrl), headers)
             player.prepareAsync()
         }.onFailure { throwable ->
             mutableUiState.update {

--- a/app/src/main/java/com/stillshelf/app/ui/common/CoverImageModels.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/common/CoverImageModels.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.stillshelf.app.core.network.authorizationHeaderValue
+import com.stillshelf.app.core.network.splitAuthenticatedUrl
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
@@ -29,22 +31,27 @@ private const val TypicalCoverAspectRatio = 0.66f
 fun rememberCoverImageModel(coverUrl: String?): Any? {
     val context = LocalContext.current
     val normalizedCacheKey = remember(coverUrl) { coverUrl?.let(::normalizeCoverCacheKey) }
-    return remember(coverUrl, normalizedCacheKey, context) {
+    val resolvedUrl = remember(coverUrl) { coverUrl?.let(::splitAuthenticatedUrl) }
+    return remember(coverUrl, normalizedCacheKey, resolvedUrl, context) {
         if (coverUrl.isNullOrBlank()) {
             null
         } else {
-            ImageRequest.Builder(context)
-                .data(coverUrl)
-                .memoryCacheKey(normalizedCacheKey)
-                .diskCacheKey(normalizedCacheKey)
-                .crossfade(false)
-                .build()
+            ImageRequest.Builder(context).apply {
+                data(resolvedUrl?.cleanUrl ?: coverUrl)
+                memoryCacheKey(normalizedCacheKey)
+                diskCacheKey(normalizedCacheKey)
+                crossfade(false)
+                resolvedUrl?.authToken?.takeIf { it.isNotBlank() }?.let { token ->
+                    addHeader("Authorization", authorizationHeaderValue(token))
+                }
+            }.build()
         }
     }
 }
 
 private fun normalizeCoverCacheKey(url: String): String {
-    val httpUrl = url.toHttpUrlOrNull() ?: return url
+    val cleanUrl = splitAuthenticatedUrl(url).cleanUrl
+    val httpUrl = cleanUrl.toHttpUrlOrNull() ?: return cleanUrl
     val builder = httpUrl.newBuilder().query(null)
     val queryNames = httpUrl.queryParameterNames.sorted()
     queryNames.forEach { key ->

--- a/app/src/main/java/com/stillshelf/app/ui/screens/PlaceholderScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/PlaceholderScreens.kt
@@ -119,6 +119,8 @@ import coil.compose.SubcomposeAsyncImage
 import coil.compose.SubcomposeAsyncImageContent
 import coil.request.ImageRequest
 import coil.imageLoader
+import com.stillshelf.app.core.network.authorizationHeaderValue
+import com.stillshelf.app.core.network.splitAuthenticatedUrl
 import com.stillshelf.app.core.model.BookSummary
 import com.stillshelf.app.core.model.BookChapter
 import com.stillshelf.app.core.model.ContinueListeningItem
@@ -2883,8 +2885,14 @@ private fun rememberDominantCoverColor(
 
         value = withContext(Dispatchers.IO) {
             runCatching {
+                val resolvedCover = splitAuthenticatedUrl(coverUrl)
                 val request = ImageRequest.Builder(context)
-                    .data(coverUrl)
+                    .data(resolvedCover.cleanUrl)
+                    .apply {
+                        resolvedCover.authToken?.takeIf { it.isNotBlank() }?.let { token ->
+                            addHeader("Authorization", authorizationHeaderValue(token))
+                        }
+                    }
                     .allowHardware(false)
                     .size(64)
                     .build()


### PR DESCRIPTION
## Summary
- enforce HTTPS-only server configuration and active-session usage
- disable cleartext traffic in Android manifest
- stop generating token query auth on media/image URLs
- switch image and playback requests to use Authorization headers from authenticated URL metadata (including legacy token-query compatibility)

## Verification
- GRADLE_USER_HOME=/tmp/gradle ./gradlew :app:compileDebugKotlin --stacktrace

## Notes
- Existing legacy URLs containing token query params are still supported via parser migration logic, but outgoing requests now use clean URLs plus headers.
