### PR TITLE
Polish UI flows: persistent view modes, home action wiring, and player/browse fixes

### DIFF
--- a/app/src/main/java/com/stillshelf/app/core/datastore/SessionPreferences.kt
+++ b/app/src/main/java/com/stillshelf/app/core/datastore/SessionPreferences.kt
@@ -27,6 +27,9 @@ class SessionPreferences @Inject constructor(
     private val booksStatusFilterKey = stringPreferencesKey("books_status_filter")
     private val booksSortKey = stringPreferencesKey("books_sort_key")
     private val booksCollapseSeriesKey = booleanPreferencesKey("books_collapse_series")
+    private val authorLayoutModeKey = stringPreferencesKey("author_layout_mode")
+    private val authorCollapseSeriesKey = booleanPreferencesKey("author_collapse_series")
+    private val seriesDetailListModeKey = booleanPreferencesKey("series_detail_list_mode")
     private val immersivePlayerEnabledKey = booleanPreferencesKey("immersive_player_enabled")
     private val appThemeModeKey = stringPreferencesKey("app_theme_mode")
     private val materialDesignEnabledKey = booleanPreferencesKey("material_design_enabled")
@@ -47,6 +50,9 @@ class SessionPreferences @Inject constructor(
             booksStatusFilter = prefs[booksStatusFilterKey],
             booksSortKey = prefs[booksSortKey],
             booksCollapseSeries = prefs[booksCollapseSeriesKey] ?: true,
+            authorLayoutMode = prefs[authorLayoutModeKey],
+            authorCollapseSeries = prefs[authorCollapseSeriesKey] ?: true,
+            seriesDetailListMode = prefs[seriesDetailListModeKey] ?: true,
             immersivePlayerEnabled = prefs[immersivePlayerEnabledKey] ?: false,
             appThemeMode = prefs[appThemeModeKey] ?: "follow_system",
             materialDesignEnabled = prefs[materialDesignEnabledKey] ?: false
@@ -159,6 +165,28 @@ class SessionPreferences @Inject constructor(
         }
     }
 
+    suspend fun setAuthorLayoutMode(mode: String) {
+        dataStore.edit { prefs ->
+            if (mode.isBlank()) {
+                prefs.remove(authorLayoutModeKey)
+            } else {
+                prefs[authorLayoutModeKey] = mode
+            }
+        }
+    }
+
+    suspend fun setAuthorCollapseSeries(collapse: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[authorCollapseSeriesKey] = collapse
+        }
+    }
+
+    suspend fun setSeriesDetailListMode(listMode: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[seriesDetailListModeKey] = listMode
+        }
+    }
+
     suspend fun setImmersivePlayerEnabled(enabled: Boolean) {
         dataStore.edit { prefs ->
             prefs[immersivePlayerEnabledKey] = enabled
@@ -241,6 +269,9 @@ data class SessionPreferenceState(
     val booksStatusFilter: String? = null,
     val booksSortKey: String? = null,
     val booksCollapseSeries: Boolean = true,
+    val authorLayoutMode: String? = null,
+    val authorCollapseSeries: Boolean = true,
+    val seriesDetailListMode: Boolean = true,
     val immersivePlayerEnabled: Boolean = false,
     val appThemeMode: String = "follow_system",
     val materialDesignEnabled: Boolean = false

--- a/app/src/main/java/com/stillshelf/app/core/model/Models.kt
+++ b/app/src/main/java/com/stillshelf/app/core/model/Models.kt
@@ -35,7 +35,8 @@ data class NamedEntitySummary(
     val id: String,
     val name: String,
     val subtitle: String? = null,
-    val imageUrl: String? = null
+    val imageUrl: String? = null,
+    val description: String? = null
 )
 
 data class ContinueListeningItem(

--- a/app/src/main/java/com/stillshelf/app/data/api/AudiobookshelfApi.kt
+++ b/app/src/main/java/com/stillshelf/app/data/api/AudiobookshelfApi.kt
@@ -56,7 +56,8 @@ data class AudiobookshelfNamedEntityDto(
     val id: String,
     val name: String,
     val subtitle: String? = null,
-    val imagePath: String? = null
+    val imagePath: String? = null,
+    val description: String? = null
 )
 
 data class AudiobookshelfSearchDto(
@@ -263,6 +264,10 @@ class AudiobookshelfApi @Inject constructor(
                         subtitle = item.optString("numBooks").takeIf { it.isNotBlank() }?.let { "$it books" },
                         imagePath = item.optString("imagePath")
                             .ifBlank { item.optString("avatarPath") }
+                            .ifBlank { null },
+                        description = item.optString("description")
+                            .ifBlank { item.optString("bio") }
+                            .ifBlank { item.optString("descriptionPlain") }
                             .ifBlank { null }
                     )
                 }

--- a/app/src/main/java/com/stillshelf/app/data/repo/SessionRepositoryImpl.kt
+++ b/app/src/main/java/com/stillshelf/app/data/repo/SessionRepositoryImpl.kt
@@ -1338,6 +1338,7 @@ class SessionRepositoryImpl @Inject constructor(
             id = id,
             name = name,
             subtitle = subtitle,
+            description = description,
             imageUrl = if (includeAuthorImage) {
                 imagePath?.takeIf { it.startsWith("http://") || it.startsWith("https://") }
                     ?: audiobookshelfApi.buildAuthorImageUrl(baseUrl, id, authToken)

--- a/app/src/main/java/com/stillshelf/app/playback/controller/PlaybackController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/controller/PlaybackController.kt
@@ -149,12 +149,19 @@ class PlaybackController @Inject constructor(
         } else {
             (current + deltaMs).coerceAtLeast(0L)
         }
-        runCatching { player.seekTo(target.toInt()) }
-        mutableUiState.update { it.copy(positionMs = target) }
-        syncProgress(force = true, isFinished = false)
+        seekToPosition(targetMs = target, forceSync = true)
     }
 
-    private fun seekToPosition(targetMs: Long) {
+    fun seekToProgress(progressFraction: Float, commit: Boolean) {
+        val player = mediaPlayer ?: return
+        val duration = safeDuration(player)
+        if (duration <= 0L) return
+        val clamped = progressFraction.coerceIn(0f, 1f)
+        val targetMs = (duration.toDouble() * clamped.toDouble()).toLong()
+        seekToPosition(targetMs = targetMs, forceSync = commit)
+    }
+
+    private fun seekToPosition(targetMs: Long, forceSync: Boolean = true) {
         val player = mediaPlayer ?: return
         val duration = safeDuration(player)
         val clamped = if (duration > 0L) {
@@ -164,7 +171,9 @@ class PlaybackController @Inject constructor(
         }
         runCatching { player.seekTo(clamped.toInt()) }
         mutableUiState.update { it.copy(positionMs = clamped) }
-        syncProgress(force = true, isFinished = false)
+        if (forceSync) {
+            syncProgress(force = true, isFinished = false)
+        }
     }
 
     private fun pause() {

--- a/app/src/main/java/com/stillshelf/app/ui/navigation/MainNavGraph.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/navigation/MainNavGraph.kt
@@ -107,6 +107,18 @@ private fun MainTabsNavHost(
     paddingValues: PaddingValues,
     navController: androidx.navigation.NavHostController
 ) {
+    val onHomeClick: () -> Unit = {
+        if (!navController.popBackStack(MainTab.Home.route, inclusive = false)) {
+            navController.navigate(MainTab.Home.route) {
+                popUpTo(navController.graph.findStartDestination().id) {
+                    saveState = true
+                }
+                launchSingleTop = true
+                restoreState = true
+            }
+        }
+    }
+
     NavHost(
         navController = navController,
         startDestination = MainTab.Home.route,
@@ -167,6 +179,7 @@ private fun MainTabsNavHost(
         }
         composable(MainTab.Browse.route) {
             BrowsePlaceholderScreen(
+                onHomeClick = onHomeClick,
                 onBookClick = { bookId ->
                     navController.navigate(DetailRoute.book(bookId)) {
                         launchSingleTop = true
@@ -203,7 +216,9 @@ private fun MainTabsNavHost(
                 }
             )
         }
-        composable(MainTab.Downloads.route) { DownloadsPlaceholderScreen() }
+        composable(MainTab.Downloads.route) {
+            DownloadsPlaceholderScreen(onHomeClick = onHomeClick)
+        }
         composable(MainTab.Settings.route) {
             SettingsPlaceholderScreen(
                 onBackClick = { navController.popBackStack() },
@@ -269,7 +284,8 @@ private fun MainTabsNavHost(
                     navController.navigate(AuthRoute.ADD_SERVER) {
                         launchSingleTop = true
                     }
-                }
+                },
+                onHomeClick = onHomeClick
             )
         }
         composable(AuthRoute.ADD_SERVER) {
@@ -317,12 +333,16 @@ private fun MainTabsNavHost(
             )
         }
         composable(MainRoute.CUSTOMIZE) {
-            CustomizePlaceholderScreen(onDone = { navController.popBackStack() })
+            CustomizePlaceholderScreen(
+                onDone = { navController.popBackStack() },
+                onHomeClick = onHomeClick
+            )
         }
 
         composable(BrowseRoute.BOOKS) {
             BrowsePlaceholderScreen(
                 onBackClick = { navController.popBackStack() },
+                onHomeClick = onHomeClick,
                 onBookClick = { bookId ->
                     navController.navigate(DetailRoute.book(bookId)) {
                         launchSingleTop = true
@@ -338,6 +358,7 @@ private fun MainTabsNavHost(
         composable(BrowseRoute.AUTHORS) {
             AuthorsBrowseScreen(
                 onBackClick = { navController.popBackStack() },
+                onHomeClick = onHomeClick,
                 onAuthorClick = { authorName ->
                     navController.navigate(DetailRoute.author(authorName)) {
                         launchSingleTop = true
@@ -348,6 +369,7 @@ private fun MainTabsNavHost(
         composable(BrowseRoute.NARRATORS) {
             NarratorsBrowseScreen(
                 onBackClick = { navController.popBackStack() },
+                onHomeClick = onHomeClick,
                 onNarratorClick = { narratorName ->
                     navController.navigate(DetailRoute.narrator(narratorName)) {
                         launchSingleTop = true
@@ -358,6 +380,7 @@ private fun MainTabsNavHost(
         composable(BrowseRoute.SERIES) {
             SeriesBrowseScreen(
                 onBackClick = { navController.popBackStack() },
+                onHomeClick = onHomeClick,
                 onSeriesClick = { seriesName ->
                     navController.navigate(DetailRoute.series(seriesName)) {
                         launchSingleTop = true
@@ -367,12 +390,14 @@ private fun MainTabsNavHost(
         }
         composable(BrowseRoute.COLLECTIONS) {
             CollectionsBrowseScreen(
-                onBackClick = { navController.popBackStack() }
+                onBackClick = { navController.popBackStack() },
+                onHomeClick = onHomeClick
             )
         }
         composable(BrowseRoute.GENRES) {
             GenresBrowseScreen(
                 onBackClick = { navController.popBackStack() },
+                onHomeClick = onHomeClick,
                 onGenreClick = { genreName ->
                     navController.navigate(DetailRoute.genre(genreName)) {
                         launchSingleTop = true
@@ -385,7 +410,8 @@ private fun MainTabsNavHost(
                 title = "Bookmarks",
                 emptyMessage = "Bookmarks you add will appear here.",
                 icon = Icons.Outlined.BookmarkBorder,
-                onBackClick = { navController.popBackStack() }
+                onBackClick = { navController.popBackStack() },
+                onHomeClick = onHomeClick
             )
         }
         composable(BrowseRoute.PLAYLISTS) {
@@ -393,12 +419,14 @@ private fun MainTabsNavHost(
                 title = "Playlists",
                 emptyMessage = "Playlists you create will appear here.",
                 icon = Icons.Outlined.MusicNote,
-                onBackClick = { navController.popBackStack() }
+                onBackClick = { navController.popBackStack() },
+                onHomeClick = onHomeClick
             )
         }
         composable(BrowseRoute.DOWNLOADED) {
             DownloadsPlaceholderScreen(
-                onBackClick = { navController.popBackStack() }
+                onBackClick = { navController.popBackStack() },
+                onHomeClick = onHomeClick
             )
         }
 
@@ -412,6 +440,7 @@ private fun MainTabsNavHost(
         ) {
             BookDetailScreen(
                 onBackClick = { navController.popBackStack() },
+                onHomeClick = onHomeClick,
                 onStartListening = { bookId ->
                     navController.navigate(MainRoute.player(bookId)) {
                         launchSingleTop = true
@@ -434,6 +463,7 @@ private fun MainTabsNavHost(
         ) {
             AuthorDetailScreen(
                 onBackClick = { navController.popBackStack() },
+                onHomeClick = onHomeClick,
                 onBookClick = { bookId ->
                     navController.navigate(DetailRoute.book(bookId)) {
                         launchSingleTop = true
@@ -456,6 +486,7 @@ private fun MainTabsNavHost(
         ) {
             SeriesDetailScreen(
                 onBackClick = { navController.popBackStack() },
+                onHomeClick = onHomeClick,
                 onBookClick = { bookId ->
                     navController.navigate(DetailRoute.book(bookId)) {
                         launchSingleTop = true
@@ -473,6 +504,7 @@ private fun MainTabsNavHost(
         ) {
             NarratorDetailScreen(
                 onBackClick = { navController.popBackStack() },
+                onHomeClick = onHomeClick,
                 onBookClick = { bookId ->
                     navController.navigate(DetailRoute.book(bookId)) {
                         launchSingleTop = true
@@ -490,6 +522,7 @@ private fun MainTabsNavHost(
         ) {
             GenreDetailScreen(
                 onBackClick = { navController.popBackStack() },
+                onHomeClick = onHomeClick,
                 onBookClick = { bookId ->
                     navController.navigate(DetailRoute.book(bookId)) {
                         launchSingleTop = true

--- a/app/src/main/java/com/stillshelf/app/ui/screens/FacetDetailScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/FacetDetailScreens.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items as gridItems
 import androidx.compose.foundation.shape.CircleShape
@@ -34,6 +35,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.outlined.ChevronRight
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material.icons.outlined.GridView
+import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.MoreHoriz
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -54,6 +56,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
@@ -65,6 +69,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
+import com.stillshelf.app.core.datastore.SessionPreferences
 import com.stillshelf.app.core.model.BookSummary
 import com.stillshelf.app.core.util.AppResult
 import com.stillshelf.app.data.repo.SessionRepository
@@ -79,6 +84,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.text.Regex
@@ -88,6 +94,7 @@ data class FacetBooksUiState(
     val title: String = "",
     val books: List<BookSummary> = emptyList(),
     val authorImageUrl: String? = null,
+    val authorAbout: String? = null,
     val errorMessage: String? = null
 )
 
@@ -104,7 +111,7 @@ data class GenresUiState(
     val errorMessage: String? = null
 )
 
-private enum class AuthorLayoutMode {
+enum class AuthorLayoutMode {
     Grid,
     List
 }
@@ -129,26 +136,57 @@ private sealed interface AuthorDisplayEntry {
 @HiltViewModel
 class AuthorDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val sessionRepository: SessionRepository
+    private val sessionRepository: SessionRepository,
+    private val sessionPreferences: SessionPreferences
 ) : ViewModel() {
     private val authorName = savedStateHandle.get<String>(DetailRoute.AUTHOR_NAME_ARG).orEmpty()
     private val mutableUiState = MutableStateFlow(FacetBooksUiState(isLoading = true, title = authorName))
     val uiState: StateFlow<FacetBooksUiState> = mutableUiState.asStateFlow()
+    private val mutableLayoutMode = MutableStateFlow(AuthorLayoutMode.Grid)
+    val layoutMode: StateFlow<AuthorLayoutMode> = mutableLayoutMode.asStateFlow()
+    private val mutableCollapseSeries = MutableStateFlow(true)
+    val collapseSeries: StateFlow<Boolean> = mutableCollapseSeries.asStateFlow()
 
     init {
+        viewModelScope.launch { restoreUiPreferences() }
         refresh()
+    }
+
+    fun setLayoutMode(value: AuthorLayoutMode) {
+        mutableLayoutMode.value = value
+        viewModelScope.launch {
+            sessionPreferences.setAuthorLayoutMode(value.name)
+        }
+    }
+
+    fun toggleCollapseSeries() {
+        val nextValue = !mutableCollapseSeries.value
+        mutableCollapseSeries.value = nextValue
+        viewModelScope.launch {
+            sessionPreferences.setAuthorCollapseSeries(nextValue)
+        }
+    }
+
+    private suspend fun restoreUiPreferences() {
+        val pref = sessionPreferences.state.first()
+        mutableLayoutMode.value = pref.authorLayoutMode
+            ?.let { raw -> enumValueOrNull<AuthorLayoutMode>(raw) }
+            ?: AuthorLayoutMode.Grid
+        mutableCollapseSeries.value = pref.authorCollapseSeries
     }
 
     fun refresh() {
         mutableUiState.update { it.copy(isLoading = true, errorMessage = null) }
         viewModelScope.launch {
-            val authorImageUrl = when (val authorsResult = sessionRepository.fetchAuthorsForActiveLibrary(limit = 400, page = 0)) {
+            val matchedAuthor = when (val authorsResult = sessionRepository.fetchAuthorsForActiveLibrary(limit = 400, page = 0)) {
                 is AppResult.Success -> {
-                    authorsResult.value.firstOrNull { it.name.equals(authorName, ignoreCase = true) }?.imageUrl
+                    authorsResult.value.firstOrNull { it.name.equals(authorName, ignoreCase = true) }
                 }
 
                 is AppResult.Error -> null
             }
+            val authorImageUrl = matchedAuthor?.imageUrl
+            val authorAbout = matchedAuthor?.description?.takeIf { it.isNotBlank() }
 
             when (val result = sessionRepository.fetchBooksForActiveLibrary(limit = 400, page = 0)) {
                 is AppResult.Success -> {
@@ -159,7 +197,8 @@ class AuthorDetailViewModel @Inject constructor(
                         it.copy(
                             isLoading = false,
                             books = books,
-                            authorImageUrl = authorImageUrl
+                            authorImageUrl = authorImageUrl,
+                            authorAbout = authorAbout
                         )
                     }
                 }
@@ -169,6 +208,7 @@ class AuthorDetailViewModel @Inject constructor(
                         it.copy(
                             isLoading = false,
                             authorImageUrl = authorImageUrl,
+                            authorAbout = authorAbout,
                             errorMessage = result.message
                         )
                     }
@@ -181,14 +221,27 @@ class AuthorDetailViewModel @Inject constructor(
 @HiltViewModel
 class SeriesDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val sessionRepository: SessionRepository
+    private val sessionRepository: SessionRepository,
+    private val sessionPreferences: SessionPreferences
 ) : ViewModel() {
     private val seriesName = savedStateHandle.get<String>(DetailRoute.SERIES_NAME_ARG).orEmpty()
     private val mutableUiState = MutableStateFlow(FacetBooksUiState(isLoading = true, title = seriesName))
     val uiState: StateFlow<FacetBooksUiState> = mutableUiState.asStateFlow()
+    private val mutableListMode = MutableStateFlow(true)
+    val listMode: StateFlow<Boolean> = mutableListMode.asStateFlow()
 
     init {
+        viewModelScope.launch {
+            mutableListMode.value = sessionPreferences.state.first().seriesDetailListMode
+        }
         refresh()
+    }
+
+    fun setListMode(value: Boolean) {
+        mutableListMode.value = value
+        viewModelScope.launch {
+            sessionPreferences.setSeriesDetailListMode(value)
+        }
     }
 
     fun refresh() {
@@ -458,12 +511,12 @@ fun AuthorDetailScreen(
     onBackClick: () -> Unit,
     onBookClick: (String) -> Unit,
     onSeriesClick: (String) -> Unit,
+    onHomeClick: (() -> Unit)? = null,
     viewModel: AuthorDetailViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    var layoutMode by rememberSaveable { mutableStateOf(AuthorLayoutMode.Grid) }
-    var collapseSeries by rememberSaveable { mutableStateOf(true) }
-    var optionsExpanded by remember { mutableStateOf(false) }
+    val layoutMode by viewModel.layoutMode.collectAsStateWithLifecycle()
+    val collapseSeries by viewModel.collapseSeries.collectAsStateWithLifecycle()
 
     val displayBooks = remember(uiState.books) { uiState.books.sortedBy { it.title.lowercase() } }
     val displayEntries = remember(displayBooks, collapseSeries) {
@@ -472,11 +525,179 @@ fun AuthorDetailScreen(
             collapseSeries = collapseSeries
         )
     }
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 18.dp, vertical = 14.dp)
-    ) {
+    val aboutText = uiState.authorAbout?.takeIf { it.isNotBlank() }
+        ?: "No author biography is available from this Audiobookshelf server."
+
+    if (layoutMode == AuthorLayoutMode.Grid) {
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(2),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 18.dp, vertical = 14.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(bottom = 120.dp)
+        ) {
+            item(span = { GridItemSpan(2) }) {
+                AuthorDetailHeader(
+                    title = uiState.title,
+                    bookCount = displayBooks.size,
+                    authorImageUrl = uiState.authorImageUrl,
+                    aboutText = aboutText,
+                    layoutMode = layoutMode,
+                    collapseSeries = collapseSeries,
+                    onBackClick = onBackClick,
+                    onHomeClick = onHomeClick,
+                    onSetLayoutMode = viewModel::setLayoutMode,
+                    onToggleCollapseSeries = viewModel::toggleCollapseSeries
+                )
+            }
+
+            when {
+                uiState.isLoading -> item(span = { GridItemSpan(2) }) {
+                    Text(
+                        text = "Loading...",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                uiState.errorMessage != null -> item(span = { GridItemSpan(2) }) {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text(
+                            text = uiState.errorMessage.orEmpty(),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                        Button(onClick = viewModel::refresh) {
+                            Text("Retry")
+                        }
+                    }
+                }
+
+                displayBooks.isEmpty() -> item(span = { GridItemSpan(2) }) {
+                    Text(
+                        text = "No books found.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                else -> {
+                    gridItems(displayEntries, key = { it.stableKey }) { entry ->
+                        when (entry) {
+                            is AuthorDisplayEntry.BookItem -> {
+                                AuthorGridBookItem(
+                                    book = entry.book,
+                                    onClick = { onBookClick(entry.book.id) }
+                                )
+                            }
+
+                            is AuthorDisplayEntry.SeriesItem -> {
+                                AuthorSeriesGridItem(
+                                    entry = entry,
+                                    onClick = { onSeriesClick(entry.seriesName) }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    } else {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 18.dp, vertical = 14.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+            contentPadding = PaddingValues(bottom = 120.dp)
+        ) {
+            item {
+                AuthorDetailHeader(
+                    title = uiState.title,
+                    bookCount = displayBooks.size,
+                    authorImageUrl = uiState.authorImageUrl,
+                    aboutText = aboutText,
+                    layoutMode = layoutMode,
+                    collapseSeries = collapseSeries,
+                    onBackClick = onBackClick,
+                    onHomeClick = onHomeClick,
+                    onSetLayoutMode = viewModel::setLayoutMode,
+                    onToggleCollapseSeries = viewModel::toggleCollapseSeries
+                )
+            }
+
+            when {
+                uiState.isLoading -> item {
+                    Text(
+                        text = "Loading...",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                uiState.errorMessage != null -> item {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text(
+                            text = uiState.errorMessage.orEmpty(),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                        Button(onClick = viewModel::refresh) {
+                            Text("Retry")
+                        }
+                    }
+                }
+
+                displayBooks.isEmpty() -> item {
+                    Text(
+                        text = "No books found.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                else -> {
+                    items(displayEntries, key = { it.stableKey }) { entry ->
+                        when (entry) {
+                            is AuthorDisplayEntry.BookItem -> {
+                                AuthorBookRow(
+                                    book = entry.book,
+                                    onClick = { onBookClick(entry.book.id) }
+                                )
+                            }
+
+                            is AuthorDisplayEntry.SeriesItem -> {
+                                AuthorSeriesListRow(
+                                    entry = entry,
+                                    onClick = { onSeriesClick(entry.seriesName) }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AuthorDetailHeader(
+    title: String,
+    bookCount: Int,
+    authorImageUrl: String?,
+    aboutText: String,
+    layoutMode: AuthorLayoutMode,
+    collapseSeries: Boolean,
+    onBackClick: () -> Unit,
+    onHomeClick: (() -> Unit)?,
+    onSetLayoutMode: (AuthorLayoutMode) -> Unit,
+    onToggleCollapseSeries: () -> Unit
+) {
+    var optionsExpanded by remember { mutableStateOf(false) }
+    var aboutExpanded by rememberSaveable(title, aboutText) { mutableStateOf(false) }
+    var aboutCanExpand by remember(title, aboutText) { mutableStateOf(false) }
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             IconButton(
                 onClick = onBackClick,
@@ -488,6 +709,21 @@ fun AuthorDetailScreen(
                     imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
                     contentDescription = "Back"
                 )
+            }
+            if (onHomeClick != null) {
+                Spacer(modifier = Modifier.width(FacetBackTitleSpacing))
+                IconButton(
+                    onClick = onHomeClick,
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.surface)
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Home,
+                        contentDescription = "Home"
+                    )
+                }
             }
             Spacer(modifier = Modifier.weight(1f))
             Box {
@@ -515,7 +751,7 @@ fun AuthorDetailScreen(
                             }
                         },
                         onClick = {
-                            layoutMode = AuthorLayoutMode.Grid
+                            onSetLayoutMode(AuthorLayoutMode.Grid)
                             optionsExpanded = false
                         }
                     )
@@ -536,7 +772,7 @@ fun AuthorDetailScreen(
                             }
                         },
                         onClick = {
-                            layoutMode = AuthorLayoutMode.List
+                            onSetLayoutMode(AuthorLayoutMode.List)
                             optionsExpanded = false
                         }
                     )
@@ -551,7 +787,7 @@ fun AuthorDetailScreen(
                             }
                         },
                         onClick = {
-                            collapseSeries = !collapseSeries
+                            onToggleCollapseSeries()
                             optionsExpanded = false
                         }
                     )
@@ -567,9 +803,9 @@ fun AuthorDetailScreen(
                 .align(Alignment.CenterHorizontally),
             contentAlignment = Alignment.Center
         ) {
-            if (uiState.authorImageUrl.isNullOrBlank()) {
+            if (authorImageUrl.isNullOrBlank()) {
                 Text(
-                    text = uiState.title.split(" ")
+                    text = title.split(" ")
                         .mapNotNull { it.firstOrNull()?.uppercaseChar() }
                         .take(2)
                         .joinToString(""),
@@ -577,8 +813,8 @@ fun AuthorDetailScreen(
                 )
             } else {
                 AsyncImage(
-                    model = rememberCoverImageModel(uiState.authorImageUrl),
-                    contentDescription = uiState.title,
+                    model = rememberCoverImageModel(authorImageUrl),
+                    contentDescription = title,
                     modifier = Modifier
                         .fillMaxSize()
                         .clip(CircleShape),
@@ -587,99 +823,42 @@ fun AuthorDetailScreen(
             }
         }
         Text(
-            text = uiState.title,
+            text = title,
             style = MaterialTheme.typography.headlineMedium,
             modifier = Modifier.align(Alignment.CenterHorizontally)
         )
         Text(
-            text = "${displayBooks.size} books",
+            text = "$bookCount books",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.align(Alignment.CenterHorizontally)
         )
-        Spacer(modifier = Modifier.height(12.dp))
-
-        when {
-            uiState.isLoading -> {
-                Text(
-                    text = "Loading...",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-
-            uiState.errorMessage != null -> {
-                Text(
-                    text = uiState.errorMessage.orEmpty(),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.error
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Button(onClick = viewModel::refresh) {
-                    Text("Retry")
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = "About",
+            style = MaterialTheme.typography.titleMedium
+        )
+        Text(
+            text = aboutText,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = if (aboutExpanded) Int.MAX_VALUE else 5,
+            overflow = TextOverflow.Ellipsis,
+            onTextLayout = { textLayoutResult ->
+                if (!aboutExpanded) {
+                    aboutCanExpand = textLayoutResult.hasVisualOverflow
                 }
             }
-
-            displayBooks.isEmpty() -> {
-                Text(
-                    text = "No books found.",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-
-            else -> {
-                if (layoutMode == AuthorLayoutMode.Grid) {
-                    LazyVerticalGrid(
-                        columns = GridCells.Fixed(2),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
-                        contentPadding = PaddingValues(bottom = 120.dp)
-                    ) {
-                        gridItems(displayEntries, key = { it.stableKey }) { entry ->
-                            when (entry) {
-                                is AuthorDisplayEntry.BookItem -> {
-                                    AuthorGridBookItem(
-                                        book = entry.book,
-                                        onClick = { onBookClick(entry.book.id) }
-                                    )
-                                }
-
-                                is AuthorDisplayEntry.SeriesItem -> {
-                                    AuthorSeriesGridItem(
-                                        entry = entry,
-                                        onClick = { onSeriesClick(entry.seriesName) }
-                                    )
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    LazyColumn(
-                        verticalArrangement = Arrangement.spacedBy(6.dp),
-                        contentPadding = PaddingValues(bottom = 120.dp)
-                    ) {
-                        items(displayEntries, key = { it.stableKey }) { entry ->
-                            when (entry) {
-                                is AuthorDisplayEntry.BookItem -> {
-                                    AuthorBookRow(
-                                        book = entry.book,
-                                        onClick = { onBookClick(entry.book.id) }
-                                    )
-                                }
-
-                                is AuthorDisplayEntry.SeriesItem -> {
-                                    AuthorSeriesListRow(
-                                        entry = entry,
-                                        onClick = { onSeriesClick(entry.seriesName) }
-                                    )
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+        )
+        if (aboutCanExpand || aboutExpanded) {
+            Text(
+                text = if (aboutExpanded) "Show less" else "Show more",
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.clickable { aboutExpanded = !aboutExpanded }
+            )
         }
+        Spacer(modifier = Modifier.height(4.dp))
     }
 }
 
@@ -759,9 +938,17 @@ private fun AuthorSeriesGridItem(
     onClick: () -> Unit
 ) {
     val lead = entry.leadBook
-    val layerCount = entry.count.coerceIn(3, 6)
-    val frontOffsetX = 12.dp
-    val frontOffsetY = 6.dp
+    val layerCount = entry.count.coerceIn(2, 3)
+    val frameHeight = StandardGridCoverHeight
+    val stackStepX = 5.dp
+    val stackStepY = 10.dp
+    val totalShiftX = stackStepX * (layerCount - 1)
+    val totalShiftY = stackStepY * (layerCount - 1)
+    val cardWidth = StandardGridCoverWidth - totalShiftX - 3.dp
+    val cardHeight = StandardGridCoverHeight - totalShiftY - 3.dp
+    val baseShiftX = (-4).dp
+    val baseShiftY = 1.dp
+    val layerShape = RoundedCornerShape(8.dp)
     Column(
         modifier = Modifier.clickable(onClick = onClick),
         verticalArrangement = Arrangement.spacedBy(6.dp)
@@ -769,50 +956,42 @@ private fun AuthorSeriesGridItem(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(StandardGridCoverHeight + frontOffsetY + 4.dp),
+                .height(frameHeight)
+                .clipToBounds(),
             contentAlignment = Alignment.TopCenter
         ) {
-            repeat(layerCount - 1) { layer ->
-                val depth = layerCount - 2 - layer
-                val xOffset = (frontOffsetX - ((depth + 1) * 3).dp).coerceAtLeast(0.dp)
-                val yOffset = (frontOffsetY - ((depth + 1) * 2).dp).coerceAtLeast(0.dp)
-                val alpha = (0.34f + layer * 0.14f).coerceIn(0f, 1f)
+            repeat(layerCount) { layer ->
+                val xOffset = baseShiftX + (stackStepX * layer)
+                val yOffset = baseShiftY + (stackStepY * layer)
+                val alpha = 1f
+                val layerShadow = if (layer == layerCount - 1) 1.2.dp else 3.4.dp
                 FramedCoverImage(
                     coverUrl = lead.coverUrl,
                     contentDescription = entry.seriesName,
                     modifier = Modifier
                         .offset(x = xOffset, y = yOffset)
-                        .width(StandardGridCoverWidth)
-                        .height(StandardGridCoverHeight)
+                        .width(cardWidth)
+                        .height(cardHeight)
+                        .shadow(elevation = layerShadow, shape = layerShape, clip = false)
                         .graphicsLayer(alpha = alpha),
-                    shape = RoundedCornerShape(8.dp),
+                    shape = layerShape,
                     contentScale = ContentScale.Fit,
                     backgroundBlur = WideCoverBackgroundBlur
                 )
             }
-            FramedCoverImage(
-                coverUrl = lead.coverUrl,
-                contentDescription = entry.seriesName,
-                modifier = Modifier
-                    .offset(x = frontOffsetX, y = frontOffsetY)
-                    .width(StandardGridCoverWidth)
-                    .height(StandardGridCoverHeight),
-                shape = RoundedCornerShape(8.dp),
-                contentScale = ContentScale.Fit,
-                backgroundBlur = WideCoverBackgroundBlur
+        }
+        Row(
+            modifier = Modifier
+                .width(StandardGridCoverWidth)
+                .align(Alignment.CenterHorizontally),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = if (entry.count == 1) "1 book" else "${entry.count} books",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
-        Text(
-            text = entry.seriesName,
-            style = MaterialTheme.typography.bodyMedium,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
-        Text(
-            text = if (entry.count == 1) "1 book" else "${entry.count} books",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
     }
 }
 
@@ -892,22 +1071,37 @@ private fun AuthorSeriesListRow(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Box(
-                modifier = Modifier.size(74.dp),
+                modifier = Modifier
+                    .size(72.dp)
+                    .clipToBounds(),
                 contentAlignment = Alignment.Center
             ) {
-                val layerCount = entry.count.coerceIn(2, 5)
+                val layerCount = entry.count.coerceIn(2, 3)
+                val frameSize = 72.dp
+                val stackStepX = 4.dp
+                val stackStepY = 7.dp
+                val totalShiftX = stackStepX * (layerCount - 1)
+                val totalShiftY = stackStepY * (layerCount - 1)
+                val cardWidth = frameSize - totalShiftX - 3.dp
+                val cardHeight = frameSize - totalShiftY - 3.dp
+                val baseShiftX = (-4).dp
+                val baseShiftY = 1.dp
+                val layerShape = RoundedCornerShape(8.dp)
                 repeat(layerCount) { layer ->
-                    val xOffset = (layer * 3).dp
-                    val yOffset = (layer * 2).dp
-                    val alpha = if (layer == layerCount - 1) 1f else 0.56f + (layer * 0.1f)
+                    val xOffset = baseShiftX + (stackStepX * layer)
+                    val yOffset = baseShiftY + (stackStepY * layer)
+                    val alpha = 1f
+                    val layerShadow = if (layer == layerCount - 1) 1.dp else 2.8.dp
                     FramedCoverImage(
                         coverUrl = lead.coverUrl,
                         contentDescription = entry.seriesName,
                         modifier = Modifier
                             .offset(x = xOffset, y = yOffset)
-                            .size(64.dp)
+                            .width(cardWidth)
+                            .height(cardHeight)
+                            .shadow(elevation = layerShadow, shape = layerShape, clip = false)
                             .graphicsLayer(alpha = alpha),
-                        shape = RoundedCornerShape(8.dp),
+                        shape = layerShape,
                         contentScale = ContentScale.Fit,
                         backgroundBlur = WideCoverBackgroundBlur
                     )
@@ -943,10 +1137,11 @@ private fun AuthorSeriesListRow(
 fun SeriesDetailScreen(
     onBackClick: () -> Unit,
     onBookClick: (String) -> Unit,
+    onHomeClick: (() -> Unit)? = null,
     viewModel: SeriesDetailViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    var listMode by remember { mutableStateOf(true) }
+    val listMode by viewModel.listMode.collectAsStateWithLifecycle()
     val refreshState = rememberPullRefreshState(
         refreshing = uiState.isLoading,
         onRefresh = viewModel::refresh
@@ -1016,6 +1211,21 @@ fun SeriesDetailScreen(
                                         contentDescription = "Back"
                                     )
                                 }
+                                if (onHomeClick != null) {
+                                    Spacer(modifier = Modifier.width(FacetBackTitleSpacing))
+                                    IconButton(
+                                        onClick = onHomeClick,
+                                        modifier = Modifier
+                                            .size(40.dp)
+                                            .clip(CircleShape)
+                                            .background(MaterialTheme.colorScheme.surface)
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Outlined.Home,
+                                            contentDescription = "Home"
+                                        )
+                                    }
+                                }
                                 Spacer(modifier = Modifier.weight(1f))
                                 IconButton(
                                     onClick = {},
@@ -1030,7 +1240,7 @@ fun SeriesDetailScreen(
                                 }
                                 Spacer(modifier = Modifier.width(8.dp))
                                 IconButton(
-                                    onClick = { listMode = !listMode },
+                                    onClick = { viewModel.setListMode(!listMode) },
                                     modifier = Modifier
                                         .size(40.dp)
                                         .clip(CircleShape)
@@ -1053,7 +1263,7 @@ fun SeriesDetailScreen(
                     }
 
                     item {
-                        SeriesCoverStack(leadBook = leadBook, layerCount = books.size.coerceAtMost(5))
+                        SeriesCoverStack(leadBook = leadBook, layerCount = books.size.coerceIn(2, 3))
                     }
                     item {
                         Text(
@@ -1075,16 +1285,7 @@ fun SeriesDetailScreen(
 
                     if (listMode) {
                         itemsIndexed(books, key = { _, item -> item.id }) { index, book ->
-                            val orderLabel = book.seriesSequence
-                                ?.takeIf { it > 0.0 }
-                                ?.let { sequence ->
-                                    if (sequence % 1.0 == 0.0) {
-                                        sequence.toInt().toString()
-                                    } else {
-                                        sequence.toString()
-                                    }
-                                }
-                                ?: (index + 1).toString()
+                            val orderLabel = formatSeriesOrderLabel(book.seriesSequence) ?: (index + 1).toString()
                             SeriesDetailBookRow(
                                 book = book,
                                 orderLabel = orderLabel,
@@ -1094,14 +1295,17 @@ fun SeriesDetailScreen(
                         }
                     } else {
                         val bookRows = books.chunked(2)
-                        itemsIndexed(bookRows, key = { index, _ -> "series-grid-row-$index" }) { _, rowBooks ->
+                        itemsIndexed(bookRows, key = { index, _ -> "series-grid-row-$index" }) { rowIndex, rowBooks ->
                             Row(
                                 modifier = Modifier.fillMaxWidth(),
                                 horizontalArrangement = Arrangement.spacedBy(12.dp)
                             ) {
-                                rowBooks.forEach { book ->
+                                rowBooks.forEachIndexed { columnIndex, book ->
+                                    val fallbackIndex = (rowIndex * 2) + columnIndex + 1
+                                    val orderLabel = formatSeriesOrderLabel(book.seriesSequence) ?: fallbackIndex.toString()
                                     SeriesDetailGridCard(
                                         book = book,
+                                        orderLabel = orderLabel,
                                         modifier = Modifier.weight(1f),
                                         onClick = { onBookClick(book.id) }
                                     )
@@ -1129,6 +1333,7 @@ fun SeriesDetailScreen(
 fun GenresBrowseScreen(
     onBackClick: () -> Unit,
     onGenreClick: (String) -> Unit,
+    onHomeClick: (() -> Unit)? = null,
     viewModel: GenresBrowseViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -1144,7 +1349,8 @@ fun GenresBrowseScreen(
     ) {
         FacetTopBar(
             title = "Genres",
-            onBackClick = onBackClick
+            onBackClick = onBackClick,
+            onHomeClick = onHomeClick
         )
         Spacer(modifier = Modifier.height(10.dp))
         Box(
@@ -1229,12 +1435,14 @@ fun GenresBrowseScreen(
 fun GenreDetailScreen(
     onBackClick: () -> Unit,
     onBookClick: (String) -> Unit,
+    onHomeClick: (() -> Unit)? = null,
     viewModel: GenreDetailViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     FacetBooksScreen(
         uiState = uiState,
         onBackClick = onBackClick,
+        onHomeClick = onHomeClick,
         onBookClick = onBookClick,
         onRetry = viewModel::refresh,
         showMoreIcon = true
@@ -1245,12 +1453,14 @@ fun GenreDetailScreen(
 fun NarratorDetailScreen(
     onBackClick: () -> Unit,
     onBookClick: (String) -> Unit,
+    onHomeClick: (() -> Unit)? = null,
     viewModel: NarratorDetailViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     FacetBooksScreen(
         uiState = uiState,
         onBackClick = onBackClick,
+        onHomeClick = onHomeClick,
         onBookClick = onBookClick,
         onRetry = viewModel::refresh
     )
@@ -1261,6 +1471,7 @@ fun NarratorDetailScreen(
 private fun FacetBooksScreen(
     uiState: FacetBooksUiState,
     onBackClick: () -> Unit,
+    onHomeClick: (() -> Unit)? = null,
     onBookClick: (String) -> Unit,
     onRetry: () -> Unit,
     showMoreIcon: Boolean = false
@@ -1277,6 +1488,7 @@ private fun FacetBooksScreen(
         FacetTopBar(
             title = uiState.title,
             onBackClick = onBackClick,
+            onHomeClick = onHomeClick,
             showMoreIcon = showMoreIcon
         )
         Spacer(modifier = Modifier.height(10.dp))
@@ -1342,6 +1554,7 @@ private fun FacetBooksScreen(
 private fun FacetTopBar(
     title: String,
     onBackClick: () -> Unit,
+    onHomeClick: (() -> Unit)? = null,
     showMoreIcon: Boolean = false
 ) {
     Row(
@@ -1361,6 +1574,21 @@ private fun FacetTopBar(
             )
         }
         Spacer(modifier = Modifier.width(FacetBackTitleSpacing))
+        if (onHomeClick != null) {
+            IconButton(
+                onClick = onHomeClick,
+                modifier = Modifier
+                    .size(42.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surface)
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Home,
+                    contentDescription = "Home"
+                )
+            }
+            Spacer(modifier = Modifier.width(FacetBackTitleSpacing))
+        }
         Text(
             text = title,
             style = MaterialTheme.typography.titleLarge,
@@ -1379,17 +1607,27 @@ private fun FacetTopBar(
     }
 }
 
+private inline fun <reified T : Enum<T>> enumValueOrNull(raw: String): T? {
+    return runCatching { enumValueOf<T>(raw) }.getOrNull()
+}
+
 @Composable
 private fun SeriesCoverStack(
     leadBook: BookSummary,
     layerCount: Int
 ) {
-    val count = layerCount.coerceAtLeast(1)
-    val posterWidth = 168.dp
-    val posterHeight = 172.dp
-    val stepX = 14f
-    val stepY = 5f
-    val startX = (-(stepX * (count - 1)) / 2f).dp
+    val count = layerCount.coerceIn(2, 3)
+    val frameWidth = 168.dp
+    val frameHeight = 172.dp
+    val stepX = 7.dp
+    val stepY = 12.dp
+    val totalShiftX = stepX * (count - 1)
+    val totalShiftY = stepY * (count - 1)
+    val cardWidth = frameWidth - totalShiftX - 3.dp
+    val cardHeight = frameHeight - totalShiftY - 3.dp
+    val baseShiftX = (-4).dp
+    val baseShiftY = 1.dp
+    val layerShape = RoundedCornerShape(10.dp)
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -1397,19 +1635,20 @@ private fun SeriesCoverStack(
         contentAlignment = Alignment.TopCenter
     ) {
         for (layer in 0 until count) {
-            val offsetX = startX + (layer * stepX).dp
-            val offsetY = (layer * stepY).dp
-            val isFront = layer == count - 1
-            val alpha = if (isFront) 1f else (0.32f + (layer * 0.14f)).coerceAtMost(0.78f)
+            val offsetX = baseShiftX + (stepX * layer)
+            val offsetY = baseShiftY + (stepY * layer)
+            val alpha = 1f
+            val layerShadow = if (layer == count - 1) 1.2.dp else 3.4.dp
             FramedCoverImage(
                 coverUrl = leadBook.coverUrl,
                 contentDescription = leadBook.title,
                 modifier = Modifier
                     .offset(x = offsetX, y = offsetY)
-                    .width(posterWidth)
-                    .height(posterHeight)
+                    .width(cardWidth)
+                    .height(cardHeight)
+                    .shadow(elevation = layerShadow, shape = layerShape, clip = false)
                     .graphicsLayer(alpha = alpha),
-                shape = RoundedCornerShape(10.dp),
+                shape = layerShape,
                 contentScale = ContentScale.Fit,
                 backgroundBlur = 44.dp
             )
@@ -1494,6 +1733,7 @@ private fun SeriesDetailBookRow(
 @Composable
 private fun SeriesDetailGridCard(
     book: BookSummary,
+    orderLabel: String,
     modifier: Modifier = Modifier,
     onClick: () -> Unit
 ) {
@@ -1501,21 +1741,45 @@ private fun SeriesDetailGridCard(
         modifier = modifier.clickable(onClick = onClick),
         verticalArrangement = Arrangement.spacedBy(6.dp)
     ) {
-        FramedCoverImage(
-            coverUrl = book.coverUrl,
-            contentDescription = book.title,
+        Box(
             modifier = Modifier
                 .width(StandardGridCoverWidth)
                 .height(StandardGridCoverHeight)
+                .align(Alignment.CenterHorizontally)
+        ) {
+            FramedCoverImage(
+                coverUrl = book.coverUrl,
+                contentDescription = book.title,
+                modifier = Modifier.matchParentSize(),
+                shape = RoundedCornerShape(8.dp),
+                contentScale = ContentScale.Fit
+            )
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .offset(x = (-4).dp, y = (-4).dp)
+                    .clip(RoundedCornerShape(5.dp))
+                    .background(MaterialTheme.colorScheme.surface)
+                    .padding(horizontal = 4.dp, vertical = 1.dp)
+            ) {
+                Text(
+                    text = "#$orderLabel",
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+        }
+        Row(
+            modifier = Modifier
+                .width(StandardGridCoverWidth)
                 .align(Alignment.CenterHorizontally),
-            shape = RoundedCornerShape(8.dp),
-            contentScale = ContentScale.Fit
-        )
-        Text(
-            text = formatDuration(book.durationSeconds),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = formatDuration(book.durationSeconds),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
     }
 }
 
@@ -1578,4 +1842,13 @@ private fun formatDuration(durationSeconds: Double?): String {
     val hours = seconds / 3600
     val minutes = (seconds % 3600) / 60
     return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
+}
+
+private fun formatSeriesOrderLabel(seriesSequence: Double?): String? {
+    val sequence = seriesSequence?.takeIf { it > 0.0 } ?: return null
+    return if (sequence % 1.0 == 0.0) {
+        sequence.toInt().toString()
+    } else {
+        sequence.toString()
+    }
 }

--- a/app/src/main/java/com/stillshelf/app/ui/screens/PlaceholderScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/PlaceholderScreens.kt
@@ -5,10 +5,14 @@ import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -54,6 +58,7 @@ import androidx.compose.material.icons.outlined.FastForward
 import androidx.compose.material.icons.outlined.FastRewind
 import androidx.compose.material.icons.outlined.GraphicEq
 import androidx.compose.material.icons.outlined.GridView
+import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.MoreHoriz
 import androidx.compose.material.icons.outlined.MusicNote
 import androidx.compose.material.icons.outlined.Pause
@@ -94,13 +99,18 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -194,6 +204,7 @@ fun HomePlaceholderScreen(
     onOpenSeries: (String) -> Unit = {},
     onOpenAuthor: (String) -> Unit = {},
     onOpenPlayer: (String?) -> Unit = {},
+    onHomeClick: (() -> Unit)? = null,
     viewModel: HomeViewModel = hiltViewModel(),
     menuViewModel: HomeMenuViewModel = hiltViewModel(),
     customizeViewModel: CustomizeViewModel = hiltViewModel()
@@ -283,11 +294,19 @@ fun HomePlaceholderScreen(
                 ) {
                     Text(
                         text = uiState.libraryName,
-                        style = MaterialTheme.typography.headlineMedium,
+                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.weight(1f)
                     )
+                    if (onHomeClick != null) {
+                        CircleActionButton(
+                            icon = Icons.Outlined.Home,
+                            contentDescription = "Home",
+                            onClick = onHomeClick
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                    }
                     CircleActionButton(
                         icon = Icons.Outlined.Search,
                         contentDescription = "Search",
@@ -632,6 +651,7 @@ fun BrowsePlaceholderScreen(
     onBookClick: (String) -> Unit,
     onSeriesClick: (String) -> Unit = {},
     onBackClick: (() -> Unit)? = null,
+    onHomeClick: (() -> Unit)? = null,
     viewModel: BooksBrowseViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -665,6 +685,7 @@ fun BrowsePlaceholderScreen(
             BackTitle(
                 title = "Books",
                 onBackClick = onBackClick,
+                onHomeClick = onHomeClick,
                 modifier = Modifier.weight(1f)
             )
             Box {
@@ -762,7 +783,7 @@ fun BrowsePlaceholderScreen(
             }
         }
 
-        Spacer(modifier = Modifier.height(10.dp))
+        Spacer(modifier = Modifier.height(56.dp))
 
         Box(
             modifier = Modifier
@@ -1000,11 +1021,18 @@ private fun SeriesStackGridItem(
     onClick: () -> Unit
 ) {
     val book = entry.leadBook
-    val posterWidth = StandardGridCoverWidth
-    val posterHeight = StandardGridCoverHeight
-    val layerCount = entry.count.coerceIn(3, 6)
-    val frontOffsetX = 16.dp
-    val frontOffsetY = 8.dp
+    val layerCount = entry.count.coerceIn(2, 3)
+    val frameWidth = StandardGridCoverWidth
+    val frameHeight = StandardGridCoverHeight
+    val stackStepX = 5.dp
+    val stackStepY = 10.dp
+    val totalShiftX = stackStepX * (layerCount - 1)
+    val totalShiftY = stackStepY * (layerCount - 1)
+    val cardWidth = frameWidth - totalShiftX - 3.dp
+    val cardHeight = frameHeight - totalShiftY - 3.dp
+    val baseShiftX = (-4).dp
+    val baseShiftY = 1.dp
+    val layerShape = RoundedCornerShape(8.dp)
     Column(
         verticalArrangement = Arrangement.spacedBy(6.dp),
         modifier = Modifier.clickable(onClick = onClick)
@@ -1012,50 +1040,42 @@ private fun SeriesStackGridItem(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(posterHeight + frontOffsetY + 4.dp),
+                .height(frameHeight)
+                .clipToBounds(),
             contentAlignment = Alignment.TopCenter
         ) {
-            repeat(layerCount - 1) { layer ->
-                val depth = (layerCount - 2 - layer)
-                val xOffset = (frontOffsetX - ((depth + 1) * 4).dp).coerceAtLeast(0.dp)
-                val yOffset = (frontOffsetY - ((depth + 1) * 3).dp).coerceAtLeast(0.dp)
-                val alpha = 0.28f + (layer * 0.14f)
+            repeat(layerCount) { layer ->
+                val xOffset = baseShiftX + (stackStepX * layer)
+                val yOffset = baseShiftY + (stackStepY * layer)
+                val alpha = 1f
+                val layerShadow = if (layer == layerCount - 1) 1.2.dp else 3.4.dp
                 FramedCoverImage(
                     coverUrl = book.coverUrl,
                     contentDescription = book.title,
                     modifier = Modifier
                         .offset(x = xOffset, y = yOffset)
-                        .width(posterWidth)
-                        .height(posterHeight)
+                        .width(cardWidth)
+                        .height(cardHeight)
+                        .shadow(elevation = layerShadow, shape = layerShape, clip = false)
                         .graphicsLayer(alpha = alpha.coerceIn(0f, 1f)),
-                    shape = RoundedCornerShape(8.dp),
+                    shape = layerShape,
                     contentScale = ContentScale.Fit,
                     backgroundBlur = WideCoverBackgroundBlur
                 )
             }
-            FramedCoverImage(
-                coverUrl = book.coverUrl,
-                contentDescription = book.title,
-                modifier = Modifier
-                    .offset(x = frontOffsetX, y = frontOffsetY)
-                    .width(posterWidth)
-                    .height(posterHeight),
-                shape = RoundedCornerShape(8.dp),
-                contentScale = ContentScale.Fit,
-                backgroundBlur = WideCoverBackgroundBlur
+        }
+        Row(
+            modifier = Modifier
+                .width(frameWidth)
+                .align(Alignment.CenterHorizontally),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = if (entry.count == 1) "1 book" else "${entry.count} books",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
-        Text(
-            text = entry.seriesName,
-            style = MaterialTheme.typography.bodyMedium,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
-        Text(
-            text = if (entry.count == 1) "1 book" else "${entry.count} books",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
     }
 }
 
@@ -1140,21 +1160,34 @@ private fun SeriesStackListItem(
             modifier = Modifier
                 .width(88.dp)
                 .height(88.dp)
+                .clipToBounds()
         ) {
-            val layerCount = entry.books.size.coerceIn(2, 5)
+            val layerCount = entry.books.size.coerceIn(2, 3)
+            val frameSize = 88.dp
+            val stackStepX = 4.dp
+            val stackStepY = 7.dp
+            val totalShiftX = stackStepX * (layerCount - 1)
+            val totalShiftY = stackStepY * (layerCount - 1)
+            val cardWidth = frameSize - totalShiftX - 3.dp
+            val cardHeight = frameSize - totalShiftY - 3.dp
+            val baseShiftX = (-4).dp
+            val baseShiftY = 1.dp
+            val layerShape = RoundedCornerShape(6.dp)
             repeat(layerCount) { layer ->
-                val xOffset = (layer * 3).dp
-                val yOffset = layer.dp
-                val alpha = if (layer == layerCount - 1) 1f else 0.52f + (layer * 0.1f)
+                val xOffset = baseShiftX + (stackStepX * layer)
+                val yOffset = baseShiftY + (stackStepY * layer)
+                val alpha = 1f
+                val layerShadow = if (layer == layerCount - 1) 1.dp else 2.8.dp
                 FramedCoverImage(
                     coverUrl = lead.coverUrl,
                     contentDescription = entry.seriesName,
                     modifier = Modifier
                         .offset(x = xOffset, y = yOffset)
-                        .width(76.dp)
-                        .height(88.dp)
+                        .width(cardWidth)
+                        .height(cardHeight)
+                        .shadow(elevation = layerShadow, shape = layerShape, clip = false)
                         .graphicsLayer(alpha = alpha.coerceIn(0f, 1f)),
-                    shape = RoundedCornerShape(6.dp),
+                    shape = layerShape,
                     contentScale = ContentScale.Fit,
                     backgroundBlur = 44.dp
                 )
@@ -1225,6 +1258,7 @@ private fun buildBooksGridEntries(
 fun AuthorsBrowseScreen(
     onAuthorClick: (String) -> Unit,
     onBackClick: (() -> Unit)? = null,
+    onHomeClick: (() -> Unit)? = null,
     viewModel: AuthorsBrowseViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -1234,6 +1268,7 @@ fun AuthorsBrowseScreen(
         onRetry = viewModel::refresh,
         onEntityClick = { onAuthorClick(it.name) },
         onBackClick = onBackClick,
+        onHomeClick = onHomeClick,
         showAvatar = true
     )
 }
@@ -1241,6 +1276,7 @@ fun AuthorsBrowseScreen(
 @Composable
 fun CollectionsBrowseScreen(
     onBackClick: (() -> Unit)? = null,
+    onHomeClick: (() -> Unit)? = null,
     viewModel: CollectionsBrowseViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -1248,7 +1284,8 @@ fun CollectionsBrowseScreen(
         title = "Collections",
         uiState = uiState,
         onRetry = viewModel::refresh,
-        onBackClick = onBackClick
+        onBackClick = onBackClick,
+        onHomeClick = onHomeClick
     )
 }
 
@@ -1261,6 +1298,7 @@ fun NarratorsBrowseScreen(viewModel: NarratorsBrowseViewModel = hiltViewModel())
 fun NarratorsBrowseScreen(
     onNarratorClick: (String) -> Unit,
     onBackClick: (() -> Unit)? = null,
+    onHomeClick: (() -> Unit)? = null,
     viewModel: NarratorsBrowseViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -1272,7 +1310,8 @@ fun NarratorsBrowseScreen(
     ) {
         BackTitle(
             title = "Narrators",
-            onBackClick = onBackClick
+            onBackClick = onBackClick,
+            onHomeClick = onHomeClick
         )
         Spacer(modifier = Modifier.height(10.dp))
         when {
@@ -1359,6 +1398,7 @@ fun NarratorsBrowseScreen(
 fun SeriesBrowseScreen(
     onSeriesClick: (String) -> Unit,
     onBackClick: (() -> Unit)? = null,
+    onHomeClick: (() -> Unit)? = null,
     viewModel: SeriesBrowseViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -1370,7 +1410,8 @@ fun SeriesBrowseScreen(
     ) {
         BackTitle(
             title = "Series",
-            onBackClick = onBackClick
+            onBackClick = onBackClick,
+            onHomeClick = onHomeClick
         )
         Spacer(modifier = Modifier.height(10.dp))
 
@@ -1414,29 +1455,40 @@ fun SeriesBrowseScreen(
                             Box(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .height(234.dp),
+                                    .height(StandardGridCoverHeight)
+                                    .clipToBounds(),
                                 contentAlignment = Alignment.TopCenter
                             ) {
-                                val posterWidth = StandardGridCoverWidth
-                                val posterHeight = StandardGridCoverHeight
-                                val layerCount = 5
-                                val stackStart = 0.dp
-                                val horizontalStep = 9.dp
-                                val verticalStep = 5.dp
+                                val inferredCount = series.subtitle
+                                    .orEmpty()
+                                    .trim()
+                                    .substringBefore(" ")
+                                    .toIntOrNull()
+                                val layerCount = inferredCount?.coerceIn(2, 3) ?: 3
+                                val stackStepX = 5.dp
+                                val stackStepY = 10.dp
+                                val totalShiftX = stackStepX * (layerCount - 1)
+                                val totalShiftY = stackStepY * (layerCount - 1)
+                                val cardWidth = StandardGridCoverWidth - totalShiftX - 3.dp
+                                val cardHeight = StandardGridCoverHeight - totalShiftY - 3.dp
+                                val baseShiftX = (-4).dp
+                                val baseShiftY = 1.dp
+                                val layerShape = RoundedCornerShape(8.dp)
                                 repeat(layerCount) { layer ->
-                                    val xOffset = horizontalStep * layer
-                                    val yOffset = verticalStep * layer
-                                    val alpha = if (layer == layerCount - 1) 1f else (0.34f + (layer * 0.16f))
-                                    val layerModifier = Modifier
-                                        .offset(x = stackStart + xOffset, y = yOffset)
-                                        .width(posterWidth)
-                                        .height(posterHeight)
-                                        .graphicsLayer(alpha = alpha.coerceIn(0f, 1f))
+                                    val xOffset = baseShiftX + (stackStepX * layer)
+                                    val yOffset = baseShiftY + (stackStepY * layer)
+                                    val alpha = 1f
+                                    val layerShadow = if (layer == layerCount - 1) 1.2.dp else 3.4.dp
                                     FramedCoverImage(
                                         coverUrl = series.coverUrl,
                                         contentDescription = series.name,
-                                        modifier = layerModifier,
-                                        shape = RoundedCornerShape(8.dp),
+                                        modifier = Modifier
+                                            .offset(x = xOffset, y = yOffset)
+                                            .width(cardWidth)
+                                            .height(cardHeight)
+                                            .shadow(elevation = layerShadow, shape = layerShape, clip = false)
+                                            .graphicsLayer(alpha = alpha.coerceIn(0f, 1f)),
+                                        shape = layerShape,
                                         contentScale = ContentScale.Fit,
                                         backgroundBlur = WideCoverBackgroundBlur
                                     )
@@ -1477,7 +1529,8 @@ fun BrowseSectionPlaceholderScreen(
     title: String,
     emptyMessage: String,
     icon: androidx.compose.ui.graphics.vector.ImageVector = Icons.Outlined.GridView,
-    onBackClick: (() -> Unit)? = null
+    onBackClick: (() -> Unit)? = null,
+    onHomeClick: (() -> Unit)? = null
 ) {
     Column(
         modifier = Modifier
@@ -1486,7 +1539,8 @@ fun BrowseSectionPlaceholderScreen(
     ) {
         BackTitle(
             title = title,
-            onBackClick = onBackClick
+            onBackClick = onBackClick,
+            onHomeClick = onHomeClick
         )
         Box(modifier = Modifier.fillMaxSize()) {
             Column(
@@ -1734,12 +1788,13 @@ private fun SearchEntityRow(
 
 @Composable
 fun DownloadsPlaceholderScreen() {
-    DownloadsPlaceholderScreen(onBackClick = null)
+    DownloadsPlaceholderScreen(onBackClick = null, onHomeClick = null)
 }
 
 @Composable
 fun DownloadsPlaceholderScreen(
-    onBackClick: (() -> Unit)? = null
+    onBackClick: (() -> Unit)? = null,
+    onHomeClick: (() -> Unit)? = null
 ) {
     Column(
         modifier = Modifier
@@ -1753,6 +1808,7 @@ fun DownloadsPlaceholderScreen(
             BackTitle(
                 title = "Downloaded",
                 onBackClick = onBackClick,
+                onHomeClick = onHomeClick,
                 modifier = Modifier.weight(1f)
             )
             CircleActionButton(
@@ -2039,6 +2095,7 @@ private fun SettingsRow(
 fun ServersManagementScreen(
     onBackClick: () -> Unit,
     onAddServerClick: () -> Unit,
+    onHomeClick: (() -> Unit)? = null,
     viewModel: ServerManagementViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -2056,6 +2113,7 @@ fun ServersManagementScreen(
             BackTitle(
                 title = "Servers",
                 onBackClick = onBackClick,
+                onHomeClick = onHomeClick,
                 modifier = Modifier.weight(1f)
             )
             Card(
@@ -2139,6 +2197,7 @@ fun BookDetailScreen(
     onBackClick: () -> Unit,
     onStartListening: (String) -> Unit = {},
     onOpenAuthor: (String) -> Unit = {},
+    onHomeClick: (() -> Unit)? = null,
     viewModel: BookDetailViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
@@ -2177,6 +2236,14 @@ fun BookDetailScreen(
                     contentDescription = "Back",
                     onClick = onBackClick
                 )
+                if (onHomeClick != null) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    CircleActionButton(
+                        icon = Icons.Outlined.Home,
+                        contentDescription = "Home",
+                        onClick = onHomeClick
+                    )
+                }
                 Spacer(modifier = Modifier.weight(1f))
                 CircleActionButton(
                     icon = Icons.Outlined.Download,
@@ -2281,20 +2348,46 @@ fun BookDetailScreen(
                 val activeChapterIndex = chapterPositionSeconds
                     ?.let { position -> findActiveChapterIndex(detail.chapters, position) }
                     ?: -1
+                val seriesOrderLabel = resolveSeriesOrderLabel(
+                    seriesSequence = book.seriesSequence,
+                    book.title,
+                    detail.chapters.firstOrNull()?.title
+                )
 
                 item {
                     Box(
                         modifier = Modifier.fillMaxWidth(),
                         contentAlignment = Alignment.Center
                     ) {
-                        BookPoster(
-                            book = book,
-                            width = 240.dp,
-                            height = 320.dp,
-                            fillMaxWidth = true,
-                            shape = RoundedCornerShape(10.dp),
-                            contentScale = ContentScale.Fit
-                        )
+                        Box(
+                            modifier = Modifier
+                                .width(240.dp)
+                                .height(320.dp)
+                        ) {
+                            BookPoster(
+                                book = book,
+                                width = 240.dp,
+                                height = 320.dp,
+                                fillMaxWidth = true,
+                                shape = RoundedCornerShape(10.dp),
+                                contentScale = ContentScale.Fit
+                            )
+                            seriesOrderLabel?.let { order ->
+                                Box(
+                                    modifier = Modifier
+                                        .align(Alignment.TopStart)
+                                        .offset(x = (-4).dp, y = (-4).dp)
+                                        .clip(RoundedCornerShape(6.dp))
+                                        .background(MaterialTheme.colorScheme.surface)
+                                        .padding(horizontal = 6.dp, vertical = 2.dp)
+                                ) {
+                                    Text(
+                                        text = "#$order",
+                                        style = MaterialTheme.typography.bodySmall
+                                    )
+                                }
+                            }
+                        }
                     }
                 }
                 item {
@@ -2552,6 +2645,14 @@ fun PlayerPlaceholderScreen(
     } else {
         0f
     }
+    var isScrubbing by remember { mutableStateOf(false) }
+    var scrubbingProgress by remember { mutableStateOf(progress) }
+    LaunchedEffect(progress, isScrubbing) {
+        if (!isScrubbing) {
+            scrubbingProgress = progress
+        }
+    }
+    val effectiveProgress = if (isScrubbing) scrubbingProgress else progress
     val activeChapterTitle = findActiveChapterTitle(chapters, positionSeconds)
     val playerTitle = if (
         book != null &&
@@ -2562,38 +2663,49 @@ fun PlayerPlaceholderScreen(
     } else {
         book?.title.orEmpty()
     }
-    val immersiveColor = rememberDominantCoverColor(
-        coverUrl = book?.coverUrl,
-        enabled = appearanceUiState.immersivePlayerEnabled
+    val playerSeriesOrderLabel = resolveSeriesOrderLabel(
+        seriesSequence = book?.seriesSequence,
+        book?.title,
+        activeChapterTitle
     )
-    val backgroundModifier = if (appearanceUiState.immersivePlayerEnabled && immersiveColor != null) {
-        Modifier
-            .background(MaterialTheme.colorScheme.background)
-            .background(
-                Brush.verticalGradient(
-                    colorStops = arrayOf(
-                        0.00f to immersiveColor.copy(alpha = 0.62f),
-                        0.22f to immersiveColor.copy(alpha = 0.46f),
-                        0.48f to immersiveColor.copy(alpha = 0.26f),
-                        0.78f to immersiveColor.copy(alpha = 0.10f),
-                        1.00f to Color.Transparent
-                    )
-                )
-            )
-    } else {
-        Modifier.background(MaterialTheme.colorScheme.background)
-    }
+    val immersiveEnabled = appearanceUiState.immersivePlayerEnabled && !book?.coverUrl.isNullOrBlank()
     var dragDistance by remember { mutableStateOf(0f) }
     var bottomMenuExpanded by remember { mutableStateOf(false) }
     var playerInfoMessage by remember { mutableStateOf<String?>(null) }
     val speeds = remember { listOf(0.8f, 1.0f, 1.3f, 1.5f, 1.8f, 2.0f) }
     var speedIndex by rememberSaveable { mutableStateOf(2) }
     val speedLabel = "${speeds[speedIndex]}x"
+    val playerTopOffset = 72.dp
+    val mainPlayButtonContainer = if (immersiveEnabled) {
+        MaterialTheme.colorScheme.surface.copy(alpha = 0.84f)
+    } else {
+        MaterialTheme.colorScheme.surfaceVariant
+    }
+    val mainPlayButtonIconTint = if (mainPlayButtonContainer.luminance() > 0.5f) {
+        Color.Black
+    } else {
+        Color.White
+    }
+    val progressActiveColor = if (immersiveEnabled) {
+        Color.White.copy(alpha = 0.92f)
+    } else {
+        MaterialTheme.colorScheme.onSurface
+    }
+    val progressTrackColor = if (immersiveEnabled) {
+        Color.White.copy(alpha = 0.24f)
+    } else {
+        MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
+    }
+    val primaryTextColor = if (immersiveEnabled) Color.White else MaterialTheme.colorScheme.onSurface
+    val secondaryTextColor = if (immersiveEnabled) {
+        Color.White.copy(alpha = 0.72f)
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
 
-    Column(
+    Box(
         modifier = Modifier
             .fillMaxSize()
-            .then(backgroundModifier)
             .pointerInput(onBackClick) {
                 detectVerticalDragGestures(
                     onVerticalDrag = { _, dragAmount ->
@@ -2609,8 +2721,44 @@ fun PlayerPlaceholderScreen(
                     onDragCancel = { dragDistance = 0f }
                 )
             }
-            .padding(horizontal = 18.dp, vertical = 12.dp)
     ) {
+        if (immersiveEnabled) {
+            AsyncImage(
+                model = rememberCoverImageModel(book?.coverUrl),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer(alpha = 0.98f)
+                    .blur(28.dp)
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        Brush.verticalGradient(
+                            colorStops = arrayOf(
+                                0.00f to Color.Black.copy(alpha = 0.34f),
+                                0.24f to Color.Black.copy(alpha = 0.16f),
+                                0.58f to MaterialTheme.colorScheme.background.copy(alpha = 0.08f),
+                                1.00f to MaterialTheme.colorScheme.background.copy(alpha = 0.24f)
+                            )
+                        )
+                    )
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background)
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 18.dp, vertical = 12.dp)
+        ) {
         Box(
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)
@@ -2619,7 +2767,7 @@ fun PlayerPlaceholderScreen(
                 .clip(RoundedCornerShape(10.dp))
                 .background(MaterialTheme.colorScheme.outline.copy(alpha = 0.6f))
         )
-        Spacer(modifier = Modifier.height(10.dp))
+        Spacer(modifier = Modifier.height(playerTopOffset))
         if (book == null) {
             CenteredEmptyState(
                 icon = Icons.Outlined.PlayArrow,
@@ -2633,17 +2781,38 @@ fun PlayerPlaceholderScreen(
             modifier = Modifier.fillMaxWidth(),
             contentAlignment = Alignment.Center
         ) {
-            BookPoster(
-                book = book,
-                width = 332.dp,
-                height = 320.dp,
-                fillMaxWidth = true,
-                shape = RoundedCornerShape(14.dp),
-                contentScale = ContentScale.Fit,
-                backgroundBlur = WideCoverBackgroundBlur
-            )
+            Box(
+                modifier = Modifier
+                    .width(332.dp)
+                    .height(320.dp)
+            ) {
+                BookPoster(
+                    book = book,
+                    width = 332.dp,
+                    height = 320.dp,
+                    fillMaxWidth = true,
+                    shape = RoundedCornerShape(14.dp),
+                    contentScale = ContentScale.Fit,
+                    backgroundBlur = WideCoverBackgroundBlur
+                )
+                playerSeriesOrderLabel?.let { order ->
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.TopStart)
+                            .offset(x = (-4).dp, y = (-4).dp)
+                            .clip(RoundedCornerShape(6.dp))
+                            .background(MaterialTheme.colorScheme.surface)
+                            .padding(horizontal = 6.dp, vertical = 2.dp)
+                    ) {
+                        Text(
+                            text = "#$order",
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
+            }
         }
-        Spacer(modifier = Modifier.height(30.dp))
+        Spacer(modifier = Modifier.height(44.dp))
         Box(
             modifier = Modifier.fillMaxWidth(),
             contentAlignment = Alignment.Center
@@ -2651,6 +2820,7 @@ fun PlayerPlaceholderScreen(
             Text(
                 text = playerTitle,
                 style = MaterialTheme.typography.titleLarge,
+                color = primaryTextColor,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
                 textAlign = TextAlign.Center,
@@ -2661,15 +2831,26 @@ fun PlayerPlaceholderScreen(
             Icon(
                 imageVector = Icons.Outlined.BookmarkBorder,
                 contentDescription = "Bookmark",
+                tint = secondaryTextColor,
                 modifier = Modifier.align(Alignment.CenterEnd)
             )
         }
-        Spacer(modifier = Modifier.height(30.dp))
-        LinearProgressIndicator(
-            progress = { progress },
-            modifier = Modifier.fillMaxWidth(),
-            color = MaterialTheme.colorScheme.onSurface,
-            trackColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
+        Spacer(modifier = Modifier.height(44.dp))
+        PlayerProgressBar(
+            progress = effectiveProgress,
+            activeColor = progressActiveColor,
+            trackColor = progressTrackColor,
+            onProgressChange = { newProgress ->
+                isScrubbing = true
+                scrubbingProgress = newProgress
+                viewModel.onScrubProgress(newProgress)
+            },
+            onProgressChangeFinished = { finalProgress ->
+                scrubbingProgress = finalProgress
+                viewModel.onScrubProgressFinished(finalProgress)
+                isScrubbing = false
+            },
+            modifier = Modifier.fillMaxWidth()
         )
         Spacer(modifier = Modifier.height(10.dp))
         val remainingSeconds = (durationSeconds - positionSeconds).coerceAtLeast(0.0)
@@ -2680,19 +2861,19 @@ fun PlayerPlaceholderScreen(
             Text(
                 text = formatSecondsAsHms(positionSeconds),
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = secondaryTextColor
             )
             Text(
                 text = "${formatDurationHoursMinutes(remainingSeconds)} left · ${(progress * 100).toInt()}% complete",
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = secondaryTextColor,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.weight(1f)
             )
             Text(
                 text = "-${formatSecondsAsHms(remainingSeconds)}",
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = secondaryTextColor
             )
         }
         playerInfoMessage?.let { message ->
@@ -2700,7 +2881,7 @@ fun PlayerPlaceholderScreen(
             Text(
                 text = message,
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = secondaryTextColor,
                 modifier = Modifier.fillMaxWidth(),
                 textAlign = TextAlign.Center
             )
@@ -2720,23 +2901,27 @@ fun PlayerPlaceholderScreen(
             ) {
                 Seek15Button(
                     forward = false,
+                    tint = primaryTextColor,
                     onClick = viewModel::onRewindClick
                 )
                 Box(
                     modifier = Modifier
-                        .size(62.dp)
+                        .size(64.dp)
+                        .clip(CircleShape)
+                        .background(mainPlayButtonContainer)
                         .clickable(onClick = viewModel::onPlayPauseClick),
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(
                         imageVector = if (playbackUiState.isPlaying) Icons.Outlined.Pause else Icons.Outlined.PlayArrow,
                         contentDescription = if (playbackUiState.isPlaying) "Pause" else "Play",
-                        tint = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.size(48.dp)
+                        tint = mainPlayButtonIconTint,
+                        modifier = Modifier.size(36.dp)
                     )
                 }
                 Seek15Button(
                     forward = true,
+                    tint = primaryTextColor,
                     onClick = viewModel::onForwardClick
                 )
             }
@@ -2745,55 +2930,267 @@ fun PlayerPlaceholderScreen(
             modifier = Modifier.fillMaxWidth()
         ) {
             Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 10.dp, bottom = 8.dp),
+                verticalAlignment = Alignment.Top,
+                horizontalArrangement = Arrangement.spacedBy(18.dp, Alignment.CenterHorizontally)
             ) {
-                Text(
-                    text = speedLabel,
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.clickable {
+                PlayerBottomToolItem(
+                    label = "Speed",
+                    valueText = speedLabel,
+                    primaryColor = primaryTextColor,
+                    secondaryColor = secondaryTextColor,
+                    onClick = {
                         speedIndex = (speedIndex + 1) % speeds.size
                         playerInfoMessage = "Speed set to ${speeds[speedIndex]}x."
                     }
                 )
-                Spacer(modifier = Modifier.weight(1f))
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(2.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    IconButton(onClick = { playerInfoMessage = "Sleep timer controls coming soon." }) {
-                        Icon(imageVector = Icons.Outlined.Timer, contentDescription = "Sleep Timer")
-                    }
-                    IconButton(onClick = { playerInfoMessage = "Output controls coming soon." }) {
-                        Icon(imageVector = Icons.Outlined.SettingsVoice, contentDescription = "Output")
-                    }
-                    Box {
-                        IconButton(onClick = { bottomMenuExpanded = true }) {
-                            Icon(imageVector = Icons.Outlined.MoreHoriz, contentDescription = "More")
-                        }
-                        DropdownMenu(
-                            expanded = bottomMenuExpanded,
-                            onDismissRequest = { bottomMenuExpanded = false }
-                        ) {
-                            DropdownMenuItem(
-                                text = { Text("Share") },
-                                onClick = {
-                                    playerInfoMessage = "Share coming soon."
-                                    bottomMenuExpanded = false
-                                }
-                            )
-                            DropdownMenuItem(
-                                text = { Text("Go to Book") },
-                                onClick = {
-                                    playerInfoMessage = "Already viewing this book."
-                                    bottomMenuExpanded = false
-                                }
-                            )
-                        }
+                PlayerBottomToolItem(
+                    label = "Timer",
+                    imageVector = Icons.Outlined.Timer,
+                    primaryColor = primaryTextColor,
+                    secondaryColor = secondaryTextColor,
+                    onClick = { playerInfoMessage = "Sleep timer controls coming soon." }
+                )
+                PlayerBottomToolItem(
+                    label = "History",
+                    imageVector = Icons.Outlined.Refresh,
+                    primaryColor = primaryTextColor,
+                    secondaryColor = secondaryTextColor,
+                    onClick = { playerInfoMessage = "History controls coming soon." }
+                )
+                PlayerBottomToolItem(
+                    label = "Download",
+                    imageVector = Icons.Outlined.Download,
+                    primaryColor = primaryTextColor,
+                    secondaryColor = secondaryTextColor,
+                    onClick = { playerInfoMessage = "Download controls coming soon." }
+                )
+                Box {
+                    PlayerBottomToolItem(
+                        label = "More",
+                        imageVector = Icons.Outlined.MoreHoriz,
+                        primaryColor = primaryTextColor,
+                        secondaryColor = secondaryTextColor,
+                        onClick = { bottomMenuExpanded = true }
+                    )
+                    DropdownMenu(
+                        expanded = bottomMenuExpanded,
+                        onDismissRequest = { bottomMenuExpanded = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("Share") },
+                            onClick = {
+                                playerInfoMessage = "Share coming soon."
+                                bottomMenuExpanded = false
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Go to Book") },
+                            onClick = {
+                                playerInfoMessage = "Already viewing this book."
+                                bottomMenuExpanded = false
+                            }
+                        )
                     }
                 }
             }
         }
+        }
+    }
+}
+
+@Composable
+private fun PlayerProgressBar(
+    progress: Float,
+    activeColor: Color,
+    trackColor: Color,
+    onProgressChange: (Float) -> Unit,
+    onProgressChangeFinished: (Float) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val clampedProgress = progress.coerceIn(0f, 1f)
+    val thumbSize = 11.dp
+    val barHeight = 5.dp
+    var widthPx by remember { mutableStateOf(0f) }
+    var dragProgress by remember { mutableStateOf(clampedProgress) }
+    var isDragging by remember { mutableStateOf(false) }
+
+    LaunchedEffect(clampedProgress, isDragging) {
+        if (!isDragging) {
+            dragProgress = clampedProgress
+        }
+    }
+
+    fun offsetToProgress(x: Float): Float {
+        if (widthPx <= 0f) return clampedProgress
+        return (x / widthPx).coerceIn(0f, 1f)
+    }
+
+    val draggableState = rememberDraggableState { delta ->
+        if (widthPx <= 0f) return@rememberDraggableState
+        isDragging = true
+        dragProgress = (dragProgress + (delta / widthPx)).coerceIn(0f, 1f)
+        onProgressChange(dragProgress)
+    }
+    val displayProgress = if (isDragging) dragProgress else clampedProgress
+
+    BoxWithConstraints(
+        modifier = modifier
+            .height(thumbSize)
+            .onSizeChanged { widthPx = it.width.toFloat() }
+            .pointerInput(widthPx, clampedProgress) {
+                detectTapGestures { offset ->
+                    val tappedProgress = offsetToProgress(offset.x)
+                    isDragging = false
+                    onProgressChange(tappedProgress)
+                    onProgressChangeFinished(tappedProgress)
+                }
+            }
+            .draggable(
+                state = draggableState,
+                orientation = androidx.compose.foundation.gestures.Orientation.Horizontal,
+                onDragStarted = { offset ->
+                    isDragging = true
+                    dragProgress = offsetToProgress(offset.x)
+                    onProgressChange(dragProgress)
+                },
+                onDragStopped = {
+                    onProgressChangeFinished(dragProgress)
+                    isDragging = false
+                }
+            )
+    ) {
+        val barShape = RoundedCornerShape(999.dp)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(barHeight)
+                .align(Alignment.CenterStart)
+                .clip(barShape)
+                .background(trackColor)
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(displayProgress)
+                .height(barHeight)
+                .align(Alignment.CenterStart)
+                .clip(barShape)
+                .background(activeColor)
+        )
+        val maxOffset = (maxWidth - thumbSize).coerceAtLeast(0.dp)
+        Box(
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .offset(x = maxOffset * displayProgress)
+                .size(thumbSize)
+                .clip(CircleShape)
+                .background(activeColor)
+        )
+    }
+}
+
+@Composable
+private fun PlayerBottomToolItem(
+    label: String,
+    imageVector: androidx.compose.ui.graphics.vector.ImageVector? = null,
+    valueText: String? = null,
+    primaryColor: Color = MaterialTheme.colorScheme.onSurface,
+    secondaryColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+    onClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .width(58.dp)
+            .clickable(onClick = onClick),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        if (!valueText.isNullOrBlank()) {
+            Text(
+                text = valueText,
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Medium),
+                color = primaryColor
+            )
+        } else if (imageVector != null) {
+            Icon(
+                imageVector = imageVector,
+                contentDescription = label,
+                tint = primaryColor,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = secondaryColor,
+            maxLines = 1
+        )
+    }
+}
+
+@Composable
+private fun Seek15Button(
+    forward: Boolean,
+    tint: Color = MaterialTheme.colorScheme.onSurface,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .size(56.dp)
+            .clip(CircleShape)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Canvas(
+            modifier = Modifier
+                .size(34.dp)
+                .graphicsLayer { scaleX = if (forward) 1f else -1f }
+        ) {
+            val strokeWidth = 2.6.dp.toPx()
+            val inset = 3.dp.toPx()
+            val arcSize = size.minDimension - inset * 2
+            drawArc(
+                color = tint,
+                startAngle = 20f,
+                sweepAngle = 250f,
+                useCenter = false,
+                topLeft = androidx.compose.ui.geometry.Offset(inset, inset),
+                size = androidx.compose.ui.geometry.Size(arcSize, arcSize),
+                style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
+            )
+
+            val radius = arcSize / 2f
+            val cx = size.width / 2f
+            val cy = size.height / 2f
+            val angle = Math.toRadians(270.0)
+            val x = cx + radius * cos(angle).toFloat()
+            val y = cy + radius * sin(angle).toFloat()
+            val head = 5.dp.toPx()
+            drawLine(
+                color = tint,
+                start = androidx.compose.ui.geometry.Offset(x, y),
+                end = androidx.compose.ui.geometry.Offset(x - head, y - head * 0.55f),
+                strokeWidth = strokeWidth,
+                cap = StrokeCap.Round
+            )
+            drawLine(
+                color = tint,
+                start = androidx.compose.ui.geometry.Offset(x, y),
+                end = androidx.compose.ui.geometry.Offset(x - head, y + head * 0.55f),
+                strokeWidth = strokeWidth,
+                cap = StrokeCap.Round
+            )
+        }
+        Text(
+            text = "15",
+            style = MaterialTheme.typography.labelSmall.copy(
+                fontSize = 11.sp,
+                fontWeight = FontWeight.SemiBold
+            ),
+            color = tint
+        )
     }
 }
 
@@ -2958,70 +3355,6 @@ private fun findActiveChapterIndex(
 }
 
 @Composable
-private fun Seek15Button(
-    forward: Boolean,
-    onClick: () -> Unit
-) {
-    val tint = MaterialTheme.colorScheme.onSurface
-    Box(
-        modifier = Modifier
-            .size(56.dp)
-            .clip(CircleShape)
-            .clickable(onClick = onClick),
-        contentAlignment = Alignment.Center
-    ) {
-        Canvas(
-            modifier = Modifier
-                .size(34.dp)
-                .graphicsLayer { scaleX = if (forward) 1f else -1f }
-        ) {
-            val strokeWidth = 2.6.dp.toPx()
-            val inset = 3.dp.toPx()
-            val arcSize = size.minDimension - inset * 2
-            drawArc(
-                color = tint,
-                startAngle = 20f,
-                sweepAngle = 250f,
-                useCenter = false,
-                topLeft = androidx.compose.ui.geometry.Offset(inset, inset),
-                size = androidx.compose.ui.geometry.Size(arcSize, arcSize),
-                style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
-            )
-
-            val radius = arcSize / 2f
-            val cx = size.width / 2f
-            val cy = size.height / 2f
-            val angle = Math.toRadians(270.0)
-            val x = cx + radius * cos(angle).toFloat()
-            val y = cy + radius * sin(angle).toFloat()
-            val head = 5.dp.toPx()
-            drawLine(
-                color = tint,
-                start = androidx.compose.ui.geometry.Offset(x, y),
-                end = androidx.compose.ui.geometry.Offset(x - head, y - head * 0.55f),
-                strokeWidth = strokeWidth,
-                cap = StrokeCap.Round
-            )
-            drawLine(
-                color = tint,
-                start = androidx.compose.ui.geometry.Offset(x, y),
-                end = androidx.compose.ui.geometry.Offset(x - head, y + head * 0.55f),
-                strokeWidth = strokeWidth,
-                cap = StrokeCap.Round
-            )
-        }
-        Text(
-            text = "15",
-            style = MaterialTheme.typography.labelSmall.copy(
-                fontSize = 11.sp,
-                fontWeight = FontWeight.SemiBold
-            ),
-            color = tint
-        )
-    }
-}
-
-@Composable
 private fun PlayerToolsCard(
     title: String,
     rows: List<String>
@@ -3075,6 +3408,7 @@ private fun DetailTabChip(
 @Composable
 fun CustomizePlaceholderScreen(
     onDone: () -> Unit,
+    onHomeClick: (() -> Unit)? = null,
     viewModel: CustomizeViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -3094,6 +3428,14 @@ fun CustomizePlaceholderScreen(
                 style = MaterialTheme.typography.headlineMedium,
                 modifier = Modifier.weight(1f)
             )
+            if (onHomeClick != null) {
+                CircleActionButton(
+                    icon = Icons.Outlined.Home,
+                    contentDescription = "Home",
+                    onClick = onHomeClick
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+            }
             CircleActionButton(
                 icon = Icons.Filled.Check,
                 contentDescription = "Done",
@@ -3223,6 +3565,7 @@ private fun EntityBrowseScreen(
     onRetry: () -> Unit,
     onEntityClick: ((com.stillshelf.app.core.model.NamedEntitySummary) -> Unit)? = null,
     onBackClick: (() -> Unit)? = null,
+    onHomeClick: (() -> Unit)? = null,
     showAvatar: Boolean = false
 ) {
     val refreshState = rememberPullRefreshState(
@@ -3237,7 +3580,8 @@ private fun EntityBrowseScreen(
     ) {
         BackTitle(
             title = title,
-            onBackClick = onBackClick
+            onBackClick = onBackClick,
+            onHomeClick = onHomeClick
         )
         Spacer(modifier = Modifier.height(10.dp))
 
@@ -3385,7 +3729,7 @@ private fun SeriesStackCard(
                 val depth = (layerCount - 2 - layer)
                 val xOffset = (frontOffsetX - ((depth + 1) * 4).dp).coerceAtLeast(0.dp)
                 val yOffset = (frontOffsetY - ((depth + 1) * 3).dp).coerceAtLeast(0.dp)
-                val alpha = 0.28f + (layer * 0.14f)
+                val alpha = 1f
                 FramedCoverImage(
                     coverUrl = book.coverUrl,
                     contentDescription = book.title,
@@ -3668,6 +4012,7 @@ private fun CircleActionButton(
 private fun BackTitle(
     title: String,
     onBackClick: (() -> Unit)?,
+    onHomeClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -3679,6 +4024,14 @@ private fun BackTitle(
                 icon = Icons.AutoMirrored.Outlined.ArrowBack,
                 contentDescription = "Back",
                 onClick = onBackClick
+            )
+            Spacer(modifier = Modifier.width(BackTitleSpacing))
+        }
+        if (onHomeClick != null) {
+            CircleActionButton(
+                icon = Icons.Outlined.Home,
+                contentDescription = "Home",
+                onClick = onHomeClick
             )
             Spacer(modifier = Modifier.width(BackTitleSpacing))
         }
@@ -3761,6 +4114,28 @@ private fun parsePublishedYear(raw: String?): Int {
     raw ?: return Int.MIN_VALUE
     val fourDigits = raw.trim().take(4)
     return fourDigits.toIntOrNull() ?: Int.MIN_VALUE
+}
+
+private fun formatSeriesOrderLabel(seriesSequence: Double?): String? {
+    val sequence = seriesSequence?.takeIf { it > 0.0 } ?: return null
+    return if (sequence % 1.0 == 0.0) {
+        sequence.toInt().toString()
+    } else {
+        sequence.toString()
+    }
+}
+
+private fun extractSeriesOrderLabelFromText(text: String?): String? {
+    if (text.isNullOrBlank()) return null
+    val bookMatch = Regex("(?i)\\bbook\\s*(\\d+(?:\\.\\d+)?)\\b").find(text)
+    if (bookMatch != null) return bookMatch.groupValues.getOrNull(1)
+    val hashMatch = Regex("#(\\d+(?:\\.\\d+)?)").find(text)
+    return hashMatch?.groupValues?.getOrNull(1)
+}
+
+private fun resolveSeriesOrderLabel(seriesSequence: Double?, vararg textCandidates: String?): String? {
+    formatSeriesOrderLabel(seriesSequence)?.let { return it }
+    return textCandidates.firstNotNullOfOrNull { extractSeriesOrderLabelFromText(it) }
 }
 
 private fun splitAuthorNames(raw: String): List<String> {

--- a/app/src/main/java/com/stillshelf/app/ui/screens/PlayerViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/PlayerViewModel.kt
@@ -84,6 +84,14 @@ class PlayerViewModel @Inject constructor(
         playbackController.seekBy(deltaMs = 15_000L)
     }
 
+    fun onScrubProgress(progressFraction: Float) {
+        playbackController.seekToProgress(progressFraction = progressFraction, commit = false)
+    }
+
+    fun onScrubProgressFinished(progressFraction: Float) {
+        playbackController.seekToProgress(progressFraction = progressFraction, commit = true)
+    }
+
     fun onDismissPlayer() {
         playbackController.saveProgressSnapshot()
     }


### PR DESCRIPTION
## Summary
- wire a reusable top Home action across non-excluded screens and make it reliably return to Home
- persist Author screen layout/collapse settings and Series detail list/grid mode via SessionPreferences
- include the latest player/browse visual and interaction fixes from this branch
## Verification
- GRADLE_USER_HOME=/tmp/gradle ./gradlew :app:compileDebugKotlin --stacktrace
- GRADLE_USER_HOME=/tmp/gradle ./gradlew :app:testDebugUnitTest --stacktrace