### PR TITLE
Fix auth navigation loop and Add Server back button behavior

### DIFF
--- a/COLLECTIONS_PLAYLISTS_GAP_WRITEUP.md
+++ b/COLLECTIONS_PLAYLISTS_GAP_WRITEUP.md
@@ -1,0 +1,115 @@
+# Collections/Playlists Flow Gap Write-Up
+
+## Purpose
+Document why "Add to Collection" is currently failing, what behavior we actually want, and what needs to be implemented to match the expected UX (based on the 9 reference screenshots from Still).
+
+## Current Problem Summary
+- Creating a collection from our app often fails with "Unable to create collection."
+- When adding a book to collection, our app auto-creates/uses a default collection (`StillShelf Collection`) instead of letting the user choose.
+- Users cannot reliably choose an existing collection before adding a book.
+- Playlist support is missing in this flow (user should be able to add to playlists too).
+- Result: user intent is ignored, and collection management feels broken/opaque.
+
+## What We Are Trying To Achieve
+From any book's 3-dot menu, tapping `Add to Collection` should open a picker sheet/dialog that allows:
+- Add book to an existing collection (if any exist).
+- Create a new collection and add this book to it immediately.
+- Add book to an existing playlist (if any exist).
+- Create a new playlist and add this book to it immediately.
+
+No silent auto-creation of a default collection should happen.
+
+## What We Are Getting Instead
+- App auto-routes add actions into a default collection (`StillShelf Collection`) without user selection.
+- Creating a collection from UI can fail and returns generic error.
+- User cannot reproduce Still-style workflow shown in screenshots.
+
+## Screenshot-Based Expected Behavior (9-step reference)
+- **1**: User taps `Add to Collection` from book menu.
+- **2**: Add sheet opens with editable row for creating a new collection.
+- **3**: Existing collection list is visible; user can pick one.
+- **4**: Playlist section mirrors collection behavior (new + existing).
+- **5**: Collections tab then shows created collection cards.
+- **6**: Opening a collection shows collection header + contained books.
+- **7**: Collection detail supports grid/list layout toggle.
+- **8**: Collection detail supports delete action.
+- **9**: Inside collection item menu, user can remove book from collection and run other actions.
+
+## Functional Gap Analysis
+- Missing explicit "choose destination" flow for collection/playlist add.
+- Incorrect fallback behavior (forced default collection) masks backend failures and user intent.
+- Collection create endpoint usage appears incompatible for some ABS server states (possible "must include at least one item" rule, depending on ABS version/config).
+- Playlist create/add flow is not wired in the same unified picker.
+
+## Required Implementation Changes
+
+### 1) Replace Default-Collection Shortcut
+- Stop calling "add to default collection" from book menus.
+- Route all add actions through a unified `AddToList` sheet/dialog.
+
+### 2) Unified Add Sheet (Collection + Playlist)
+- Show two sections:
+  - `Collections`
+  - `Playlists`
+- In each section:
+  - `+ New ...` row
+  - existing items list with counts
+- Selecting an existing item adds the current book immediately.
+
+### 3) Create-Then-Add Behavior
+- For new collection/playlist:
+  - create target
+  - add current book to the newly created target in same transaction flow
+- If create-only API fails but create-with-book API exists/works, use create-with-book path.
+
+### 4) Server Compatibility Strategy (ABS Variants)
+- Handle both cases:
+  - server allows empty collection creation
+  - server requires first book during creation
+- Fallback order:
+  1. try create empty
+  2. if rejected with known validation error, retry create-with-book
+
+### 5) UI Feedback and State Updates
+- Success: toast/snackbar with specific action result:
+  - `Added to "<collection name>"`
+  - `Created "<collection name>" and added book`
+- Failure: preserve actionable error text (no generic-only message).
+- Optimistically update relevant screens:
+  - Collections list
+  - Collection detail
+  - Book menu state if needed
+
+### 6) Collection Detail Actions
+- Keep per-collection page with:
+  - grid/list toggle
+  - delete collection
+  - book item menu including `Remove from Collection`
+
+### 7) Playlist Parity
+- Apply same UX structure and create/add behavior to playlists.
+
+## Acceptance Criteria
+- User can create a named collection from add sheet and the chosen book appears in it.
+- User can add to any existing collection from the same sheet.
+- No automatic forced use of `StillShelf Collection`.
+- User can create playlist + add same book in one flow.
+- Book can be removed from collection from collection detail screen.
+- Errors are specific and explain what failed (create vs add).
+
+## Suggested Technical Approach
+- Replace existing `addBookToDefaultCollection(bookId)` calls in UI with:
+  - open `CollectionPicker`/`AddToList` UI
+  - submit explicit target selection or new-name creation
+- Add/confirm repository methods:
+  - `createCollection(name)`
+  - `createCollectionWithBook(name, bookId)` (fallback)
+  - `addBookToCollection(collectionId, bookId)`
+  - equivalent playlist methods
+- Keep one source of truth in ViewModel state for:
+  - available collections/playlists
+  - create/add loading state
+  - last action result
+
+## Why This Matters
+Collections/playlists are organizational core features. If users cannot trust where a book is added, this breaks a primary reason to use the app over basic library browsing.

--- a/PLAN_TODO_CHECKLIST.md
+++ b/PLAN_TODO_CHECKLIST.md
@@ -1,0 +1,68 @@
+# StillShelf Plan TODO Checklist
+
+Source: `/home/kalzi/Desktop/audiobooks app plan`
+
+## Residual Risk / Testing Gap
+- [ ] Add UI/instrumentation tests for Home-button navigation and saved view-mode restore.
+
+## Major Functional Issue
+- [x] Fix add-to-collection so it actually adds books.
+
+## Current Batch TODO
+- [x] In Settings > Lock Screen Controls, remove right chevrons from `Next/Previous` and `Skip Forward/Back`.
+- [x] In Settings > Lock Screen Controls, show only checkmark for selected option and nothing for unselected option.
+- [x] In Settings > Skip Buttons, add selectable durations for both forward/backward: `10`, `15`, `30`, `45`, `60` seconds.
+- [x] Wire selected skip durations into actual player behavior (mini player + fullscreen player).
+- [x] Verify all 3-dot UI options persist across screen exits/re-entry, not only in Books.
+- [ ] Keep Home button in its own circle next to mini player and ensure spacing/sizing is consistent. Make mini player narrower and decrease its hight and its text to work with the new home button
+- [x] Auto-advance to next chapter when current chapter ends (do not stop playback).
+- [x] In Chapters tab, show correct per-chapter times.
+- [x] In fullscreen player, show progress/time metadata for the current chapter, not mismatched values.
+- [x] Preserve last selected book tab (`About`/`Chapters`/`Bookmarks`) when opening/minimizing fullscreen player.
+- [x] Implement Books/Series/Discover 3-dot menu actions: `Add to collection`, `Mark as finished`, `Download`/`Remove download`.
+- [x] Implement Home > Continue Listening 3-dot menu actions: `Go to book`, `Add to collection`, `Mark as finished`, `Remove from Continue Listening`, `Download`/`Remove download`.
+- [x] Implement Home > Recently Added 3-dot menu actions: `Add to collection`, `Mark as unfinished`, `Download`/`Remove download`.
+- [x] Show more entries in Home > Recent Series.
+- [x] Make Home > Recent Series cover size/style match other home shelves.
+- [x] Make the player show on the phone's lockscreen and wherever else the phone shows playing things. Like on my oneplus 12, whatever I play, a song or a video, the player and its controls will show in the lockscreen so I can control things while the phone is locked, and it also shows the player in the drop down notification area (when you swipe down from the top of the phone screen and get that android notification menu if you you know what I am talking about), this will be phone dependent (I think) because different android phones do different things with whatever is playing (figure that out)
+
+## Hotfix Batch (Current)
+- [ ] Collections list entries open to a collection-books detail screen so added books are visible in-app. `Reported still inconsistent.`
+- [x] Downloaded tab renders downloaded books from saved download state without disappearing/requiring re-entry. `Rewired to DownloadManager-backed state + completed-file validation.`
+- [x] Series detail single-book 3-dot menu shows `Add to collection`, `Mark as finished`, and `Download`/`Remove download` on every item. `Also respects active in-progress downloads for label state.`
+- [x] Download state labels/menu + Downloaded tab visibility stay in sync across all surfaces. `Completed-only = downloaded; in-progress = progress state.`
+- [x] Series detail ordering maps correctly (`#1 -> first item`) and does not invert on some series. `Removed misleading chapter-title sequence inference.`
+- [x] Media notification/lockscreen metadata now publishes large artwork for current book (when cover is available). `Pixel confirmed; OnePlus lockscreen behavior appears OEM-limited.`
+
+## New Device-Test Regressions
+- [ ] Fix cold-start Books placeholders that stay blank until leaving/re-entering tab.
+- [ ] Remove page-entry hitch on book-heavy screens (Books, series details, similar routes).
+- [ ] Keep mini player floating style consistent on all screens (no extra background layer behind it).
+- [ ] Keep mini player fully above system nav bar on all screens/devices.
+- [ ] Align fullscreen player bottom action row consistently (Speed/Timer/History/Download/More baseline and spacing).
+
+## Latest Requests Batch
+- [x] Implement real offline download (actual file download) so downloaded books remain available without Wi‑Fi/cellular. `Playback now prefers completed local file if present.`
+- [x] Add visible per-book download progress indicator (queued/downloading/completed). `Extended to Home shelves + Books/Series stack cards + Book detail/Series detail cards.`
+- [x] Replace ambiguous download icon state with explicit circular downloader UI on each book:
+  - [x] When download starts, show a clearly visible circle on the book cover/card.
+  - [x] Show real progress as a ring around the circle + numeric `%` in the center.
+  - [x] When download completes, replace progress circle with downloaded-state down-arrow icon.
+  - [x] On remove download, delete local file(s), remove downloaded-state icon, and ensure offline play no longer works for that removed book.
+  - [x] Verify tapping `Start/Continue Listening` on a downloaded book opens and plays that exact book offline (no network required, no fallback to currently-loaded book). `Implemented in controller; device validation pending.`
+- [x] Clarify and improve `Mark as finished` behavior (clear user feedback and expected state change). `Success feedback now explicitly states 100% completion / reset.`
+- [ ] Redesign Collections flow: user-created collections + picker when adding books + create/rename/delete management. `In progress: create/rename/delete + collection-item removal implemented; ABS no-books fallback now seeds create-from-book then removes seed item; add-to-collection picker still pending.`
+- [x] Make 3-dot actions in Collections tab functional (not just opening book page). `Browse now has rename/delete actions; collection detail has remove-from-collection action.`
+- [x] Clarify/implement `Skip intro & outro` behavior in 3-dot menus. `Now explicitly labeled as coming soon and no longer ambiguous.`
+- [x] Fix fullscreen player progress-time row jitter/rocking during ticking updates. `Stabilized with weighted layout + monospace side timers.`
+- [x] Add List/Grid toggle on Series main page (browse list of series).
+- [x] Disable landscape mode app-wide.
+- [x] Fix Search field position so it does not sit behind Android navigation bar.
+
+## Data / Performance
+- [x] Investigate and reduce excessive refreshes/server hits on content pages. `Done: longer repository cache age + removed automatic background home refetch when fresh cache is available.`
+- [x] Implement stronger caching + sync strategy so pages open from cache first, then refresh intelligently. `Done: cache-first path kept, user-initiated pull refresh remains force-refresh path.`
+
+## Notes
+- The mini-player + home-button experiment should be done in its own branch.
+- Keep this checklist as the running tracker; check items off as they are completed.

--- a/app/src/main/java/com/stillshelf/app/core/datastore/SecureTokenStorage.kt
+++ b/app/src/main/java/com/stillshelf/app/core/datastore/SecureTokenStorage.kt
@@ -2,9 +2,11 @@ package com.stillshelf.app.core.datastore
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.security.KeyStore
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
@@ -14,10 +16,48 @@ import kotlinx.coroutines.withContext
 class SecureTokenStorage @Inject constructor(
     @param:ApplicationContext private val context: Context
 ) {
-    private val sharedPreferences: SharedPreferences by lazy {
-        val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+    @Volatile
+    private var sharedPreferences: SharedPreferences? = null
+    private val sharedPreferencesLock = Any()
 
-        EncryptedSharedPreferences.create(
+    private fun getSharedPreferences(): SharedPreferences {
+        sharedPreferences?.let { return it }
+        return synchronized(sharedPreferencesLock) {
+            sharedPreferences?.let { return@synchronized it }
+
+            val initialized = initializeEncryptedPreferences()
+            sharedPreferences = initialized
+            initialized
+        }
+    }
+
+    private fun initializeEncryptedPreferences(): SharedPreferences {
+        val masterKeyAlias = runCatching {
+            MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+        }.getOrElse { throwable ->
+            Log.e(TAG, "Unable to obtain master key alias. Falling back to local token prefs.", throwable)
+            return context.getSharedPreferences(FALLBACK_TOKENS_FILE, Context.MODE_PRIVATE)
+        }
+
+        return runCatching {
+            createEncryptedPreferences(masterKeyAlias)
+        }.recoverCatching { firstError ->
+            Log.w(TAG, "Encrypted token prefs failed. Clearing token prefs and retrying once.", firstError)
+            clearEncryptedPreferencesFile()
+            createEncryptedPreferences(masterKeyAlias)
+        }.recoverCatching { secondError ->
+            Log.w(TAG, "Encrypted token prefs still failing. Resetting master key and retrying.", secondError)
+            runCatching { deleteMasterKey(masterKeyAlias) }
+            clearEncryptedPreferencesFile()
+            createEncryptedPreferences(masterKeyAlias)
+        }.getOrElse { finalError ->
+            Log.e(TAG, "Unable to initialize encrypted token prefs. Using local fallback prefs.", finalError)
+            context.getSharedPreferences(FALLBACK_TOKENS_FILE, Context.MODE_PRIVATE)
+        }
+    }
+
+    private fun createEncryptedPreferences(masterKeyAlias: String): SharedPreferences {
+        return EncryptedSharedPreferences.create(
             TOKENS_FILE,
             masterKeyAlias,
             context,
@@ -26,21 +66,34 @@ class SecureTokenStorage @Inject constructor(
         )
     }
 
+    private fun clearEncryptedPreferencesFile() {
+        runCatching {
+            context.deleteSharedPreferences(TOKENS_FILE)
+        }
+    }
+
+    private fun deleteMasterKey(alias: String) {
+        val keyStore = KeyStore.getInstance(ANDROID_KEY_STORE).apply { load(null) }
+        if (keyStore.containsAlias(alias)) {
+            keyStore.deleteEntry(alias)
+        }
+    }
+
     suspend fun saveToken(serverId: String, token: String) {
         withContext(Dispatchers.IO) {
-            sharedPreferences.edit()
+            getSharedPreferences().edit()
                 .putString(tokenKey(serverId), token)
                 .apply()
         }
     }
 
     suspend fun getToken(serverId: String): String? = withContext(Dispatchers.IO) {
-        sharedPreferences.getString(tokenKey(serverId), null)
+        getSharedPreferences().getString(tokenKey(serverId), null)
     }
 
     suspend fun clearToken(serverId: String) {
         withContext(Dispatchers.IO) {
-            sharedPreferences.edit()
+            getSharedPreferences().edit()
                 .remove(tokenKey(serverId))
                 .apply()
         }
@@ -49,6 +102,9 @@ class SecureTokenStorage @Inject constructor(
     private fun tokenKey(serverId: String): String = "token_$serverId"
 
     private companion object {
+        const val TAG = "SecureTokenStorage"
+        const val ANDROID_KEY_STORE = "AndroidKeyStore"
         const val TOKENS_FILE = "secure_tokens"
+        const val FALLBACK_TOKENS_FILE = "secure_tokens_fallback"
     }
 }

--- a/app/src/main/java/com/stillshelf/app/data/repo/SessionRepositoryImpl.kt
+++ b/app/src/main/java/com/stillshelf/app/data/repo/SessionRepositoryImpl.kt
@@ -2023,9 +2023,17 @@ class SessionRepositoryImpl @Inject constructor(
         val activeServerId = session.activeServerId
             ?: return AppResult.Error("No active server selected.")
         val server = serverDao.getById(activeServerId)
-            ?: return AppResult.Error("Active server not found.")
+            ?: run {
+                sessionPreferences.setActiveLibraryId(null)
+                sessionPreferences.setActiveServerId(null)
+                return AppResult.Error("Active server not found.")
+            }
         val token = secureTokenStorage.getToken(server.id)
-            ?: return AppResult.Error("No saved session for this server. Please log in again.")
+            ?: run {
+                sessionPreferences.setActiveLibraryId(null)
+                sessionPreferences.setActiveServerId(null)
+                return AppResult.Error("No saved session for this server. Please log in again.")
+            }
 
         if (!requireLibrary) {
             return AppResult.Success(
@@ -2040,8 +2048,12 @@ class SessionRepositoryImpl @Inject constructor(
         val activeLibraryId = session.activeLibraryId
             ?: return AppResult.Error("No active library selected.")
         val library = libraryDao.getById(activeLibraryId)
-            ?: return AppResult.Error("Active library not found.")
+            ?: run {
+                sessionPreferences.setActiveLibraryId(null)
+                return AppResult.Error("Active library not found.")
+            }
         if (library.serverId != server.id) {
+            sessionPreferences.setActiveLibraryId(null)
             return AppResult.Error("Active library does not belong to the active server.")
         }
 

--- a/app/src/main/java/com/stillshelf/app/ui/navigation/AuthNavGraph.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/navigation/AuthNavGraph.kt
@@ -23,16 +23,21 @@ fun NavGraphBuilder.authNavGraph(
         composable(AuthRoute.SERVERS) {
             ServersRoute(
                 onAddServer = { navController.navigate(AuthRoute.ADD_SERVER) },
-                onServerSelected = { navController.navigate(AuthRoute.LIBRARY_PICKER) }
+                onServerSelected = { navController.navigate(AuthRoute.LIBRARY_PICKER) },
+                onReauthenticate = { serverName, baseUrl ->
+                    navController.navigate(AuthRoute.loginRoute(serverName, baseUrl))
+                }
             )
         }
 
         composable(AuthRoute.ADD_SERVER) {
+            val canNavigateBack = navController.previousBackStackEntry != null
             AddServerRoute(
                 onContinue = { serverName, baseUrl ->
                     navController.navigate(AuthRoute.loginRoute(serverName, baseUrl))
                 },
-                onBack = { navController.popBackStack() }
+                onBack = { navController.popBackStack() },
+                showBackButton = canNavigateBack
             )
         }
 
@@ -53,7 +58,11 @@ fun NavGraphBuilder.authNavGraph(
             LibraryPickerRoute(
                 onLibrarySelected = onAuthCompleted,
                 onManageServers = {
-                    navController.popBackStack(AuthRoute.SERVERS, inclusive = false)
+                    if (!navController.popBackStack(AuthRoute.SERVERS, inclusive = false)) {
+                        navController.navigate(AuthRoute.ADD_SERVER) {
+                            launchSingleTop = true
+                        }
+                    }
                 }
             )
         }

--- a/app/src/main/java/com/stillshelf/app/ui/navigation/MainNavGraph.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/navigation/MainNavGraph.kt
@@ -335,13 +335,15 @@ private fun MainTabsNavHost(
             )
         }
         composable(AuthRoute.ADD_SERVER) {
+            val canNavigateBack = navController.previousBackStackEntry != null
             AddServerRoute(
                 onContinue = { serverName, baseUrl ->
                     navController.navigate(AuthRoute.loginRoute(serverName, baseUrl)) {
                         launchSingleTop = true
                     }
                 },
-                onBack = { navController.popBackStack() }
+                onBack = { navController.popBackStack() },
+                showBackButton = canNavigateBack
             )
         }
         composable(

--- a/app/src/main/java/com/stillshelf/app/ui/navigation/RootNavGraph.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/navigation/RootNavGraph.kt
@@ -39,7 +39,7 @@ fun RootNavGraph(
         AuthRoute.ADD_SERVER
     }
 
-    key(startGraph, authStartDestination) {
+    key(startGraph) {
         NavHost(
             navController = navController,
             startDestination = startGraph,

--- a/app/src/main/java/com/stillshelf/app/ui/navigation/RootViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/navigation/RootViewModel.kt
@@ -7,7 +7,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 
 @HiltViewModel
@@ -15,14 +15,27 @@ class RootViewModel @Inject constructor(
     sessionRepository: SessionRepository
 ) : ViewModel() {
 
-    val uiState: StateFlow<RootUiState> = sessionRepository.observeSessionState()
-        .map { session ->
-            RootUiState(
-                isLoading = false,
-                hasActiveServer = !session.activeServerId.isNullOrBlank(),
-                hasActiveLibrary = !session.activeLibraryId.isNullOrBlank()
-            )
-        }
+    val uiState: StateFlow<RootUiState> = combine(
+        sessionRepository.observeSessionState(),
+        sessionRepository.observeServers(),
+        sessionRepository.observeLibrariesForActiveServer()
+    ) { session, servers, libraries ->
+        val activeServerId = session.activeServerId
+        val activeLibraryId = session.activeLibraryId
+        val hasAnyServer = servers.isNotEmpty()
+        val hasActiveServer = !activeServerId.isNullOrBlank() &&
+            servers.any { it.id == activeServerId }
+        val hasActiveLibrary = hasActiveServer &&
+            !activeLibraryId.isNullOrBlank() &&
+            libraries.any { it.id == activeLibraryId }
+
+        RootUiState(
+            isLoading = false,
+            hasAnyServer = hasAnyServer,
+            hasActiveServer = hasActiveServer,
+            hasActiveLibrary = hasActiveLibrary
+        )
+    }
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5_000),
@@ -32,6 +45,7 @@ class RootViewModel @Inject constructor(
 
 data class RootUiState(
     val isLoading: Boolean = true,
+    val hasAnyServer: Boolean = false,
     val hasActiveServer: Boolean = false,
     val hasActiveLibrary: Boolean = false
 )

--- a/app/src/main/java/com/stillshelf/app/ui/screens/auth/AddServerScreen.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/auth/AddServerScreen.kt
@@ -38,6 +38,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 fun AddServerRoute(
     onContinue: (serverName: String, baseUrl: String) -> Unit,
     onBack: () -> Unit,
+    showBackButton: Boolean = true,
     viewModel: AddServerViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -48,7 +49,8 @@ fun AddServerRoute(
         onBaseUrlChange = viewModel::onBaseUrlChange,
         onTestConnection = viewModel::onTestConnectionClick,
         onContinue = onContinue,
-        onBack = onBack
+        onBack = onBack,
+        showBackButton = showBackButton
     )
 }
 
@@ -59,7 +61,8 @@ private fun AddServerScreen(
     onBaseUrlChange: (String) -> Unit,
     onTestConnection: () -> Unit,
     onContinue: (serverName: String, baseUrl: String) -> Unit,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    showBackButton: Boolean
 ) {
     var showInsecureHttpWarning by remember { mutableStateOf(false) }
     val trimmedBaseUrl = uiState.baseUrl.trim()
@@ -163,11 +166,13 @@ private fun AddServerScreen(
                     )
                 }
 
-                Button(
-                    onClick = onBack,
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text("Back")
+                if (showBackButton) {
+                    Button(
+                        onClick = onBack,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("Back")
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/stillshelf/app/ui/screens/auth/LibraryPickerScreen.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/auth/LibraryPickerScreen.kt
@@ -48,8 +48,9 @@ fun LibraryPickerRoute(
 
     LaunchedEffect(viewModel) {
         viewModel.events.collect { event ->
-            if (event is LibraryPickerEvent.NavigateToMain) {
-                onLibrarySelected()
+            when (event) {
+                LibraryPickerEvent.NavigateToMain -> onLibrarySelected()
+                LibraryPickerEvent.NavigateToManageServers -> onManageServers()
             }
         }
     }

--- a/app/src/main/java/com/stillshelf/app/ui/screens/auth/LibraryPickerViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/auth/LibraryPickerViewModel.kt
@@ -39,10 +39,20 @@ class LibraryPickerViewModel @Inject constructor(
                     }
                 ) {
                     is AppResult.Success -> errorState.value = null
-                    is AppResult.Error -> errorState.value = result.message
+                    is AppResult.Error -> {
+                        val message = result.message
+                        errorState.value = message
+                        if (isUnrecoverableLibraryPickerState(message)) {
+                            mutableEvents.emit(LibraryPickerEvent.NavigateToManageServers)
+                        }
+                    }
                 }
             } catch (t: Throwable) {
-                errorState.value = t.message ?: "Unable to load libraries for this server."
+                val message = t.message ?: "Unable to load libraries for this server."
+                errorState.value = message
+                if (isUnrecoverableLibraryPickerState(message)) {
+                    mutableEvents.emit(LibraryPickerEvent.NavigateToManageServers)
+                }
             } finally {
                 loadingState.value = false
             }
@@ -85,6 +95,13 @@ class LibraryPickerViewModel @Inject constructor(
     fun clearError() {
         errorState.value = null
     }
+
+    private fun isUnrecoverableLibraryPickerState(message: String?): Boolean {
+        val normalized = message?.lowercase().orEmpty()
+        return normalized.contains("active server not found") ||
+            normalized.contains("no active server selected") ||
+            normalized.contains("no saved session")
+    }
 }
 
 data class LibraryPickerUiState(
@@ -96,4 +113,5 @@ data class LibraryPickerUiState(
 
 sealed interface LibraryPickerEvent {
     data object NavigateToMain : LibraryPickerEvent
+    data object NavigateToManageServers : LibraryPickerEvent
 }

--- a/app/src/main/java/com/stillshelf/app/ui/screens/auth/ServersScreen.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/auth/ServersScreen.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 fun ServersRoute(
     onAddServer: () -> Unit,
     onServerSelected: () -> Unit,
+    onReauthenticate: (serverName: String, baseUrl: String) -> Unit,
     viewModel: ServersViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -36,8 +37,9 @@ fun ServersRoute(
 
     LaunchedEffect(viewModel) {
         viewModel.events.collect { event ->
-            if (event is ServersEvent.NavigateToLibraryPicker) {
-                onServerSelected()
+            when (event) {
+                ServersEvent.NavigateToLibraryPicker -> onServerSelected()
+                is ServersEvent.NavigateToLogin -> onReauthenticate(event.serverName, event.baseUrl)
             }
         }
     }

--- a/app/src/main/java/com/stillshelf/app/ui/screens/auth/ServersViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/auth/ServersViewModel.kt
@@ -44,6 +44,7 @@ class ServersViewModel @Inject constructor(
 
     fun onServerSelected(serverId: String) {
         viewModelScope.launch {
+            val selectedServer = uiState.value.servers.firstOrNull { it.id == serverId }
             when (val result = sessionRepository.setActiveServer(serverId)) {
                 is AppResult.Success -> {
                     errorState.value = null
@@ -51,7 +52,18 @@ class ServersViewModel @Inject constructor(
                 }
 
                 is AppResult.Error -> {
-                    errorState.value = result.message
+                    val requiresReauth = result.message.contains("no saved session", ignoreCase = true)
+                    if (requiresReauth && selectedServer != null) {
+                        errorState.value = null
+                        mutableEvents.emit(
+                            ServersEvent.NavigateToLogin(
+                                serverName = selectedServer.name,
+                                baseUrl = selectedServer.baseUrl
+                            )
+                        )
+                    } else {
+                        errorState.value = result.message
+                    }
                 }
             }
         }
@@ -70,4 +82,8 @@ data class ServersUiState(
 
 sealed interface ServersEvent {
     data object NavigateToLibraryPicker : ServersEvent
+    data class NavigateToLogin(
+        val serverName: String,
+        val baseUrl: String
+    ) : ServersEvent
 }


### PR DESCRIPTION
## Summary
- fix auth graph/root graph transitions that could loop between add-server, login, and server screens
- ensure logout/unauthenticated flow starts at Add Server with stable navigation state
- hide the Add Server back button when there is no previous back stack entry
- include related auth/session cleanup updates currently in branch

## Validation
- ./gradlew :app:compileDebugKotlin --no-daemon --stacktrace --console=plain