### PR TITLE
Fix playback service stop churn and auth re-login loop

### DIFF
--- a/app/src/main/java/com/stillshelf/app/playback/notification/PlaybackForegroundService.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/notification/PlaybackForegroundService.kt
@@ -33,10 +33,8 @@ class PlaybackForegroundService : Service() {
         }
 
         fun stop(context: Context) {
-            val intent = Intent(context, PlaybackForegroundService::class.java).apply {
-                action = ACTION_STOP
-            }
-            context.startService(intent)
+            latestNotification = null
+            context.stopService(Intent(context, PlaybackForegroundService::class.java))
         }
     }
 

--- a/app/src/main/java/com/stillshelf/app/ui/navigation/AuthNavGraph.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/navigation/AuthNavGraph.kt
@@ -14,6 +14,7 @@ import com.stillshelf.app.ui.screens.auth.ServersRoute
 fun NavGraphBuilder.authNavGraph(
     navController: NavHostController,
     startDestination: String,
+    hasAnyServer: Boolean,
     onAuthCompleted: () -> Unit
 ) {
     navigation(
@@ -59,7 +60,12 @@ fun NavGraphBuilder.authNavGraph(
                 onLibrarySelected = onAuthCompleted,
                 onManageServers = {
                     if (!navController.popBackStack(AuthRoute.SERVERS, inclusive = false)) {
-                        navController.navigate(AuthRoute.ADD_SERVER) {
+                        val fallbackRoute = if (hasAnyServer) {
+                            AuthRoute.SERVERS
+                        } else {
+                            AuthRoute.ADD_SERVER
+                        }
+                        navController.navigate(fallbackRoute) {
                             launchSingleTop = true
                         }
                     }

--- a/app/src/main/java/com/stillshelf/app/ui/navigation/RootNavGraph.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/navigation/RootNavGraph.kt
@@ -71,6 +71,7 @@ fun RootNavGraph(
             authNavGraph(
                 navController = navController,
                 startDestination = authStartDestination,
+                hasAnyServer = uiState.hasAnyServer,
                 onAuthCompleted = {
                     navController.navigate(GraphRoute.MAIN) {
                         popUpTo(GraphRoute.AUTH) { inclusive = true }

--- a/app/src/main/java/com/stillshelf/app/ui/screens/auth/LibraryPickerViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/auth/LibraryPickerViewModel.kt
@@ -7,6 +7,7 @@ import com.stillshelf.app.core.util.AppResult
 import com.stillshelf.app.data.repo.SessionRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -31,13 +32,7 @@ class LibraryPickerViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 loadingState.value = true
-                when (
-                    val result = runCatching {
-                        sessionRepository.refreshLibrariesForActiveServer()
-                    }.getOrElse {
-                        AppResult.Error("Unable to load libraries for this server.", it)
-                    }
-                ) {
+                when (val result = refreshLibrariesForActiveServerWithRetry()) {
                     is AppResult.Success -> errorState.value = null
                     is AppResult.Error -> {
                         val message = result.message
@@ -57,6 +52,28 @@ class LibraryPickerViewModel @Inject constructor(
                 loadingState.value = false
             }
         }
+    }
+
+    private suspend fun refreshLibrariesForActiveServerWithRetry(): AppResult<Unit> {
+        repeat(3) { attempt ->
+            val result = runCatching {
+                sessionRepository.refreshLibrariesForActiveServer()
+            }.getOrElse {
+                AppResult.Error("Unable to load libraries for this server.", it)
+            }
+
+            if (result is AppResult.Success) {
+                return result
+            }
+
+            val isLastAttempt = attempt == 2
+            if (isLastAttempt || !isTransientPostLoginState((result as AppResult.Error).message)) {
+                return result
+            }
+
+            delay(250)
+        }
+        return AppResult.Error("Unable to load libraries for this server.")
     }
 
     val uiState: StateFlow<LibraryPickerUiState> = combine(
@@ -98,9 +115,13 @@ class LibraryPickerViewModel @Inject constructor(
 
     private fun isUnrecoverableLibraryPickerState(message: String?): Boolean {
         val normalized = message?.lowercase().orEmpty()
+        return normalized.contains("no saved session")
+    }
+
+    private fun isTransientPostLoginState(message: String?): Boolean {
+        val normalized = message?.lowercase().orEmpty()
         return normalized.contains("active server not found") ||
-            normalized.contains("no active server selected") ||
-            normalized.contains("no saved session")
+            normalized.contains("no active server selected")
     }
 }
 


### PR DESCRIPTION
Summary:
- stop foreground playback service via stopService to avoid bootstrapping service on stop
- fix library picker manage-servers fallback behavior with server-aware route
- pass hasAnyServer into auth graph from root nav
- add transient retry in library picker refresh to prevent first-login bounce requiring duplicate server add

Validation:
- ./gradlew :app:compileDebugKotlin --no-daemon --stacktrace --console=plain