### PR TITLE
Allow HTTP servers with explicit risk acknowledgment

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:roundIcon="@android:drawable/sym_def_app_icon"
         android:supportsRtl="true"
         android:theme="@style/Theme.StillShelf"
-        android:usesCleartextTraffic="false">
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/stillshelf/app/data/repo/SessionRepositoryImpl.kt
+++ b/app/src/main/java/com/stillshelf/app/data/repo/SessionRepositoryImpl.kt
@@ -92,9 +92,6 @@ class SessionRepositoryImpl @Inject constructor(
     override suspend fun setActiveServer(serverId: String): AppResult<Unit> {
         val server = serverDao.getById(serverId)
             ?: return AppResult.Error("Server not found.")
-        if (!isHttpsUrl(server.baseUrl)) {
-            return AppResult.Error("Server URL must use https.")
-        }
 
         val token = secureTokenStorage.getToken(server.id)
             ?: return AppResult.Error("No saved session for this server. Please log in again.")
@@ -148,8 +145,8 @@ class SessionRepositoryImpl @Inject constructor(
         if (serverName.isBlank()) {
             return AppResult.Error("Server name is required.")
         }
-        if (!isHttpsUrl(baseUrl)) {
-            return AppResult.Error("Base URL must use https.")
+        if (!isHttpUrl(baseUrl)) {
+            return AppResult.Error("Base URL must use http or https.")
         }
         if (username.isBlank() || password.isBlank()) {
             return AppResult.Error("Username and password are required.")
@@ -208,8 +205,8 @@ class SessionRepositoryImpl @Inject constructor(
     }
 
     override suspend fun testServerConnection(baseUrl: String): AppResult<String> {
-        if (!isHttpsUrl(baseUrl)) {
-            return AppResult.Error("Base URL must use https.")
+        if (!isHttpUrl(baseUrl)) {
+            return AppResult.Error("Base URL must use http or https.")
         }
 
         val normalizedBaseUrl = normalizedBaseUrl(baseUrl)
@@ -1045,9 +1042,9 @@ class SessionRepositoryImpl @Inject constructor(
         }
     }
 
-    private fun isHttpsUrl(value: String): Boolean {
+    private fun isHttpUrl(value: String): Boolean {
         val uri = runCatching { URI(value.trim()) }.getOrNull() ?: return false
-        return uri.scheme.equals("https", ignoreCase = true)
+        return uri.scheme == "http" || uri.scheme == "https"
     }
 
     private suspend fun refreshLibrariesFromServer(
@@ -1104,9 +1101,6 @@ class SessionRepositoryImpl @Inject constructor(
             ?: return AppResult.Error("No active server selected.")
         val server = serverDao.getById(activeServerId)
             ?: return AppResult.Error("Active server not found.")
-        if (!isHttpsUrl(server.baseUrl)) {
-            return AppResult.Error("Server URL must use https.")
-        }
         val token = secureTokenStorage.getToken(server.id)
             ?: return AppResult.Error("No saved session for this server. Please log in again.")
 

--- a/app/src/main/java/com/stillshelf/app/ui/screens/auth/AddServerScreen.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/auth/AddServerScreen.kt
@@ -12,10 +12,15 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -48,6 +53,10 @@ private fun AddServerScreen(
     onContinue: (serverName: String, baseUrl: String) -> Unit,
     onBack: () -> Unit
 ) {
+    var showInsecureHttpWarning by remember { mutableStateOf(false) }
+    val trimmedBaseUrl = uiState.baseUrl.trim()
+    val trimmedServerName = uiState.serverName.trim()
+
     Scaffold { paddingValues ->
         Column(
             modifier = Modifier
@@ -97,10 +106,11 @@ private fun AddServerScreen(
 
                 Button(
                     onClick = {
-                        onContinue(
-                            uiState.serverName,
-                            uiState.baseUrl
-                        )
+                        if (isHttpUrl(trimmedBaseUrl)) {
+                            showInsecureHttpWarning = true
+                        } else {
+                            onContinue(trimmedServerName, trimmedBaseUrl)
+                        }
                     },
                     enabled = uiState.canContinue,
                     modifier = Modifier.weight(1f)
@@ -128,5 +138,37 @@ private fun AddServerScreen(
                 Text("Back")
             }
         }
+
+        if (showInsecureHttpWarning) {
+            AlertDialog(
+                onDismissRequest = { showInsecureHttpWarning = false },
+                title = { Text("Use insecure HTTP?") },
+                text = {
+                    Text(
+                        "This server uses an unencrypted connection. " +
+                            "Your username, password, and playback data could be exposed on the network."
+                    )
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            showInsecureHttpWarning = false
+                            onContinue(trimmedServerName, trimmedBaseUrl)
+                        }
+                    ) {
+                        Text("Use HTTP")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showInsecureHttpWarning = false }) {
+                        Text("Cancel")
+                    }
+                }
+            )
+        }
     }
+}
+
+private fun isHttpUrl(baseUrl: String): Boolean {
+    return baseUrl.trim().startsWith("http://", ignoreCase = true)
 }


### PR DESCRIPTION
## Summary
- allow both HTTP and HTTPS server URLs again in repository validation and active-server flow
- restore cleartext support so HTTP servers can connect
- add Add Server confirmation dialog when user enters an http URL, explaining the security risk and requiring explicit confirmation

## Verification
- GRADLE_USER_HOME=/tmp/gradle ./gradlew :app:compileDebugKotlin --stacktrace

## UX
- user sees a warning modal before continuing with HTTP
- cancel keeps user on Add Server screen; confirm proceeds
