### PR TITLE
Fix two blockers: paged collection/playlist filtering and empty library picker recovery

### DIFF
--- a/app/src/main/java/com/stillshelf/app/data/repo/SessionRepositoryImpl.kt
+++ b/app/src/main/java/com/stillshelf/app/data/repo/SessionRepositoryImpl.kt
@@ -62,6 +62,8 @@ class SessionRepositoryImpl @Inject constructor(
         private const val HOME_FEED_CACHE_MAX_AGE_MS: Long = 10 * 60 * 1000L
         private const val CONTENT_CACHE_MAX_AGE_MS: Long = 20 * 60 * 1000L
         private const val DETAIL_CACHE_MAX_AGE_MS: Long = 30 * 60 * 1000L
+        private const val FULL_LIBRARY_PAGE_SIZE: Int = 500
+        private const val MAX_FULL_LIBRARY_PAGES: Int = 1_000
     }
 
     private data class TimedCacheEntry<T>(
@@ -655,13 +657,7 @@ class SessionRepositoryImpl @Inject constructor(
             return AppResult.Success(emptyList())
         }
 
-        return when (
-            val booksResult = fetchBooksForActiveLibrary(
-                limit = 500,
-                page = 0,
-                forceRefresh = forceRefresh
-            )
-        ) {
+        return when (val booksResult = fetchAllBooksForActiveLibrary(forceRefresh = forceRefresh)) {
             is AppResult.Success -> {
                 val normalizedIds = bookIds
                     .map { it.trim() }
@@ -708,13 +704,7 @@ class SessionRepositoryImpl @Inject constructor(
             return AppResult.Success(emptyList())
         }
 
-        return when (
-            val booksResult = fetchBooksForActiveLibrary(
-                limit = 500,
-                page = 0,
-                forceRefresh = forceRefresh
-            )
-        ) {
+        return when (val booksResult = fetchAllBooksForActiveLibrary(forceRefresh = forceRefresh)) {
             is AppResult.Success -> {
                 val normalizedIds = bookIds
                     .map { it.trim() }
@@ -735,6 +725,37 @@ class SessionRepositoryImpl @Inject constructor(
             }
             is AppResult.Error -> booksResult
         }
+    }
+
+    private suspend fun fetchAllBooksForActiveLibrary(forceRefresh: Boolean): AppResult<List<BookSummary>> {
+        val booksById = LinkedHashMap<String, BookSummary>()
+        var page = 0
+        while (page < MAX_FULL_LIBRARY_PAGES) {
+            when (
+                val booksResult = fetchBooksForActiveLibrary(
+                    limit = FULL_LIBRARY_PAGE_SIZE,
+                    page = page,
+                    forceRefresh = forceRefresh
+                )
+            ) {
+                is AppResult.Error -> return booksResult
+                is AppResult.Success -> {
+                    val pageBooks = booksResult.value
+                    if (pageBooks.isEmpty()) {
+                        break
+                    }
+                    val beforeCount = booksById.size
+                    pageBooks.forEach { book ->
+                        booksById.putIfAbsent(book.id.trim(), book)
+                    }
+                    if (pageBooks.size < FULL_LIBRARY_PAGE_SIZE || booksById.size == beforeCount) {
+                        break
+                    }
+                    page += 1
+                }
+            }
+        }
+        return AppResult.Success(booksById.values.toList())
     }
 
     override suspend fun createCollection(name: String): AppResult<NamedEntitySummary> {

--- a/app/src/main/java/com/stillshelf/app/ui/navigation/AuthNavGraph.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/navigation/AuthNavGraph.kt
@@ -51,7 +51,10 @@ fun NavGraphBuilder.authNavGraph(
 
         composable(AuthRoute.LIBRARY_PICKER) {
             LibraryPickerRoute(
-                onLibrarySelected = onAuthCompleted
+                onLibrarySelected = onAuthCompleted,
+                onManageServers = {
+                    navController.popBackStack(AuthRoute.SERVERS, inclusive = false)
+                }
             )
         }
     }

--- a/app/src/main/java/com/stillshelf/app/ui/navigation/MainNavGraph.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/navigation/MainNavGraph.kt
@@ -368,6 +368,13 @@ private fun MainTabsNavHost(
                             launchSingleTop = true
                         }
                     }
+                },
+                onManageServers = {
+                    if (!navController.popBackStack(MainRoute.SERVERS, inclusive = false)) {
+                        navController.navigate(MainRoute.SERVERS) {
+                            launchSingleTop = true
+                        }
+                    }
                 }
             )
         }

--- a/app/src/main/java/com/stillshelf/app/ui/screens/auth/LibraryPickerScreen.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/auth/LibraryPickerScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.Button
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -39,6 +40,7 @@ import androidx.compose.foundation.layout.PaddingValues
 @Composable
 fun LibraryPickerRoute(
     onLibrarySelected: () -> Unit,
+    onManageServers: () -> Unit,
     viewModel: LibraryPickerViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -61,7 +63,8 @@ fun LibraryPickerRoute(
     LibraryPickerScreen(
         uiState = uiState,
         snackbarHostState = snackbarHostState,
-        onLibrarySelected = viewModel::onLibrarySelected
+        onLibrarySelected = viewModel::onLibrarySelected,
+        onManageServers = onManageServers
     )
 }
 
@@ -69,7 +72,8 @@ fun LibraryPickerRoute(
 private fun LibraryPickerScreen(
     uiState: LibraryPickerUiState,
     snackbarHostState: SnackbarHostState,
-    onLibrarySelected: (String) -> Unit
+    onLibrarySelected: (String) -> Unit,
+    onManageServers: () -> Unit
 ) {
     Scaffold(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
@@ -125,6 +129,13 @@ private fun LibraryPickerScreen(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(top = 6.dp)
                     )
+                    Button(
+                        onClick = onManageServers,
+                        modifier = Modifier
+                            .padding(top = 16.dp)
+                    ) {
+                        Text("Manage Servers")
+                    }
                 }
             } else {
                 val reachableLayout = uiState.libraries.size <= 3


### PR DESCRIPTION
Summary:
- Fetch all paged library books before filtering collection/playlist IDs so views are not truncated at 500 items.
- Add a Manage Servers recovery action on empty Library Picker.
- Wire onManageServers through auth and main nav graphs so users cannot get stuck.

Validation:
- ./gradlew :app:compileDebugKotlin --stacktrace