### PR TITLE
Beta 0.1 polish: player sheet, bookmarks, sync, and browse UX

### DIFF
--- a/app/src/main/java/com/stillshelf/app/core/model/Models.kt
+++ b/app/src/main/java/com/stillshelf/app/core/model/Models.kt
@@ -55,7 +55,8 @@ data class BookBookmark(
     val id: String,
     val libraryItemId: String,
     val title: String?,
-    val timeSeconds: Double?
+    val timeSeconds: Double?,
+    val createdAtMs: Long? = null
 )
 
 data class BookDetail(

--- a/app/src/main/java/com/stillshelf/app/data/api/AudiobookshelfApi.kt
+++ b/app/src/main/java/com/stillshelf/app/data/api/AudiobookshelfApi.kt
@@ -1,6 +1,7 @@
 package com.stillshelf.app.data.api
 
 import java.io.IOException
+import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
 import com.stillshelf.app.core.network.addAuthTokenFragment
@@ -76,7 +77,8 @@ data class AudiobookshelfBookmarkDto(
     val id: String,
     val libraryItemId: String,
     val title: String?,
-    val timeSeconds: Double?
+    val timeSeconds: Double?,
+    val createdAtMs: Long?
 )
 
 data class AudiobookshelfBookDetailDto(
@@ -441,6 +443,97 @@ class AudiobookshelfApi @Inject constructor(
     ): Result<List<AudiobookshelfBookmarkDto>> = withContext(Dispatchers.IO) {
         runCatching {
             parseBookmarks(requestMePayload(baseUrl, authToken))
+        }
+    }
+
+    suspend fun createBookmark(
+        baseUrl: String,
+        authToken: String,
+        itemId: String,
+        timeSeconds: Double,
+        title: String?
+    ): Result<Unit> = withContext(Dispatchers.IO) {
+        val normalizedItemId = itemId.trim()
+        val normalizedTime = timeSeconds.coerceAtLeast(0.0)
+        val normalizedTitle = title?.trim().takeUnless { it.isNullOrBlank() }
+        val verifyStartedAtMs = System.currentTimeMillis()
+        val requestBodies = buildList {
+            add(JSONObject().put("time", normalizedTime))
+            add(JSONObject().put("timeSeconds", normalizedTime))
+            add(JSONObject().put("currentTime", normalizedTime))
+            add(JSONObject().put("position", normalizedTime))
+        }.flatMap { baseBody ->
+            buildList {
+                add(baseBody)
+                if (!normalizedTitle.isNullOrBlank()) {
+                    add(JSONObject(baseBody.toString()).put("title", normalizedTitle))
+                    add(JSONObject(baseBody.toString()).put("note", normalizedTitle))
+                }
+            }
+        }.distinctBy { it.toString() }
+
+        val requestBuilders = buildList {
+            listOf(
+                "api/me/item/$itemId/bookmark",
+                "api/me/items/$itemId/bookmark",
+                "api/items/$itemId/bookmark",
+                "api/me/bookmarks",
+                "api/bookmarks"
+            ).forEach { path ->
+                requestBodies.forEach { body ->
+                    add(
+                        Request.Builder()
+                            .url(buildUrl(baseUrl, path))
+                            .header("Authorization", authHeaderValue(authToken))
+                            .post(body.toString().toRequestBody(JSON_MEDIA_TYPE))
+                            .build()
+                    )
+                }
+            }
+        }
+
+        runCatching {
+            invalidateMePayloadCache()
+            val baselineForItemCount = getBookmarks(baseUrl, authToken)
+                .getOrNull()
+                ?.count { bookmark ->
+                    bookmark.libraryItemId.matchesLibraryItemId(normalizedItemId)
+                }
+                ?: 0
+            var lastError: Throwable? = null
+            requestBuilders.forEach { request ->
+                val attempt = runCatching { executeRequestWithRetry(request) }
+                if (attempt.isSuccess) {
+                    invalidateMePayloadCache()
+                    val latestBookmarks = getBookmarks(baseUrl, authToken).getOrNull()
+                    val bookmarksForItem = latestBookmarks
+                        ?.filter { bookmark -> bookmark.libraryItemId.matchesLibraryItemId(normalizedItemId) }
+                        .orEmpty()
+                    val verified = when {
+                        bookmarksForItem.size > baselineForItemCount -> true
+                        else -> {
+                            bookmarksForItem.any { bookmark ->
+                                val timeMatches = bookmark.timeSeconds?.let { bookmarkTime ->
+                                    kotlin.math.abs(bookmarkTime - normalizedTime) <= BOOKMARK_VERIFY_TIME_TOLERANCE_SECONDS
+                                } ?: false
+                                val titleMatches = !normalizedTitle.isNullOrBlank() &&
+                                    bookmark.title?.trim()?.equals(normalizedTitle, ignoreCase = true) == true
+                                val recentEnough = bookmark.createdAtMs?.let { createdAt ->
+                                    createdAt >= (verifyStartedAtMs - BOOKMARK_VERIFY_RECENT_GRACE_MS)
+                                } ?: true
+                                recentEnough && (timeMatches || titleMatches)
+                            }
+                        }
+                    }
+                    if (verified) {
+                        return@runCatching Unit
+                    }
+                    lastError = IOException("Bookmark create verification failed.")
+                    return@forEach
+                }
+                lastError = attempt.exceptionOrNull()
+            }
+            throw IOException("Unable to add bookmark.", lastError)
         }
     }
 
@@ -1990,11 +2083,49 @@ class AudiobookshelfApi @Inject constructor(
                             ?: item.optDoubleOrNull("timeSeconds")
                             ?: item.optDoubleOrNull("startTime")
                             ?: item.optDoubleOrNull("position")
-                            ?: item.optDoubleOrNull("currentTime")
+                            ?: item.optDoubleOrNull("currentTime"),
+                        createdAtMs = item.optEpochMillis(
+                            "createdAt",
+                            "createdAtMs",
+                            "addedAt",
+                            "addedAtMs",
+                            "updatedAt",
+                            "updatedAtMs",
+                            "timestamp",
+                            "date"
+                        )
                     )
                 )
             }
         }
+    }
+
+    private fun JSONObject.optEpochMillis(vararg keys: String): Long? {
+        keys.forEach { key ->
+            if (!has(key) || isNull(key)) return@forEach
+            val raw = opt(key) ?: return@forEach
+            when (raw) {
+                is Number -> return normalizeEpochMillis(raw.toLong())
+                is String -> {
+                    val trimmed = raw.trim()
+                    if (trimmed.isBlank()) return@forEach
+                    trimmed.toLongOrNull()?.let { epoch -> return normalizeEpochMillis(epoch) }
+                    runCatching { Instant.parse(trimmed).toEpochMilli() }.getOrNull()?.let { epoch ->
+                        return normalizeEpochMillis(epoch)
+                    }
+                }
+            }
+        }
+        return null
+    }
+
+    private fun String.matchesLibraryItemId(targetItemId: String): Boolean {
+        val normalizedSource = this.trim()
+        val normalizedTarget = targetItemId.trim()
+        if (normalizedSource.isBlank() || normalizedTarget.isBlank()) return false
+        return normalizedSource.equals(normalizedTarget, ignoreCase = true) ||
+            normalizedSource.endsWith(normalizedTarget, ignoreCase = true) ||
+            normalizedTarget.endsWith(normalizedSource, ignoreCase = true)
     }
 
     private suspend fun requestMePayload(
@@ -2033,6 +2164,15 @@ class AudiobookshelfApi @Inject constructor(
                 payload
             }
         }.getOrThrow()
+    }
+
+    private suspend fun invalidateMePayloadCache() {
+        mePayloadMutex.withLock {
+            cachedMePayload = null
+            cachedMePayloadAtMs = 0L
+            cachedMePayloadBaseUrl = null
+            cachedMePayloadToken = null
+        }
     }
 
     private fun parseNamedEntities(
@@ -2573,6 +2713,8 @@ class AudiobookshelfApi @Inject constructor(
         val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
         const val MAX_429_RETRIES = 3
         const val ME_CACHE_TTL_MS = 2_500L
+        const val BOOKMARK_VERIFY_TIME_TOLERANCE_SECONDS = 2.5
+        const val BOOKMARK_VERIFY_RECENT_GRACE_MS = 8_000L
     }
 }
 

--- a/app/src/main/java/com/stillshelf/app/data/repo/SessionRepository.kt
+++ b/app/src/main/java/com/stillshelf/app/data/repo/SessionRepository.kt
@@ -87,6 +87,11 @@ interface SessionRepository {
         durationSeconds: Double?,
         isFinished: Boolean
     ): AppResult<Unit>
+    suspend fun createBookmark(
+        bookId: String,
+        timeSeconds: Double,
+        title: String? = null
+    ): AppResult<Unit>
     suspend fun markBookFinished(bookId: String, finished: Boolean): AppResult<Unit>
     suspend fun addBookToDefaultCollection(bookId: String): AppResult<String>
     suspend fun setLastPlayedBookId(bookId: String?): AppResult<Unit>

--- a/app/src/main/java/com/stillshelf/app/data/repo/SessionRepositoryImpl.kt
+++ b/app/src/main/java/com/stillshelf/app/data/repo/SessionRepositoryImpl.kt
@@ -25,6 +25,7 @@ import com.stillshelf.app.core.util.AppResult
 import com.stillshelf.app.data.api.AudiobookshelfApi
 import com.stillshelf.app.data.api.AudiobookshelfLibraryDto
 import com.stillshelf.app.data.api.AudiobookshelfLibraryItemDto
+import com.stillshelf.app.data.api.AudiobookshelfMediaProgressDto
 import com.stillshelf.app.data.api.AudiobookshelfBookDetailDto
 import com.stillshelf.app.data.api.AudiobookshelfBookmarkDto
 import com.stillshelf.app.data.api.AudiobookshelfNamedEntityDto
@@ -363,11 +364,22 @@ class SessionRepositoryImpl @Inject constructor(
             )
         }
 
-        val books = itemsResult.getOrThrow().map { item ->
+        val items = itemsResult.getOrThrow()
+        val mediaProgressByItemId = if (items.isEmpty()) {
+            emptyMap()
+        } else {
+            audiobookshelfApi.getMediaProgress(
+                baseUrl = connection.server.baseUrl,
+                authToken = connection.token
+            ).getOrNull()
+                ?.associateBy { it.libraryItemId }
+                .orEmpty()
+        }
+        val books = items.map { item ->
             item.toBookSummary(
                 baseUrl = connection.server.baseUrl,
                 authToken = connection.token
-            )
+            ).withResolvedProgress(mediaProgressByItemId[item.id])
         }
         putCache(booksCache, cacheKey, books)
 
@@ -1383,6 +1395,40 @@ class SessionRepositoryImpl @Inject constructor(
         return AppResult.Success(Unit)
     }
 
+    override suspend fun createBookmark(
+        bookId: String,
+        timeSeconds: Double,
+        title: String?
+    ): AppResult<Unit> {
+        if (bookId.isBlank()) return AppResult.Error("Invalid book id.")
+        val connection = when (val result = getActiveConnection(requireLibrary = true)) {
+            is AppResult.Success -> result.value
+            is AppResult.Error -> return result
+        }
+        val library = connection.library ?: return AppResult.Error("No active library selected.")
+
+        val createResult = audiobookshelfApi.createBookmark(
+            baseUrl = connection.server.baseUrl,
+            authToken = connection.token,
+            itemId = bookId,
+            timeSeconds = timeSeconds.coerceAtLeast(0.0),
+            title = title
+        )
+        if (createResult.isFailure) {
+            return AppResult.Error(
+                message = createResult.exceptionOrNull()?.message ?: "Unable to add bookmark.",
+                cause = createResult.exceptionOrNull()
+            )
+        }
+
+        clearBookDetailCache(
+            serverId = connection.server.id,
+            libraryId = library.id,
+            bookId = bookId
+        )
+        return AppResult.Success(Unit)
+    }
+
     override suspend fun markBookFinished(bookId: String, finished: Boolean): AppResult<Unit> {
         if (bookId.isBlank()) return AppResult.Error("Invalid book id.")
         val connection = when (val result = getActiveConnection(requireLibrary = true)) {
@@ -2126,6 +2172,17 @@ class SessionRepositoryImpl @Inject constructor(
         bookDetailCache.clear()
     }
 
+    private suspend fun clearBookDetailCache(
+        serverId: String,
+        libraryId: String,
+        bookId: String
+    ) {
+        val key = contentCacheKey(serverId, libraryId, suffix = "bookDetail:$bookId")
+        cacheMutex.withLock {
+            bookDetailCache.remove(key)
+        }
+    }
+
     private fun normalizeAuthorKey(name: String): String = name.trim().lowercase()
     private fun normalizeSeriesKey(name: String): String = name.trim().lowercase()
 
@@ -2322,6 +2379,27 @@ class SessionRepositoryImpl @Inject constructor(
         )
     }
 
+    private fun BookSummary.withResolvedProgress(
+        progress: AudiobookshelfMediaProgressDto?
+    ): BookSummary {
+        progress ?: return this
+        val mergedCurrentTimeSeconds = progress.currentTimeSeconds?.coerceAtLeast(0.0) ?: currentTimeSeconds
+        val progressFromApi = progress.progressPercent?.coerceIn(0.0, 1.0)
+        val mergedDurationSeconds = progress.durationSeconds?.takeIf { it > 0.0 } ?: durationSeconds
+        val derivedProgress = if (progressFromApi == null && mergedCurrentTimeSeconds != null && mergedDurationSeconds != null && mergedDurationSeconds > 0.0) {
+            (mergedCurrentTimeSeconds / mergedDurationSeconds).coerceIn(0.0, 1.0)
+        } else {
+            null
+        }
+        val mergedProgressPercent = progressFromApi ?: derivedProgress ?: progressPercent
+        val finishedFromProgress = (mergedProgressPercent ?: 0.0) >= 0.995
+        return copy(
+            progressPercent = mergedProgressPercent,
+            currentTimeSeconds = mergedCurrentTimeSeconds,
+            isFinished = isFinished || finishedFromProgress
+        )
+    }
+
     private fun AudiobookshelfNamedEntityDto.toModel(
         baseUrl: String,
         authToken: String,
@@ -2399,7 +2477,8 @@ class SessionRepositoryImpl @Inject constructor(
             id = id,
             libraryItemId = libraryItemId,
             title = title,
-            timeSeconds = timeSeconds
+            timeSeconds = timeSeconds,
+            createdAtMs = createdAtMs
         )
     }
 }

--- a/app/src/main/java/com/stillshelf/app/ui/components/MiniPlayerBar.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/components/MiniPlayerBar.kt
@@ -1,5 +1,8 @@
 package com.stillshelf.app.ui.components
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.MarqueeSpacing
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.Canvas
@@ -33,11 +36,11 @@ import coil.compose.AsyncImage
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
-import kotlin.math.max
 import kotlin.math.cos
 import kotlin.math.sin
 import com.stillshelf.app.ui.common.rememberCoverImageModel
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun MiniPlayerBar(
     state: MiniPlayerUiState,
@@ -47,7 +50,7 @@ fun MiniPlayerBar(
     modifier: Modifier = Modifier
 ) {
     val item = state.item
-    val title = item?.book?.title ?: "Nothing playing"
+    val title = state.displayTitle.ifBlank { item?.book?.title ?: "Nothing playing" }
     val subtitle = when {
         state.isLoading -> "Loading playback..."
         item != null -> formatMiniPlayerSubtitle(item)
@@ -98,7 +101,15 @@ fun MiniPlayerBar(
                     style = MaterialTheme.typography.bodySmall,
                     fontWeight = FontWeight.SemiBold,
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                    softWrap = false,
+                    overflow = TextOverflow.Visible,
+                    modifier = Modifier.basicMarquee(
+                        iterations = Int.MAX_VALUE,
+                        animationMode = androidx.compose.foundation.MarqueeAnimationMode.Immediately,
+                        repeatDelayMillis = 2000,
+                        initialDelayMillis = 1200,
+                        spacing = MarqueeSpacing(36.dp)
+                    )
                 )
                 Text(
                     text = subtitle,
@@ -198,11 +209,29 @@ private fun MiniSeek15Glyph(
 }
 
 private fun formatMiniPlayerSubtitle(item: com.stillshelf.app.core.model.ContinueListeningItem): String {
-    val author = item.book.authorName
-    val duration = item.book.durationSeconds
+    val duration = item.book.durationSeconds?.takeIf { it > 0.0 }
+        ?: run {
+            val progress = item.progressPercent?.coerceIn(0.0, 1.0)
+            val current = item.currentTimeSeconds?.coerceAtLeast(0.0)
+            if (progress != null && current != null && progress > 0.0) {
+                (current / progress).takeIf { it.isFinite() && it > 0.0 }
+            } else {
+                null
+            }
+        }
     val progress = item.progressPercent
     val currentTime = item.currentTimeSeconds
-    if (duration == null || duration <= 0.0) return author
+    if (duration == null || duration <= 0.0) {
+        val fallbackPercent = progress
+            ?.coerceIn(0.0, 1.0)
+            ?.let { (it * 100.0).toInt() }
+            ?: 0
+        return if (fallbackPercent > 0) {
+            "In progress • $fallbackPercent% complete"
+        } else {
+            "0h 0m left • 0% complete"
+        }
+    }
 
     val percent = when {
         progress != null -> (progress.coerceIn(0.0, 1.0) * 100.0).toInt()
@@ -216,16 +245,13 @@ private fun formatMiniPlayerSubtitle(item: com.stillshelf.app.core.model.Continu
         else -> duration
     }.coerceAtLeast(0.0)
 
-    return "$author · $percent% · ${formatDuration(remainingSeconds)} left"
+    return "${formatHoursMinutesPrecise(remainingSeconds)} left • $percent% complete"
 }
 
-private fun formatDuration(seconds: Double): String {
-    val totalSeconds = seconds.toLong()
-    val hours = totalSeconds / 3600
-    val minutes = (totalSeconds % 3600) / 60
-    return if (hours > 0) {
-        "${hours}h ${minutes}m"
-    } else {
-        "${max(minutes, 1)}m"
-    }
+private fun formatHoursMinutesPrecise(durationSeconds: Double): String {
+    if (durationSeconds <= 0.0) return "0h 0m"
+    val totalMinutes = (durationSeconds / 60.0).toLong()
+    val hours = totalMinutes / 60
+    val minutes = totalMinutes % 60
+    return "${hours}h ${minutes}m"
 }

--- a/app/src/main/java/com/stillshelf/app/ui/components/MiniPlayerViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/components/MiniPlayerViewModel.kt
@@ -3,6 +3,7 @@ package com.stillshelf.app.ui.components
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.stillshelf.app.core.datastore.SessionPreferences
+import com.stillshelf.app.core.model.BookChapter
 import com.stillshelf.app.core.model.ContinueListeningItem
 import com.stillshelf.app.core.util.AppResult
 import com.stillshelf.app.data.repo.SessionRepository
@@ -20,6 +21,7 @@ import kotlinx.coroutines.launch
 data class MiniPlayerUiState(
     val isLoading: Boolean = false,
     val item: ContinueListeningItem? = null,
+    val displayTitle: String = "Nothing playing",
     val isPlaying: Boolean = false,
     val rewindSeconds: Int = 15,
     val errorMessage: String? = null
@@ -33,6 +35,8 @@ class MiniPlayerViewModel @Inject constructor(
 ) : ViewModel() {
     private val mutableUiState = MutableStateFlow(MiniPlayerUiState())
     private var hadActivePlayback = false
+    private val chapterCache = mutableMapOf<String, List<BookChapter>>()
+    private var loadingChaptersForBookId: String? = null
     val uiState: StateFlow<MiniPlayerUiState> = mutableUiState.asStateFlow()
 
     init {
@@ -48,10 +52,12 @@ class MiniPlayerViewModel @Inject constructor(
         if (livePlaybackItem != null) {
             hadActivePlayback = true
             playbackController.cacheContinueListeningItem(livePlaybackItem)
+            ensureBookChapters(livePlaybackItem.book.id)
             mutableUiState.update {
                 it.copy(
                     isLoading = false,
                     item = livePlaybackItem,
+                    displayTitle = resolvePlayerTitle(livePlaybackItem),
                     isPlaying = playbackState.isPlaying,
                     errorMessage = null
                 )
@@ -65,10 +71,12 @@ class MiniPlayerViewModel @Inject constructor(
             when (val result = sessionRepository.fetchMiniPlayerItem()) {
                 is AppResult.Success -> {
                     playbackController.cacheContinueListeningItem(result.value)
+                    result.value?.book?.id?.let(::ensureBookChapters)
                     mutableUiState.update {
                         it.copy(
                             isLoading = false,
                             item = result.value,
+                            displayTitle = resolvePlayerTitle(result.value),
                             isPlaying = false,
                             errorMessage = null
                         )
@@ -80,6 +88,7 @@ class MiniPlayerViewModel @Inject constructor(
                         it.copy(
                             isLoading = false,
                             item = null,
+                            displayTitle = "Nothing playing",
                             isPlaying = false,
                             errorMessage = result.message
                         )
@@ -125,10 +134,12 @@ class MiniPlayerViewModel @Inject constructor(
                 if (livePlaybackItem != null) {
                     hadActivePlayback = true
                     playbackController.cacheContinueListeningItem(livePlaybackItem)
+                    ensureBookChapters(livePlaybackItem.book.id)
                     mutableUiState.update {
                         it.copy(
                             isLoading = false,
                             item = livePlaybackItem,
+                            displayTitle = resolvePlayerTitle(livePlaybackItem),
                             isPlaying = playbackState.isPlaying,
                             errorMessage = null
                         )
@@ -137,7 +148,7 @@ class MiniPlayerViewModel @Inject constructor(
                     hadActivePlayback = false
                     refresh()
                 } else {
-                    mutableUiState.update { it.copy(isPlaying = false) }
+                    mutableUiState.update { it.copy(isPlaying = false, displayTitle = "Nothing playing") }
                 }
             }
         }
@@ -153,18 +164,74 @@ class MiniPlayerViewModel @Inject constructor(
             }
         }
     }
+
+    private fun ensureBookChapters(bookId: String) {
+        if (bookId.isBlank()) return
+        if (chapterCache.containsKey(bookId) || loadingChaptersForBookId == bookId) return
+        loadingChaptersForBookId = bookId
+        viewModelScope.launch {
+            when (val result = sessionRepository.fetchBookDetail(bookId, forceRefresh = false)) {
+                is AppResult.Success -> {
+                    chapterCache[bookId] = result.value.chapters
+                    val currentItem = uiState.value.item
+                    if (currentItem?.book?.id == bookId) {
+                        mutableUiState.update {
+                            it.copy(displayTitle = resolvePlayerTitle(currentItem))
+                        }
+                    }
+                }
+
+                is AppResult.Error -> Unit
+            }
+            if (loadingChaptersForBookId == bookId) {
+                loadingChaptersForBookId = null
+            }
+        }
+    }
+
+    private fun resolvePlayerTitle(item: ContinueListeningItem?): String {
+        if (item == null) return "Nothing playing"
+        val chapterTitle = findActiveChapterTitle(
+            chapters = chapterCache[item.book.id].orEmpty(),
+            positionSeconds = item.currentTimeSeconds ?: 0.0
+        )
+        return if (!chapterTitle.isNullOrBlank() && !chapterTitle.equals(item.book.title, ignoreCase = true)) {
+            "${item.book.title} - $chapterTitle"
+        } else {
+            item.book.title
+        }
+    }
+}
+
+private fun findActiveChapterTitle(chapters: List<BookChapter>, positionSeconds: Double): String? {
+    val index = findActiveChapterIndex(chapters, positionSeconds)
+    if (index !in chapters.indices) return null
+    return chapters[index].title.trim().takeIf { it.isNotBlank() }
+}
+
+private fun findActiveChapterIndex(chapters: List<BookChapter>, positionSeconds: Double): Int {
+    if (chapters.isEmpty()) return -1
+    val target = positionSeconds.coerceAtLeast(0.0)
+    val index = chapters.indexOfFirst { chapter ->
+        val end = chapter.endSeconds ?: Double.POSITIVE_INFINITY
+        target >= chapter.startSeconds && target < end
+    }
+    return if (index >= 0) index else chapters.lastIndex
 }
 
 private fun com.stillshelf.app.playback.controller.PlaybackUiState.toMiniPlayerItem(): ContinueListeningItem? {
     val currentBook = book ?: return null
-    val durationSeconds = if (durationMs > 0L) durationMs / 1000.0 else currentBook.durationSeconds
+    val durationSeconds = currentBook.durationSeconds?.takeIf { it > 0.0 }
+        ?: if (durationMs > 0L) durationMs / 1000.0 else null
     val positionSeconds = positionMs.coerceAtLeast(0L) / 1000.0
     val progress = durationSeconds
         ?.takeIf { it > 0.0 }
         ?.let { (positionSeconds / it).coerceIn(0.0, 1.0) }
 
     return ContinueListeningItem(
-        book = currentBook,
+        book = currentBook.copy(
+            durationSeconds = currentBook.durationSeconds?.takeIf { it > 0.0 } ?: durationSeconds
+        ),
         progressPercent = progress,
         currentTimeSeconds = positionSeconds
     )

--- a/app/src/main/java/com/stillshelf/app/ui/screens/BookDetailViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/BookDetailViewModel.kt
@@ -3,7 +3,6 @@ package com.stillshelf.app.ui.screens
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.stillshelf.app.core.datastore.SessionPreferences
 import com.stillshelf.app.core.model.BookDetail
 import com.stillshelf.app.core.util.AppResult
 import com.stillshelf.app.data.repo.SessionRepository
@@ -37,7 +36,6 @@ class BookDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val sessionRepository: SessionRepository,
     private val playbackController: PlaybackController,
-    private val sessionPreferences: SessionPreferences,
     private val bookDownloadManager: BookDownloadManager
 ) : ViewModel() {
     private val bookId: String = savedStateHandle.get<String>(DetailRoute.BOOK_ID_ARG).orEmpty()
@@ -138,9 +136,6 @@ class BookDetailViewModel @Inject constructor(
 
     fun setSelectedTab(tab: String) {
         mutableUiState.update { it.copy(selectedTab = tab) }
-        viewModelScope.launch {
-            sessionPreferences.setLastBookDetailTab(tab)
-        }
     }
 
     fun clearActionMessage() {
@@ -169,13 +164,6 @@ class BookDetailViewModel @Inject constructor(
                         downloadedBookIds = downloadedIds,
                         downloadProgressPercent = progressPercent
                     )
-                }
-            }
-        }
-        viewModelScope.launch {
-            sessionPreferences.state.collect { pref ->
-                mutableUiState.update {
-                    it.copy(selectedTab = pref.lastBookDetailTab.ifBlank { "About" })
                 }
             }
         }

--- a/app/src/main/java/com/stillshelf/app/ui/screens/BooksBrowseViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/BooksBrowseViewModel.kt
@@ -209,6 +209,8 @@ class BooksBrowseViewModel @Inject constructor(
 
         when (
             val result = sessionRepository.fetchBooksForActiveLibrary(
+                limit = 400,
+                page = 0,
                 forceRefresh = isUserRefresh
             )
         ) {

--- a/app/src/main/java/com/stillshelf/app/ui/screens/CollectionPickerViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/CollectionPickerViewModel.kt
@@ -28,11 +28,16 @@ data class CollectionPickerUiState(
 class CollectionPickerViewModel @Inject constructor(
     private val sessionRepository: SessionRepository
 ) : ViewModel() {
-    private val mutableUiState = MutableStateFlow(CollectionPickerUiState())
+    private val mutableUiState = MutableStateFlow(
+        CollectionPickerUiState(
+            collections = CollectionPickerMemoryCache.collectionsSnapshot(),
+            playlists = CollectionPickerMemoryCache.playlistsSnapshot()
+        )
+    )
     val uiState: StateFlow<CollectionPickerUiState> = mutableUiState.asStateFlow()
 
     fun loadDestinations(
-        forceRefresh: Boolean = true,
+        forceRefresh: Boolean = false,
         showLoader: Boolean = true
     ) {
         if (mutableUiState.value.isLoading) return
@@ -75,6 +80,10 @@ class CollectionPickerViewModel @Inject constructor(
                     errorMessage = errorParts.takeIf { parts -> parts.isNotEmpty() }?.joinToString("  ")
                 )
             }
+            CollectionPickerMemoryCache.update(
+                collections = nextCollections,
+                playlists = nextPlaylists
+            )
         }
     }
 
@@ -284,5 +293,25 @@ class CollectionPickerViewModel @Inject constructor(
             it.id == added.id || it.name.equals(added.name, ignoreCase = true)
         }
         return listOf(added) + filtered
+    }
+}
+
+private object CollectionPickerMemoryCache {
+    private var collections: List<NamedEntitySummary> = emptyList()
+    private var playlists: List<NamedEntitySummary> = emptyList()
+
+    @Synchronized
+    fun collectionsSnapshot(): List<NamedEntitySummary> = collections
+
+    @Synchronized
+    fun playlistsSnapshot(): List<NamedEntitySummary> = playlists
+
+    @Synchronized
+    fun update(
+        collections: List<NamedEntitySummary>,
+        playlists: List<NamedEntitySummary>
+    ) {
+        this.collections = collections
+        this.playlists = playlists
     }
 }

--- a/app/src/main/java/com/stillshelf/app/ui/screens/EntityBrowseViewModels.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/EntityBrowseViewModels.kt
@@ -35,6 +35,7 @@ data class SeriesBrowseUiState(
 data class CollectionsBrowseUiState(
     val isLoading: Boolean = false,
     val entities: List<NamedEntitySummary> = emptyList(),
+    val coverStackByCollectionId: Map<String, List<String>> = emptyMap(),
     val errorMessage: String? = null,
     val actionMessage: String? = null
 )
@@ -202,6 +203,7 @@ class CollectionsBrowseViewModel @Inject constructor(
 ) : ViewModel() {
     private val mutableUiState = MutableStateFlow(CollectionsBrowseUiState())
     val uiState: StateFlow<CollectionsBrowseUiState> = mutableUiState.asStateFlow()
+    private val inFlightCoverLoads = mutableSetOf<String>()
 
     init {
         refresh(forceRefresh = false)
@@ -209,6 +211,12 @@ class CollectionsBrowseViewModel @Inject constructor(
 
     fun refresh() {
         refresh(forceRefresh = true)
+    }
+
+    fun refreshLibrary() {
+        EntityCoverStackMemoryCache.clearCollections()
+        mutableUiState.update { it.copy(coverStackByCollectionId = emptyMap()) }
+        refresh(forceRefresh = true, reloadAllCoverStacks = true)
     }
 
     fun createCollection(name: String) {
@@ -257,19 +265,38 @@ class CollectionsBrowseViewModel @Inject constructor(
         mutableUiState.update { it.copy(actionMessage = null) }
     }
 
-    private fun refresh(forceRefresh: Boolean) {
+    private fun refresh(forceRefresh: Boolean, reloadAllCoverStacks: Boolean = false) {
         if (uiState.value.isLoading) return
         mutableUiState.update { it.copy(isLoading = true, errorMessage = null) }
 
         viewModelScope.launch {
             when (val result = sessionRepository.fetchCollectionsForActiveLibrary(forceRefresh = forceRefresh)) {
                 is AppResult.Success -> {
+                    val previousState = uiState.value
                     val filtered = result.value.filterNot { isStillShelfProbeCollection(it.name) }
+                    val visibleIds = filtered.map { it.id }.toSet()
+                    val cachedStacks = EntityCoverStackMemoryCache.collectionsForIds(visibleIds)
+                    val retainedStacks = previousState.coverStackByCollectionId.filterKeys { id ->
+                        visibleIds.contains(id)
+                    }
+                    val mergedStacks = retainedStacks + cachedStacks
+                    val previousById = previousState.entities.associateBy { it.id }
+                    val collectionsToReload = filtered.filter { collection ->
+                        val previous = previousById[collection.id]
+                        val hasCoverStack = mergedStacks.containsKey(collection.id)
+                        reloadAllCoverStacks ||
+                            !hasCoverStack ||
+                            (previous != null && previous.subtitle != collection.subtitle)
+                    }
                     mutableUiState.update {
                         it.copy(
                             isLoading = false,
-                            entities = filtered
+                            entities = filtered,
+                            coverStackByCollectionId = mergedStacks
                         )
+                    }
+                    if (collectionsToReload.isNotEmpty()) {
+                        loadCollectionCoverStacks(collections = collectionsToReload, forceRefresh = forceRefresh)
                     }
                 }
 
@@ -284,6 +311,58 @@ class CollectionsBrowseViewModel @Inject constructor(
             }
         }
     }
+
+    private fun loadCollectionCoverStacks(
+        collections: List<NamedEntitySummary>,
+        forceRefresh: Boolean
+    ) {
+        collections.forEach { collection ->
+            if (!inFlightCoverLoads.add(collection.id)) return@forEach
+
+            viewModelScope.launch {
+                try {
+                    val covers = when (
+                        val result = sessionRepository.fetchCollectionBooks(
+                            collectionId = collection.id,
+                            forceRefresh = forceRefresh
+                        )
+                    ) {
+                        is AppResult.Success -> result.value
+                            .mapNotNull { it.coverUrl?.trim() }
+                            .filter { it.isNotEmpty() }
+                            .distinct()
+                            .take(3)
+
+                        is AppResult.Error -> emptyList()
+                    }
+
+                    mutableUiState.update { state ->
+                        if (state.entities.none { it.id == collection.id }) {
+                            state
+                        } else {
+                            val current = state.coverStackByCollectionId[collection.id].orEmpty()
+                            if (current == covers) {
+                                state
+                            } else {
+                                val updatedStacks = if (covers.isEmpty()) {
+                                    state.coverStackByCollectionId - collection.id
+                                } else {
+                                    state.coverStackByCollectionId + (collection.id to covers)
+                                }
+                                EntityCoverStackMemoryCache.updateCollection(
+                                    collectionId = collection.id,
+                                    covers = covers
+                                )
+                                state.copy(coverStackByCollectionId = updatedStacks)
+                            }
+                        }
+                    }
+                } finally {
+                    inFlightCoverLoads.remove(collection.id)
+                }
+            }
+        }
+    }
 }
 
 @HiltViewModel
@@ -292,6 +371,7 @@ class PlaylistsBrowseViewModel @Inject constructor(
 ) : ViewModel() {
     private val mutableUiState = MutableStateFlow(CollectionsBrowseUiState())
     val uiState: StateFlow<CollectionsBrowseUiState> = mutableUiState.asStateFlow()
+    private val inFlightCoverLoads = mutableSetOf<String>()
 
     init {
         refresh(forceRefresh = false)
@@ -299,6 +379,12 @@ class PlaylistsBrowseViewModel @Inject constructor(
 
     fun refresh() {
         refresh(forceRefresh = true)
+    }
+
+    fun refreshLibrary() {
+        EntityCoverStackMemoryCache.clearPlaylists()
+        mutableUiState.update { it.copy(coverStackByCollectionId = emptyMap()) }
+        refresh(forceRefresh = true, reloadAllCoverStacks = true)
     }
 
     fun createPlaylist(name: String) {
@@ -347,18 +433,37 @@ class PlaylistsBrowseViewModel @Inject constructor(
         mutableUiState.update { it.copy(actionMessage = null) }
     }
 
-    private fun refresh(forceRefresh: Boolean) {
+    private fun refresh(forceRefresh: Boolean, reloadAllCoverStacks: Boolean = false) {
         if (uiState.value.isLoading) return
         mutableUiState.update { it.copy(isLoading = true, errorMessage = null) }
 
         viewModelScope.launch {
             when (val result = sessionRepository.fetchPlaylistsForActiveLibrary(forceRefresh = forceRefresh)) {
                 is AppResult.Success -> {
+                    val previousState = uiState.value
+                    val visibleIds = result.value.map { it.id }.toSet()
+                    val cachedStacks = EntityCoverStackMemoryCache.playlistsForIds(visibleIds)
+                    val retainedStacks = previousState.coverStackByCollectionId.filterKeys { id ->
+                        visibleIds.contains(id)
+                    }
+                    val mergedStacks = retainedStacks + cachedStacks
+                    val previousById = previousState.entities.associateBy { it.id }
+                    val playlistsToReload = result.value.filter { playlist ->
+                        val previous = previousById[playlist.id]
+                        val hasCoverStack = mergedStacks.containsKey(playlist.id)
+                        reloadAllCoverStacks ||
+                            !hasCoverStack ||
+                            (previous != null && previous.subtitle != playlist.subtitle)
+                    }
                     mutableUiState.update {
                         it.copy(
                             isLoading = false,
-                            entities = result.value
+                            entities = result.value,
+                            coverStackByCollectionId = mergedStacks
                         )
+                    }
+                    if (playlistsToReload.isNotEmpty()) {
+                        loadPlaylistCoverStacks(playlists = playlistsToReload, forceRefresh = forceRefresh)
                     }
                 }
 
@@ -372,6 +477,105 @@ class PlaylistsBrowseViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun loadPlaylistCoverStacks(
+        playlists: List<NamedEntitySummary>,
+        forceRefresh: Boolean
+    ) {
+        playlists.forEach { playlist ->
+            if (!inFlightCoverLoads.add(playlist.id)) return@forEach
+
+            viewModelScope.launch {
+                try {
+                    val covers = when (
+                        val result = sessionRepository.fetchPlaylistBooks(
+                            playlistId = playlist.id,
+                            forceRefresh = forceRefresh
+                        )
+                    ) {
+                        is AppResult.Success -> result.value
+                            .mapNotNull { it.coverUrl?.trim() }
+                            .filter { it.isNotEmpty() }
+                            .distinct()
+                            .take(3)
+
+                        is AppResult.Error -> emptyList()
+                    }
+
+                    mutableUiState.update { state ->
+                        if (state.entities.none { it.id == playlist.id }) {
+                            state
+                        } else {
+                            val current = state.coverStackByCollectionId[playlist.id].orEmpty()
+                            if (current == covers) {
+                                state
+                            } else {
+                                val updatedStacks = if (covers.isEmpty()) {
+                                    state.coverStackByCollectionId - playlist.id
+                                } else {
+                                    state.coverStackByCollectionId + (playlist.id to covers)
+                                }
+                                EntityCoverStackMemoryCache.updatePlaylist(
+                                    playlistId = playlist.id,
+                                    covers = covers
+                                )
+                                state.copy(coverStackByCollectionId = updatedStacks)
+                            }
+                        }
+                    }
+                } finally {
+                    inFlightCoverLoads.remove(playlist.id)
+                }
+            }
+        }
+    }
+}
+
+private object EntityCoverStackMemoryCache {
+    private val collectionStacks = mutableMapOf<String, List<String>>()
+    private val playlistStacks = mutableMapOf<String, List<String>>()
+
+    @Synchronized
+    fun collectionsForIds(ids: Set<String>): Map<String, List<String>> {
+        val stacks = LinkedHashMap<String, List<String>>(ids.size)
+        ids.forEach { id -> collectionStacks[id]?.let { stacks[id] = it } }
+        return stacks
+    }
+
+    @Synchronized
+    fun playlistsForIds(ids: Set<String>): Map<String, List<String>> {
+        val stacks = LinkedHashMap<String, List<String>>(ids.size)
+        ids.forEach { id -> playlistStacks[id]?.let { stacks[id] = it } }
+        return stacks
+    }
+
+    @Synchronized
+    fun updateCollection(collectionId: String, covers: List<String>) {
+        if (covers.isEmpty()) {
+            collectionStacks.remove(collectionId)
+        } else {
+            collectionStacks[collectionId] = covers
+        }
+    }
+
+    @Synchronized
+    fun updatePlaylist(playlistId: String, covers: List<String>) {
+        if (covers.isEmpty()) {
+            playlistStacks.remove(playlistId)
+        } else {
+            playlistStacks[playlistId] = covers
+        }
+    }
+
+    @Synchronized
+    fun clearCollections() {
+        collectionStacks.clear()
+    }
+
+    @Synchronized
+    fun clearPlaylists() {
+        playlistStacks.clear()
     }
 }
 

--- a/app/src/main/java/com/stillshelf/app/ui/screens/FacetDetailScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/FacetDetailScreens.kt
@@ -196,6 +196,46 @@ class AuthorDetailViewModel @Inject constructor(
         refresh(forceRefresh = true)
     }
 
+    fun markAsFinished(bookId: String) {
+        if (bookId.isBlank()) return
+        viewModelScope.launch {
+            when (val result = sessionRepository.markBookFinished(bookId = bookId, finished = true)) {
+                is AppResult.Success -> {
+                    mutableUiState.update { it.copy(actionMessage = "Marked as finished. Progress is now 100%.") }
+                    refresh(forceRefresh = true)
+                }
+
+                is AppResult.Error -> {
+                    mutableUiState.update { it.copy(actionMessage = result.message) }
+                }
+            }
+        }
+    }
+
+    fun toggleDownload(bookId: String) {
+        if (bookId.isBlank()) return
+        viewModelScope.launch {
+            val book = uiState.value.books.firstOrNull { it.id == bookId }
+            if (book == null) {
+                mutableUiState.update { it.copy(actionMessage = "Unable to find book for download.") }
+                return@launch
+            }
+            when (val result = bookDownloadManager.toggleDownload(book)) {
+                is AppResult.Success -> {
+                    mutableUiState.update { it.copy(actionMessage = result.value.message) }
+                }
+
+                is AppResult.Error -> {
+                    mutableUiState.update { it.copy(actionMessage = result.message) }
+                }
+            }
+        }
+    }
+
+    fun clearActionMessage() {
+        mutableUiState.update { it.copy(actionMessage = null) }
+    }
+
     private fun refresh(forceRefresh: Boolean) {
         mutableUiState.update { it.copy(isLoading = true, errorMessage = null) }
         viewModelScope.launch {
@@ -496,21 +536,30 @@ private fun normalizeAuthorName(raw: String): String {
 private fun List<BookSummary>.applySeriesStatusFilter(filter: BooksStatusFilter): List<BookSummary> {
     return when (filter) {
         BooksStatusFilter.All -> this
-        BooksStatusFilter.Finished -> filter { book ->
-            book.isFinished || (book.progressPercent ?: 0.0) >= 0.999
-        }
-        BooksStatusFilter.InProgress -> filter { book ->
-            val progress = (book.progressPercent ?: 0.0).coerceIn(0.0, 1.0)
-            !book.isFinished && progress > 0.001 && progress < 0.999
-        }
-        BooksStatusFilter.NotStarted -> filter { book ->
-            val progress = (book.progressPercent ?: 0.0).coerceIn(0.0, 1.0)
-            !book.isFinished && progress <= 0.001
-        }
-        BooksStatusFilter.NotFinished -> filter { book ->
-            !book.isFinished
-        }
+        BooksStatusFilter.Finished -> filter { it.hasFinishedStatusProgress() }
+        BooksStatusFilter.InProgress -> filter { it.hasStartedStatusProgress() && !it.hasFinishedStatusProgress() }
+        BooksStatusFilter.NotStarted -> filter { !it.hasStartedStatusProgress() && !it.hasFinishedStatusProgress() }
+        BooksStatusFilter.NotFinished -> filter { !it.hasFinishedStatusProgress() }
     }
+}
+
+private fun BookSummary.hasStartedStatusProgress(): Boolean {
+    if (hasFinishedStatusProgress()) return true
+    val normalized = normalizedStatusProgressPercent()
+    return normalized != null && normalized > 0.001
+}
+
+private fun BookSummary.hasFinishedStatusProgress(): Boolean {
+    val normalized = normalizedStatusProgressPercent()
+    return isFinished || (normalized != null && normalized >= 0.995)
+}
+
+private fun BookSummary.normalizedStatusProgressPercent(): Double? {
+    progressPercent?.coerceIn(0.0, 1.0)?.let { return it }
+    val duration = durationSeconds ?: return null
+    if (duration <= 0.0) return null
+    val current = currentTimeSeconds ?: return null
+    return (current / duration).coerceIn(0.0, 1.0)
 }
 
 private fun buildAuthorDisplayEntries(
@@ -724,11 +773,36 @@ fun AuthorDetailScreen(
     onBookClick: (String) -> Unit,
     onSeriesClick: (String) -> Unit,
     onHomeClick: (() -> Unit)? = null,
-    viewModel: AuthorDetailViewModel = hiltViewModel()
+    viewModel: AuthorDetailViewModel = hiltViewModel(),
+    collectionPickerViewModel: CollectionPickerViewModel = hiltViewModel()
 ) {
+    val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val collectionPickerUiState by collectionPickerViewModel.uiState.collectAsStateWithLifecycle()
     val layoutMode by viewModel.layoutMode.collectAsStateWithLifecycle()
     val collapseSeries by viewModel.collapseSeries.collectAsStateWithLifecycle()
+    var addToListBookId by rememberSaveable { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(uiState.actionMessage) {
+        val message = uiState.actionMessage ?: return@LaunchedEffect
+        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        viewModel.clearActionMessage()
+    }
+    LaunchedEffect(addToListBookId) {
+        if (!addToListBookId.isNullOrBlank()) {
+            collectionPickerViewModel.loadDestinations(forceRefresh = false)
+        }
+    }
+    LaunchedEffect(collectionPickerUiState.actionMessage) {
+        val message = collectionPickerUiState.actionMessage ?: return@LaunchedEffect
+        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        collectionPickerViewModel.clearMessages()
+    }
+    LaunchedEffect(collectionPickerUiState.errorMessage) {
+        val message = collectionPickerUiState.errorMessage ?: return@LaunchedEffect
+        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        collectionPickerViewModel.clearMessages()
+    }
 
     val displayBooks = remember(uiState.books) { uiState.books.sortedBy { it.title.lowercase() } }
     val displayEntries = remember(displayBooks, collapseSeries) {
@@ -803,7 +877,10 @@ fun AuthorDetailScreen(
                                     book = entry.book,
                                     isDownloaded = uiState.downloadedBookIds.contains(entry.book.id),
                                     downloadProgressPercent = uiState.downloadProgressByBookId[entry.book.id],
-                                    onClick = { onBookClick(entry.book.id) }
+                                    onClick = { onBookClick(entry.book.id) },
+                                    onAddToCollection = { addToListBookId = entry.book.id },
+                                    onMarkAsFinished = { viewModel.markAsFinished(entry.book.id) },
+                                    onToggleDownload = { viewModel.toggleDownload(entry.book.id) }
                                 )
                             }
 
@@ -881,7 +958,10 @@ fun AuthorDetailScreen(
                                     book = entry.book,
                                     isDownloaded = uiState.downloadedBookIds.contains(entry.book.id),
                                     downloadProgressPercent = uiState.downloadProgressByBookId[entry.book.id],
-                                    onClick = { onBookClick(entry.book.id) }
+                                    onClick = { onBookClick(entry.book.id) },
+                                    onAddToCollection = { addToListBookId = entry.book.id },
+                                    onMarkAsFinished = { viewModel.markAsFinished(entry.book.id) },
+                                    onToggleDownload = { viewModel.toggleDownload(entry.book.id) }
                                 )
                             }
 
@@ -898,6 +978,41 @@ fun AuthorDetailScreen(
                 }
             }
         }
+    }
+
+    val targetBookId = addToListBookId
+    if (!targetBookId.isNullOrBlank()) {
+        AddToListDialog(
+            uiState = collectionPickerUiState,
+            onDismiss = {
+                addToListBookId = null
+                collectionPickerViewModel.clearMessages()
+            },
+            onAddToExistingCollection = { collectionId ->
+                collectionPickerViewModel.addBookToExistingCollection(
+                    bookId = targetBookId,
+                    collectionId = collectionId
+                )
+            },
+            onCreateCollection = { name ->
+                collectionPickerViewModel.createCollectionAndAddBook(
+                    bookId = targetBookId,
+                    name = name
+                )
+            },
+            onAddToExistingPlaylist = { playlistId ->
+                collectionPickerViewModel.addBookToExistingPlaylist(
+                    bookId = targetBookId,
+                    playlistId = playlistId
+                )
+            },
+            onCreatePlaylist = { name ->
+                collectionPickerViewModel.createPlaylistAndAddBook(
+                    bookId = targetBookId,
+                    name = name
+                )
+            }
+        )
     }
 }
 
@@ -1087,9 +1202,14 @@ private fun AuthorGridBookItem(
     book: BookSummary,
     isDownloaded: Boolean,
     downloadProgressPercent: Int?,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    onAddToCollection: () -> Unit,
+    onMarkAsFinished: () -> Unit,
+    onToggleDownload: () -> Unit
 ) {
     var menuExpanded by remember { mutableStateOf(false) }
+    val hasActiveDownload = downloadProgressPercent != null && downloadProgressPercent in 0..99
+    val downloadLabel = if (isDownloaded || hasActiveDownload) "Remove Download" else "Download"
     Column(
         modifier = Modifier.clickable(onClick = onClick),
         verticalArrangement = Arrangement.spacedBy(6.dp)
@@ -1144,16 +1264,25 @@ private fun AuthorGridBookItem(
                     onDismissRequest = { menuExpanded = false }
                 ) {
                     DropdownMenuItem(
-                        text = { Text("Download") },
-                        onClick = { menuExpanded = false }
+                        text = { Text(downloadLabel) },
+                        onClick = {
+                            menuExpanded = false
+                            onToggleDownload()
+                        }
                     )
                     DropdownMenuItem(
                         text = { Text("Mark as Finished") },
-                        onClick = { menuExpanded = false }
+                        onClick = {
+                            menuExpanded = false
+                            onMarkAsFinished()
+                        }
                     )
                     DropdownMenuItem(
                         text = { Text("Add to Collection") },
-                        onClick = { menuExpanded = false }
+                        onClick = {
+                            menuExpanded = false
+                            onAddToCollection()
+                        }
                     )
                 }
             }
@@ -1238,8 +1367,14 @@ private fun AuthorBookRow(
     book: BookSummary,
     isDownloaded: Boolean,
     downloadProgressPercent: Int?,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    onAddToCollection: () -> Unit,
+    onMarkAsFinished: () -> Unit,
+    onToggleDownload: () -> Unit
 ) {
+    var menuExpanded by remember { mutableStateOf(false) }
+    val hasActiveDownload = downloadProgressPercent != null && downloadProgressPercent in 0..99
+    val downloadLabel = if (isDownloaded || hasActiveDownload) "Remove Download" else "Download"
     Card(
         shape = RoundedCornerShape(10.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
@@ -1295,11 +1430,44 @@ private fun AuthorBookRow(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
-            Icon(
-                imageVector = Icons.Outlined.MoreHoriz,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+            Box {
+                IconButton(
+                    onClick = { menuExpanded = true },
+                    modifier = Modifier.size(24.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.MoreHoriz,
+                        contentDescription = "Book actions",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                DropdownMenu(
+                    expanded = menuExpanded,
+                    onDismissRequest = { menuExpanded = false }
+                ) {
+                    DropdownMenuItem(
+                        text = { Text(downloadLabel) },
+                        onClick = {
+                            menuExpanded = false
+                            onToggleDownload()
+                        }
+                    )
+                    DropdownMenuItem(
+                        text = { Text("Mark as Finished") },
+                        onClick = {
+                            menuExpanded = false
+                            onMarkAsFinished()
+                        }
+                    )
+                    DropdownMenuItem(
+                        text = { Text("Add to Collection") },
+                        onClick = {
+                            menuExpanded = false
+                            onAddToCollection()
+                        }
+                    )
+                }
+            }
         }
     }
 }
@@ -1712,10 +1880,12 @@ class CollectionDetailViewModel @Inject constructor(
 ) : ViewModel() {
     private val collectionId = savedStateHandle.get<String>(DetailRoute.COLLECTION_ID_ARG).orEmpty()
     private val collectionName = savedStateHandle.get<String>(DetailRoute.COLLECTION_NAME_ARG).orEmpty()
+    private val initialBooks = FacetBooksMemoryCache.collectionBooks(collectionId)
     private val mutableUiState = MutableStateFlow(
         FacetBooksUiState(
-            isLoading = true,
-            title = collectionName.ifBlank { "Collection" }
+            isLoading = initialBooks.isEmpty(),
+            title = collectionName.ifBlank { "Collection" },
+            books = initialBooks
         )
     )
     val uiState: StateFlow<FacetBooksUiState> = mutableUiState.asStateFlow()
@@ -1726,7 +1896,7 @@ class CollectionDetailViewModel @Inject constructor(
         viewModelScope.launch {
             mutableListMode.value = sessionPreferences.state.first().collectionDetailListMode
         }
-        refresh(forceRefresh = false)
+        refresh(forceRefresh = false, showLoader = initialBooks.isEmpty())
     }
 
     fun setListMode(value: Boolean) {
@@ -1737,7 +1907,7 @@ class CollectionDetailViewModel @Inject constructor(
     }
 
     fun refresh() {
-        refresh(forceRefresh = true)
+        refresh(forceRefresh = true, showLoader = true)
     }
 
     fun removeBook(bookId: String) {
@@ -1751,8 +1921,10 @@ class CollectionDetailViewModel @Inject constructor(
             ) {
                 is AppResult.Success -> {
                     mutableUiState.update {
+                        val updatedBooks = it.books.filterNot { book -> book.id == bookId }
+                        FacetBooksMemoryCache.updateCollectionBooks(collectionId, updatedBooks)
                         it.copy(
-                            books = it.books.filterNot { book -> book.id == bookId },
+                            books = updatedBooks,
                             actionMessage = "Removed from collection."
                         )
                     }
@@ -1769,14 +1941,19 @@ class CollectionDetailViewModel @Inject constructor(
         mutableUiState.update { it.copy(actionMessage = null) }
     }
 
-    private fun refresh(forceRefresh: Boolean) {
+    private fun refresh(forceRefresh: Boolean, showLoader: Boolean) {
         if (collectionId.isBlank()) {
             mutableUiState.update {
                 it.copy(isLoading = false, errorMessage = "Invalid collection.")
             }
             return
         }
-        mutableUiState.update { it.copy(isLoading = true, errorMessage = null) }
+        mutableUiState.update {
+            it.copy(
+                isLoading = showLoader,
+                errorMessage = null
+            )
+        }
         viewModelScope.launch {
             when (
                 val result = sessionRepository.fetchCollectionBooks(
@@ -1785,19 +1962,22 @@ class CollectionDetailViewModel @Inject constructor(
                 )
             ) {
                 is AppResult.Success -> {
+                    FacetBooksMemoryCache.updateCollectionBooks(collectionId, result.value)
                     mutableUiState.update {
                         it.copy(
                             isLoading = false,
-                            books = result.value
+                            books = result.value,
+                            errorMessage = null
                         )
                     }
                 }
 
                 is AppResult.Error -> {
                     mutableUiState.update {
+                        val shouldShowError = showLoader || it.books.isEmpty()
                         it.copy(
                             isLoading = false,
-                            errorMessage = result.message
+                            errorMessage = if (shouldShowError) result.message else null
                         )
                     }
                 }
@@ -1935,10 +2115,12 @@ class PlaylistDetailViewModel @Inject constructor(
 ) : ViewModel() {
     private val playlistId = savedStateHandle.get<String>(DetailRoute.PLAYLIST_ID_ARG).orEmpty()
     private val playlistName = savedStateHandle.get<String>(DetailRoute.PLAYLIST_NAME_ARG).orEmpty()
+    private val initialBooks = FacetBooksMemoryCache.playlistBooks(playlistId)
     private val mutableUiState = MutableStateFlow(
         FacetBooksUiState(
-            isLoading = true,
-            title = playlistName.ifBlank { "Playlist" }
+            isLoading = initialBooks.isEmpty(),
+            title = playlistName.ifBlank { "Playlist" },
+            books = initialBooks
         )
     )
     val uiState: StateFlow<FacetBooksUiState> = mutableUiState.asStateFlow()
@@ -1949,7 +2131,7 @@ class PlaylistDetailViewModel @Inject constructor(
         viewModelScope.launch {
             mutableListMode.value = sessionPreferences.state.first().playlistDetailListMode
         }
-        refresh(forceRefresh = false)
+        refresh(forceRefresh = false, showLoader = initialBooks.isEmpty())
     }
 
     fun setListMode(value: Boolean) {
@@ -1960,7 +2142,7 @@ class PlaylistDetailViewModel @Inject constructor(
     }
 
     fun refresh() {
-        refresh(forceRefresh = true)
+        refresh(forceRefresh = true, showLoader = true)
     }
 
     fun removeBook(bookId: String) {
@@ -1975,6 +2157,7 @@ class PlaylistDetailViewModel @Inject constructor(
             ) {
                 is AppResult.Success -> {
                     if (wasLastVisibleBook) {
+                        FacetBooksMemoryCache.updatePlaylistBooks(playlistId, emptyList())
                         mutableUiState.update {
                             it.copy(
                                 isLoading = false,
@@ -1984,12 +2167,16 @@ class PlaylistDetailViewModel @Inject constructor(
                             )
                         }
                     } else {
+                        val updatedBooks = uiState.value.books.filterNot { book -> book.id == bookId }
+                        FacetBooksMemoryCache.updatePlaylistBooks(playlistId, updatedBooks)
                         mutableUiState.update {
                             it.copy(
+                                books = updatedBooks,
+                                errorMessage = null,
                                 actionMessage = "Removed from playlist."
                             )
                         }
-                        refresh(forceRefresh = true)
+                        refresh(forceRefresh = true, showLoader = false)
                     }
                 }
 
@@ -2004,14 +2191,19 @@ class PlaylistDetailViewModel @Inject constructor(
         mutableUiState.update { it.copy(actionMessage = null) }
     }
 
-    private fun refresh(forceRefresh: Boolean) {
+    private fun refresh(forceRefresh: Boolean, showLoader: Boolean) {
         if (playlistId.isBlank()) {
             mutableUiState.update {
                 it.copy(isLoading = false, errorMessage = "Invalid playlist.")
             }
             return
         }
-        mutableUiState.update { it.copy(isLoading = true, errorMessage = null) }
+        mutableUiState.update {
+            it.copy(
+                isLoading = showLoader,
+                errorMessage = null
+            )
+        }
         viewModelScope.launch {
             when (
                 val result = sessionRepository.fetchPlaylistBooks(
@@ -2020,25 +2212,53 @@ class PlaylistDetailViewModel @Inject constructor(
                 )
             ) {
                 is AppResult.Success -> {
+                    FacetBooksMemoryCache.updatePlaylistBooks(playlistId, result.value)
                     mutableUiState.update {
                         it.copy(
                             isLoading = false,
-                            books = result.value
+                            books = result.value,
+                            errorMessage = null
                         )
                     }
                 }
 
                 is AppResult.Error -> {
-                    val treatAsEmpty = result.message.contains("404") && uiState.value.books.isEmpty()
                     mutableUiState.update {
+                        val treatAsEmpty = result.message.contains("404") && it.books.isEmpty()
+                        val shouldShowError = (showLoader || it.books.isEmpty()) && !treatAsEmpty
                         it.copy(
                             isLoading = false,
-                            errorMessage = if (treatAsEmpty) null else result.message
+                            errorMessage = if (shouldShowError) result.message else null
                         )
                     }
                 }
             }
         }
+    }
+}
+
+private object FacetBooksMemoryCache {
+    private val collectionBooksById = mutableMapOf<String, List<BookSummary>>()
+    private val playlistBooksById = mutableMapOf<String, List<BookSummary>>()
+
+    @Synchronized
+    fun collectionBooks(collectionId: String): List<BookSummary> {
+        return collectionBooksById[collectionId].orEmpty()
+    }
+
+    @Synchronized
+    fun playlistBooks(playlistId: String): List<BookSummary> {
+        return playlistBooksById[playlistId].orEmpty()
+    }
+
+    @Synchronized
+    fun updateCollectionBooks(collectionId: String, books: List<BookSummary>) {
+        collectionBooksById[collectionId] = books
+    }
+
+    @Synchronized
+    fun updatePlaylistBooks(playlistId: String, books: List<BookSummary>) {
+        playlistBooksById[playlistId] = books
     }
 }
 

--- a/app/src/main/java/com/stillshelf/app/ui/screens/PlaceholderScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/PlaceholderScreens.kt
@@ -4,6 +4,9 @@ import android.graphics.Bitmap
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.MarqueeSpacing
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.draggable
@@ -21,6 +24,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -43,6 +47,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
@@ -54,6 +59,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.MenuBook
 import androidx.compose.material.icons.automirrored.outlined.ViewList
+import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.BookmarkBorder
@@ -123,15 +129,18 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -158,6 +167,7 @@ import coil.request.ImageRequest
 import coil.imageLoader
 import com.stillshelf.app.core.network.authorizationHeaderValue
 import com.stillshelf.app.core.network.splitAuthenticatedUrl
+import com.stillshelf.app.core.model.BookBookmark
 import com.stillshelf.app.core.model.BookSummary
 import com.stillshelf.app.core.model.BookChapter
 import com.stillshelf.app.core.model.ContinueListeningItem
@@ -171,9 +181,14 @@ import com.stillshelf.app.ui.navigation.BrowseRoute
 import com.stillshelf.app.ui.navigation.MainRoute
 import com.stillshelf.app.ui.navigation.MainTab
 import com.stillshelf.app.ui.theme.AppThemeMode
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 import kotlin.math.max
 import kotlin.math.sin
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 
 private data class LibraryListItem(
@@ -196,12 +211,15 @@ enum class BooksStatusFilter(val label: String) {
     NotFinished("Not Finished")
 }
 
-enum class BooksSortKey(val label: String) {
-    Title("Title"),
-    Author("Author"),
-    PublicationDate("Publication Date"),
-    DateAdded("Date Added"),
-    Duration("Duration")
+enum class BooksSortKey(
+    val label: String,
+    val hint: String
+) {
+    Title(label = "Title", hint = "A - Z"),
+    Author(label = "Author", hint = "A - Z"),
+    PublicationDate(label = "Publication Date", hint = "Newest first"),
+    DateAdded(label = "Date Added", hint = "Newest first"),
+    Duration(label = "Duration", hint = "Longest first")
 }
 
 private val BackTitleSpacing = 12.dp
@@ -314,7 +332,7 @@ fun HomePlaceholderScreen(
     }
     LaunchedEffect(addToListBookId) {
         if (!addToListBookId.isNullOrBlank()) {
-            collectionPickerViewModel.loadDestinations(forceRefresh = true)
+            collectionPickerViewModel.loadDestinations(forceRefresh = false)
         }
     }
     LaunchedEffect(collectionPickerUiState.actionMessage) {
@@ -908,7 +926,7 @@ fun BrowsePlaceholderScreen(
     }
     LaunchedEffect(collectionPickerBookId) {
         if (!collectionPickerBookId.isNullOrBlank()) {
-            collectionPickerViewModel.loadDestinations(forceRefresh = true)
+            collectionPickerViewModel.loadDestinations(forceRefresh = false)
         }
     }
     LaunchedEffect(collectionPickerUiState.actionMessage) {
@@ -1016,10 +1034,22 @@ fun BrowsePlaceholderScreen(
                     )
                     HorizontalDivider()
                     BooksSortKey.entries.forEach { option ->
+                        val isSelected = uiState.sortKey == option
                         DropdownMenuItem(
-                            text = { Text(option.label) },
+                            text = {
+                                Column(verticalArrangement = Arrangement.spacedBy(1.dp)) {
+                                    Text(option.label)
+                                    if (isSelected) {
+                                        Text(
+                                            text = option.hint,
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    }
+                                }
+                            },
                             trailingIcon = {
-                                if (uiState.sortKey == option) {
+                                if (isSelected) {
                                     Icon(imageVector = Icons.Filled.Check, contentDescription = null)
                                 }
                             },
@@ -1819,7 +1849,7 @@ fun CollectionsBrowseScreen(
         refreshing = uiState.isLoading && manualRefreshInProgress,
         onRefresh = {
             manualRefreshInProgress = true
-            viewModel.refresh()
+            viewModel.refreshLibrary()
         }
     )
     var renameTarget by remember { mutableStateOf<com.stillshelf.app.core.model.NamedEntitySummary?>(null) }
@@ -1838,7 +1868,7 @@ fun CollectionsBrowseScreen(
         lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
             viewModel.refresh()
             while (true) {
-                kotlinx.coroutines.delay(5_000L)
+                kotlinx.coroutines.delay(1_000L)
                 viewModel.refresh()
             }
         }
@@ -1868,86 +1898,166 @@ fun CollectionsBrowseScreen(
         ) {
             when {
                 uiState.entities.isNotEmpty() -> {
-                    LazyColumn(
-                        verticalArrangement = Arrangement.spacedBy(0.dp),
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(minSize = 132.dp),
+                        horizontalArrangement = Arrangement.spacedBy(14.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
                         contentPadding = PaddingValues(bottom = 120.dp)
                     ) {
-                        items(uiState.entities, key = { it.id }) { collection ->
+                        gridItems(uiState.entities, key = { it.id }) { collection ->
                             var menuExpanded by remember { mutableStateOf(false) }
-                            Row(
+                            val coverStack = uiState.coverStackByCollectionId[collection.id].orEmpty()
+                            Column(
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .clickable { onCollectionClick(collection) }
-                                    .padding(vertical = 12.dp),
-                                verticalAlignment = Alignment.CenterVertically
+                                    .padding(bottom = 2.dp),
+                                verticalArrangement = Arrangement.spacedBy(6.dp)
                             ) {
-                                Column(modifier = Modifier.weight(1f)) {
-                                    Text(
-                                        text = collection.name,
-                                        style = MaterialTheme.typography.titleMedium,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis
-                                    )
-                                    collection.subtitle?.takeIf { it.isNotBlank() }?.let { subtitle ->
-                                        Text(
-                                            text = subtitle,
-                                            style = MaterialTheme.typography.bodySmall,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                            maxLines = 1,
-                                            overflow = TextOverflow.Ellipsis
-                                        )
-                                    }
-                                }
-                                Box {
-                                    IconButton(
-                                        onClick = { menuExpanded = true },
-                                        modifier = Modifier.size(28.dp)
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.Outlined.MoreHoriz,
-                                            contentDescription = "Collection actions",
-                                            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                                        )
-                                    }
-                                    DropdownMenu(
-                                        expanded = menuExpanded,
-                                        onDismissRequest = { menuExpanded = false }
-                                    ) {
-                                        DropdownMenuItem(
-                                            text = { Text("Rename") },
-                                            onClick = {
-                                                menuExpanded = false
-                                                nameInput = collection.name
-                                                renameTarget = collection
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .height(186.dp)
+                                        .clip(RoundedCornerShape(10.dp))
+                                        .background(MaterialTheme.colorScheme.surfaceContainerLow)
+                                ) {
+                                    if (coverStack.isNotEmpty()) {
+                                        val frontCover = coverStack.getOrNull(0)
+                                        val backCoverLeft = coverStack.getOrNull(1)
+                                        val backCoverRight = coverStack.getOrNull(2)
+                                        val coverShape = RoundedCornerShape(8.dp)
+                                        val layerWidth = 102.dp
+                                        val layerHeight = 154.dp
+
+                                        Box(
+                                            modifier = Modifier.fillMaxSize(),
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            backCoverRight?.let { coverUrl ->
+                                                FramedCoverImage(
+                                                    coverUrl = coverUrl,
+                                                    contentDescription = null,
+                                                    modifier = Modifier
+                                                        .offset(x = 14.dp, y = (-8).dp)
+                                                        .width(layerWidth)
+                                                        .height(layerHeight)
+                                                        .graphicsLayer(alpha = 0.7f),
+                                                    shape = coverShape,
+                                                    contentScale = ContentScale.Crop,
+                                                    backgroundBlur = WideCoverBackgroundBlur
+                                                )
                                             }
-                                        )
-                                        DropdownMenuItem(
-                                            text = { Text("Delete") },
-                                            onClick = {
-                                                menuExpanded = false
-                                                deleteTarget = collection
+                                            backCoverLeft?.let { coverUrl ->
+                                                FramedCoverImage(
+                                                    coverUrl = coverUrl,
+                                                    contentDescription = null,
+                                                    modifier = Modifier
+                                                        .offset(x = (-14).dp, y = (-8).dp)
+                                                        .width(layerWidth)
+                                                        .height(layerHeight)
+                                                        .graphicsLayer(alpha = 0.7f),
+                                                    shape = coverShape,
+                                                    contentScale = ContentScale.Crop,
+                                                    backgroundBlur = WideCoverBackgroundBlur
+                                                )
                                             }
-                                        )
+                                            frontCover?.let { coverUrl ->
+                                                FramedCoverImage(
+                                                    coverUrl = coverUrl,
+                                                    contentDescription = collection.name,
+                                                    modifier = Modifier
+                                                        .offset(y = 4.dp)
+                                                        .width(layerWidth)
+                                                        .height(layerHeight)
+                                                        .shadow(
+                                                            elevation = 3.dp,
+                                                            shape = coverShape,
+                                                            clip = false
+                                                        ),
+                                                    shape = coverShape,
+                                                    contentScale = ContentScale.Crop,
+                                                    backgroundBlur = WideCoverBackgroundBlur
+                                                )
+                                            }
+                                        }
+                                    } else {
+                                        Box(
+                                            modifier = Modifier
+                                                .fillMaxSize()
+                                                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.32f)),
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Outlined.CollectionsBookmark,
+                                                contentDescription = null,
+                                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                modifier = Modifier.size(40.dp)
+                                            )
+                                        }
                                     }
+
                                 }
-                                Spacer(modifier = Modifier.width(4.dp))
-                                Icon(
-                                    imageVector = Icons.Outlined.ChevronRight,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+
+                                Text(
+                                    text = collection.name,
+                                    style = MaterialTheme.typography.titleMedium,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
                                 )
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                ) {
+                                    Text(
+                                        text = collection.subtitle.orEmpty(),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        modifier = Modifier.weight(1f)
+                                    )
+                                    Box {
+                                        Box(
+                                            modifier = Modifier
+                                                .size(width = 34.dp, height = 24.dp)
+                                                .clip(RoundedCornerShape(8.dp))
+                                                .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.88f))
+                                                .clickable { menuExpanded = true },
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Outlined.MoreHoriz,
+                                                contentDescription = "Collection actions",
+                                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                modifier = Modifier.size(16.dp)
+                                            )
+                                        }
+                                        DropdownMenu(
+                                            expanded = menuExpanded,
+                                            onDismissRequest = { menuExpanded = false }
+                                        ) {
+                                            DropdownMenuItem(
+                                                text = { Text("Rename") },
+                                                onClick = {
+                                                    menuExpanded = false
+                                                    nameInput = collection.name
+                                                    renameTarget = collection
+                                                }
+                                            )
+                                            DropdownMenuItem(
+                                                text = { Text("Delete") },
+                                                onClick = {
+                                                    menuExpanded = false
+                                                    deleteTarget = collection
+                                                }
+                                            )
+                                        }
+                                    }
+                                }
                             }
-                            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.35f))
                         }
                     }
-                }
-
-                uiState.isLoading -> {
-                    Text(
-                        text = "Loading collections...",
-                        modifier = Modifier.align(Alignment.Center),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
                 }
 
                 else -> {
@@ -1956,6 +2066,22 @@ fun CollectionsBrowseScreen(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.spacedBy(6.dp)
                     ) {
+                        if (uiState.errorMessage == null) {
+                            Box(
+                                modifier = Modifier
+                                    .size(56.dp)
+                                    .clip(RoundedCornerShape(14.dp))
+                                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Outlined.CollectionsBookmark,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.size(30.dp)
+                                )
+                            }
+                        }
                         Text(
                             text = uiState.errorMessage ?: "No collections yet.",
                             style = MaterialTheme.typography.bodyLarge,
@@ -2052,7 +2178,7 @@ fun PlaylistsBrowseScreen(
         refreshing = uiState.isLoading && manualRefreshInProgress,
         onRefresh = {
             manualRefreshInProgress = true
-            viewModel.refresh()
+            viewModel.refreshLibrary()
         }
     )
     var createDialogVisible by remember { mutableStateOf(false) }
@@ -2072,7 +2198,7 @@ fun PlaylistsBrowseScreen(
         lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
             viewModel.refresh()
             while (true) {
-                kotlinx.coroutines.delay(5_000L)
+                kotlinx.coroutines.delay(1_000L)
                 viewModel.refresh()
             }
         }
@@ -2110,86 +2236,165 @@ fun PlaylistsBrowseScreen(
         ) {
             when {
                 uiState.entities.isNotEmpty() -> {
-                    LazyColumn(
-                        verticalArrangement = Arrangement.spacedBy(0.dp),
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(minSize = 132.dp),
+                        horizontalArrangement = Arrangement.spacedBy(14.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
                         contentPadding = PaddingValues(bottom = 120.dp)
                     ) {
-                        items(uiState.entities, key = { it.id }) { playlist ->
+                        gridItems(uiState.entities, key = { it.id }) { playlist ->
                             var menuExpanded by remember { mutableStateOf(false) }
-                            Row(
+                            val coverStack = uiState.coverStackByCollectionId[playlist.id].orEmpty()
+                            Column(
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .clickable { onPlaylistClick(playlist) }
-                                    .padding(vertical = 12.dp),
-                                verticalAlignment = Alignment.CenterVertically
+                                    .padding(bottom = 2.dp),
+                                verticalArrangement = Arrangement.spacedBy(6.dp)
                             ) {
-                                Column(modifier = Modifier.weight(1f)) {
-                                    Text(
-                                        text = playlist.name,
-                                        style = MaterialTheme.typography.titleMedium,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis
-                                    )
-                                    playlist.subtitle?.takeIf { it.isNotBlank() }?.let { subtitle ->
-                                        Text(
-                                            text = subtitle,
-                                            style = MaterialTheme.typography.bodySmall,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                            maxLines = 1,
-                                            overflow = TextOverflow.Ellipsis
-                                        )
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .height(186.dp)
+                                        .clip(RoundedCornerShape(10.dp))
+                                        .background(MaterialTheme.colorScheme.surfaceContainerLow)
+                                ) {
+                                    if (coverStack.isNotEmpty()) {
+                                        val frontCover = coverStack.getOrNull(0)
+                                        val backCoverLeft = coverStack.getOrNull(1)
+                                        val backCoverRight = coverStack.getOrNull(2)
+                                        val coverShape = RoundedCornerShape(8.dp)
+                                        val layerWidth = 102.dp
+                                        val layerHeight = 154.dp
+
+                                        Box(
+                                            modifier = Modifier.fillMaxSize(),
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            backCoverRight?.let { coverUrl ->
+                                                FramedCoverImage(
+                                                    coverUrl = coverUrl,
+                                                    contentDescription = null,
+                                                    modifier = Modifier
+                                                        .offset(x = 14.dp, y = (-8).dp)
+                                                        .width(layerWidth)
+                                                        .height(layerHeight)
+                                                        .graphicsLayer(alpha = 0.7f),
+                                                    shape = coverShape,
+                                                    contentScale = ContentScale.Crop,
+                                                    backgroundBlur = WideCoverBackgroundBlur
+                                                )
+                                            }
+                                            backCoverLeft?.let { coverUrl ->
+                                                FramedCoverImage(
+                                                    coverUrl = coverUrl,
+                                                    contentDescription = null,
+                                                    modifier = Modifier
+                                                        .offset(x = (-14).dp, y = (-8).dp)
+                                                        .width(layerWidth)
+                                                        .height(layerHeight)
+                                                        .graphicsLayer(alpha = 0.7f),
+                                                    shape = coverShape,
+                                                    contentScale = ContentScale.Crop,
+                                                    backgroundBlur = WideCoverBackgroundBlur
+                                                )
+                                            }
+                                            frontCover?.let { coverUrl ->
+                                                FramedCoverImage(
+                                                    coverUrl = coverUrl,
+                                                    contentDescription = playlist.name,
+                                                    modifier = Modifier
+                                                        .offset(y = 4.dp)
+                                                        .width(layerWidth)
+                                                        .height(layerHeight)
+                                                        .shadow(
+                                                            elevation = 3.dp,
+                                                            shape = coverShape,
+                                                            clip = false
+                                                        ),
+                                                    shape = coverShape,
+                                                    contentScale = ContentScale.Crop,
+                                                    backgroundBlur = WideCoverBackgroundBlur
+                                                )
+                                            }
+                                        }
+                                    } else {
+                                        Box(
+                                            modifier = Modifier
+                                                .fillMaxSize()
+                                                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.32f)),
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Outlined.MusicNote,
+                                                contentDescription = null,
+                                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                modifier = Modifier.size(40.dp)
+                                            )
+                                        }
                                     }
                                 }
-                                Box {
-                                    IconButton(
-                                        onClick = { menuExpanded = true },
-                                        modifier = Modifier.size(28.dp)
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.Outlined.MoreHoriz,
-                                            contentDescription = "Playlist actions",
-                                            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                                        )
-                                    }
-                                    DropdownMenu(
-                                        expanded = menuExpanded,
-                                        onDismissRequest = { menuExpanded = false }
-                                    ) {
-                                        DropdownMenuItem(
-                                            text = { Text("Rename") },
-                                            onClick = {
-                                                menuExpanded = false
-                                                nameInput = playlist.name
-                                                renameTarget = playlist
-                                            }
-                                        )
-                                        DropdownMenuItem(
-                                            text = { Text("Delete") },
-                                            onClick = {
-                                                menuExpanded = false
-                                                deleteTarget = playlist
-                                            }
-                                        )
-                                    }
-                                }
-                                Spacer(modifier = Modifier.width(4.dp))
-                                Icon(
-                                    imageVector = Icons.Outlined.ChevronRight,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+
+                                Text(
+                                    text = playlist.name,
+                                    style = MaterialTheme.typography.titleMedium,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
                                 )
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                ) {
+                                    Text(
+                                        text = playlist.subtitle.orEmpty(),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        modifier = Modifier.weight(1f)
+                                    )
+                                    Box {
+                                        Box(
+                                            modifier = Modifier
+                                                .size(width = 34.dp, height = 24.dp)
+                                                .clip(RoundedCornerShape(8.dp))
+                                                .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.88f))
+                                                .clickable { menuExpanded = true },
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Outlined.MoreHoriz,
+                                                contentDescription = "Playlist actions",
+                                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                modifier = Modifier.size(16.dp)
+                                            )
+                                        }
+                                        DropdownMenu(
+                                            expanded = menuExpanded,
+                                            onDismissRequest = { menuExpanded = false }
+                                        ) {
+                                            DropdownMenuItem(
+                                                text = { Text("Rename") },
+                                                onClick = {
+                                                    menuExpanded = false
+                                                    nameInput = playlist.name
+                                                    renameTarget = playlist
+                                                }
+                                            )
+                                            DropdownMenuItem(
+                                                text = { Text("Delete") },
+                                                onClick = {
+                                                    menuExpanded = false
+                                                    deleteTarget = playlist
+                                                }
+                                            )
+                                        }
+                                    }
+                                }
                             }
-                            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.35f))
                         }
                     }
-                }
-
-                uiState.isLoading -> {
-                    Text(
-                        text = "Loading playlists...",
-                        modifier = Modifier.align(Alignment.Center),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
                 }
 
                 else -> {
@@ -2198,6 +2403,22 @@ fun PlaylistsBrowseScreen(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.spacedBy(10.dp)
                     ) {
+                        if (uiState.errorMessage == null) {
+                            Box(
+                                modifier = Modifier
+                                    .size(56.dp)
+                                    .clip(RoundedCornerShape(14.dp))
+                                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Outlined.MusicNote,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.size(30.dp)
+                                )
+                            }
+                        }
                         Text(
                             text = uiState.errorMessage ?: "No playlists yet.",
                             style = MaterialTheme.typography.bodyLarge,
@@ -3990,7 +4211,7 @@ fun BookDetailScreen(
     }
     LaunchedEffect(addToListBookId) {
         if (!addToListBookId.isNullOrBlank()) {
-            collectionPickerViewModel.loadDestinations(forceRefresh = true)
+            collectionPickerViewModel.loadDestinations(forceRefresh = false)
         }
     }
     LaunchedEffect(collectionPickerUiState.actionMessage) {
@@ -4080,13 +4301,6 @@ fun BookDetailScreen(
                                 actionsExpanded = false
                             }
                         )
-                        DropdownMenuItem(
-                            text = { Text("Go to Book") },
-                            onClick = {
-                                infoMessage = "Already viewing this book."
-                                actionsExpanded = false
-                            }
-                        )
                     }
                 }
             }
@@ -4131,6 +4345,25 @@ fun BookDetailScreen(
                     serverPlaybackSeconds > 0.5 ||
                     (uiState.progressPercent ?: 0.0) > 0.001
                 val listenLabel = if (hasProgress) "Continue Listening" else "Start Listening"
+                val listenProgressFraction = run {
+                    val duration = when {
+                        book.durationSeconds != null && book.durationSeconds > 0.0 -> book.durationSeconds
+                        playbackUiState.book?.id == book.id && playbackUiState.durationMs > 0L -> {
+                            playbackUiState.durationMs / 1000.0
+                        }
+                        else -> null
+                    }
+                    val resolved = when {
+                        duration != null && duration > 0.0 && livePlaybackSeconds > 0.0 -> {
+                            (livePlaybackSeconds / duration).coerceIn(0.0, 1.0)
+                        }
+                        duration != null && duration > 0.0 && serverPlaybackSeconds > 0.0 -> {
+                            (serverPlaybackSeconds / duration).coerceIn(0.0, 1.0)
+                        }
+                        else -> (uiState.progressPercent ?: 0.0).coerceIn(0.0, 1.0)
+                    }
+                    resolved.toFloat().coerceIn(0f, 1f)
+                }
                 val chapterPositionSeconds = if (playbackUiState.book?.id == book.id) {
                     (playbackUiState.positionMs.coerceAtLeast(0L) / 1000.0)
                 } else {
@@ -4231,21 +4464,29 @@ fun BookDetailScreen(
                     }
                 }
                 item {
-                    Button(
-                        onClick = { onStartListening(book.id) },
-                        modifier = Modifier.fillMaxWidth(),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.onSurface,
-                            contentColor = MaterialTheme.colorScheme.surface
+                    if (hasProgress) {
+                        BookListenProgressButton(
+                            text = listenLabel,
+                            progress = listenProgressFraction,
+                            onClick = { onStartListening(book.id) }
                         )
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.PlayArrow,
-                            contentDescription = null,
-                            modifier = Modifier.size(16.dp)
-                        )
-                        Spacer(modifier = Modifier.width(6.dp))
-                        Text(listenLabel)
+                    } else {
+                        Button(
+                            onClick = { onStartListening(book.id) },
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.onSurface,
+                                contentColor = MaterialTheme.colorScheme.surface
+                            )
+                        ) {
+                            Icon(
+                                imageVector = Icons.Outlined.PlayArrow,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp)
+                            )
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Text(listenLabel)
+                        }
                     }
                 }
                 item {
@@ -4453,19 +4694,25 @@ fun BookDetailScreen(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun PlayerPlaceholderScreen(
     onBackClick: (() -> Unit)? = null,
     viewModel: PlayerViewModel = hiltViewModel(),
     appearanceViewModel: AppAppearanceViewModel = hiltViewModel()
 ) {
+    val context = LocalContext.current
+    val hapticFeedback = LocalHapticFeedback.current
     val playbackUiState by viewModel.uiState.collectAsStateWithLifecycle()
     val previewItem by viewModel.previewItem.collectAsStateWithLifecycle()
     val chapters by viewModel.chapters.collectAsStateWithLifecycle()
+    val bookmarks by viewModel.bookmarks.collectAsStateWithLifecycle()
+    val actionMessage by viewModel.actionMessage.collectAsStateWithLifecycle()
     val controlPrefs by viewModel.controlPrefs.collectAsStateWithLifecycle()
     val appearanceUiState by appearanceViewModel.uiState.collectAsStateWithLifecycle()
     val book = playbackUiState.book ?: previewItem?.book
     val durationSeconds = when {
+        book?.durationSeconds != null && book.durationSeconds > 0.0 -> book.durationSeconds
         playbackUiState.durationMs > 0L -> playbackUiState.durationMs / 1000.0
         else -> previewItem?.book?.durationSeconds ?: 0.0
     }
@@ -4528,6 +4775,15 @@ fun PlayerPlaceholderScreen(
     var dragDistance by remember { mutableStateOf(0f) }
     var bottomMenuExpanded by remember { mutableStateOf(false) }
     var playerInfoMessage by remember { mutableStateOf<String?>(null) }
+    var bookmarkFeedbackActive by remember { mutableStateOf(false) }
+    val bookmarkIconScale by animateFloatAsState(
+        targetValue = if (bookmarkFeedbackActive) 1.18f else 1f,
+        animationSpec = tween(durationMillis = 130),
+        label = "bookmark-icon-feedback"
+    )
+    val chapterSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+    var showChapterSheet by rememberSaveable { mutableStateOf(false) }
+    var chapterSheetTab by rememberSaveable { mutableStateOf(PlayerSheetTab.Chapters) }
     val speeds = remember { listOf(0.8f, 1.0f, 1.3f, 1.5f, 1.8f, 2.0f) }
     var speedIndex by rememberSaveable { mutableStateOf(2) }
     val speedLabel = "${speeds[speedIndex]}x"
@@ -4562,13 +4818,28 @@ fun PlayerPlaceholderScreen(
     val effectiveHeightDp = (configuration.screenHeightDp.toFloat() / density.fontScale).coerceAtLeast(520f)
     val playerHorizontalPadding = (effectiveHeightDp * 0.025f).dp.coerceIn(14.dp, 20.dp)
     val playerVerticalPadding = (effectiveHeightDp * 0.015f).dp.coerceIn(8.dp, 16.dp)
-    val adaptiveLargeGap = (effectiveHeightDp * 0.05f).dp.coerceIn(26.dp, 44.dp)
+    val coverTopGap = (effectiveHeightDp * 0.03f).dp.coerceIn(16.dp, 24.dp)
+    val coverTitleGap = (effectiveHeightDp * 0.035f).dp.coerceIn(16.dp, 30.dp)
+    val titleProgressGap = coverTitleGap
     val progressMetaGap = (effectiveHeightDp * 0.012f).dp.coerceIn(8.dp, 14.dp)
     val coverTargetWidth = (effectiveHeightDp * 0.42f).dp.coerceIn(286.dp, 332.dp)
     val controlsRowPadding = (effectiveHeightDp * 0.04f).dp.coerceIn(24.dp, 38.dp)
     val bottomToolsTopPadding = (effectiveHeightDp * 0.012f).dp.coerceIn(8.dp, 14.dp)
     val bottomToolsBottomPadding = (effectiveHeightDp * 0.01f).dp.coerceIn(6.dp, 10.dp)
-    val playerTopOffset = (effectiveHeightDp * 0.01f).dp.coerceIn(4.dp, 10.dp)
+    val playerTopOffset = (effectiveHeightDp * 0.02f).dp.coerceIn(8.dp, 16.dp)
+
+    LaunchedEffect(actionMessage) {
+        val latest = actionMessage ?: return@LaunchedEffect
+        Toast.makeText(context, latest, Toast.LENGTH_SHORT).show()
+        viewModel.clearActionMessage()
+    }
+
+    LaunchedEffect(bookmarkFeedbackActive) {
+        if (bookmarkFeedbackActive) {
+            delay(160L)
+            bookmarkFeedbackActive = false
+        }
+    }
 
     Box(
         modifier = Modifier
@@ -4639,7 +4910,7 @@ fun PlayerPlaceholderScreen(
                 .clip(RoundedCornerShape(10.dp))
                 .background(MaterialTheme.colorScheme.outline.copy(alpha = 0.6f))
         )
-        Spacer(modifier = Modifier.height(playerTopOffset))
+        Spacer(modifier = Modifier.height(playerTopOffset + coverTopGap))
         if (book == null) {
             CenteredEmptyState(
                 icon = Icons.Outlined.PlayArrow,
@@ -4686,7 +4957,7 @@ fun PlayerPlaceholderScreen(
                 }
             }
         }
-        Spacer(modifier = Modifier.height(adaptiveLargeGap))
+        Spacer(modifier = Modifier.height(coverTitleGap))
         Box(
             modifier = Modifier.fillMaxWidth(),
             contentAlignment = Alignment.Center
@@ -4695,21 +4966,54 @@ fun PlayerPlaceholderScreen(
                 text = playerTitle,
                 style = MaterialTheme.typography.titleMedium,
                 color = primaryTextColor,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                textAlign = TextAlign.Center,
+                maxLines = 1,
+                softWrap = false,
+                overflow = TextOverflow.Visible,
+                textAlign = TextAlign.Start,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 48.dp)
+                    .clickable {
+                        chapterSheetTab = PlayerSheetTab.Chapters
+                        showChapterSheet = true
+                    }
+                    .basicMarquee(
+                        iterations = Int.MAX_VALUE,
+                        animationMode = androidx.compose.foundation.MarqueeAnimationMode.Immediately,
+                        repeatDelayMillis = 2000,
+                        initialDelayMillis = 1200,
+                        spacing = MarqueeSpacing(48.dp)
+                    )
             )
-            Icon(
-                imageVector = Icons.Outlined.BookmarkBorder,
-                contentDescription = "Bookmark",
-                tint = secondaryTextColor,
-                modifier = Modifier.align(Alignment.CenterEnd)
-            )
+            IconButton(
+                onClick = {
+                    bookmarkFeedbackActive = true
+                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                    viewModel.addBookmark(
+                        positionSeconds = positionSeconds,
+                        title = activeChapterTitle ?: playerTitle
+                    )
+                },
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .size(34.dp)
+                    .graphicsLayer {
+                        scaleX = bookmarkIconScale
+                        scaleY = bookmarkIconScale
+                    }
+            ) {
+                Icon(
+                    imageVector = if (bookmarkFeedbackActive) {
+                        Icons.Filled.Bookmark
+                    } else {
+                        Icons.Outlined.BookmarkBorder
+                    },
+                    contentDescription = "Bookmark",
+                    tint = secondaryTextColor
+                )
+            }
         }
-        Spacer(modifier = Modifier.height(adaptiveLargeGap))
+        Spacer(modifier = Modifier.height(titleProgressGap))
         PlayerProgressBar(
             progress = effectiveProgress,
             activeColor = progressActiveColor,
@@ -4748,6 +5052,10 @@ fun PlayerPlaceholderScreen(
             .coerceAtLeast(currentDisplaySeconds)
         val remainingDisplaySeconds = (chapterDisplayDurationSeconds - currentDisplaySeconds)
             .coerceAtLeast(0L)
+        val wholeBookProgressPercent = formatProgressPercentLabel(progress)
+        val wholeBookRemainingSeconds = (durationSeconds - positionSeconds)
+            .coerceAtLeast(0.0)
+            .toLong()
         val timeTextStyle = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace)
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -4758,15 +5066,15 @@ fun PlayerPlaceholderScreen(
                 style = timeTextStyle,
                 color = secondaryTextColor,
                 textAlign = TextAlign.Start,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.weight(0.75f),
                 maxLines = 1
             )
             Text(
-                text = "${formatDurationHoursMinutes(remainingDisplaySeconds.toDouble())} left · ${(chapterProgress * 100).toInt()}% complete",
-                style = MaterialTheme.typography.bodySmall,
+                text = "${formatHoursMinutesPrecise(wholeBookRemainingSeconds.toDouble())} left • $wholeBookProgressPercent complete",
+                style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
                 color = secondaryTextColor,
                 textAlign = TextAlign.Center,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.weight(1.5f),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
@@ -4775,7 +5083,7 @@ fun PlayerPlaceholderScreen(
                 style = timeTextStyle,
                 color = secondaryTextColor,
                 textAlign = TextAlign.End,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.weight(0.75f),
                 maxLines = 1
             )
         }
@@ -4903,6 +5211,400 @@ fun PlayerPlaceholderScreen(
             }
         }
         }
+
+        if (showChapterSheet && book != null) {
+            ModalBottomSheet(
+                onDismissRequest = { showChapterSheet = false },
+                sheetState = chapterSheetState,
+                dragHandle = null,
+                containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.94f)
+            ) {
+                PlayerChapterBookmarkSheet(
+                    book = book,
+                    chapters = chapters,
+                    bookmarks = bookmarks,
+                    selectedTab = chapterSheetTab,
+                    activeChapterIndex = activeChapterIndex,
+                    positionSeconds = positionSeconds,
+                    isPlaying = playbackUiState.isPlaying,
+                    timeLeftLabel = formatTimeLeftLabel(durationSeconds = durationSeconds, positionSeconds = positionSeconds),
+                    onSelectTab = { chapterSheetTab = it },
+                    onPlayChapter = { chapterStart ->
+                        viewModel.jumpToSeconds(chapterStart)
+                    },
+                    onPlayBookmark = { bookmarkSeconds ->
+                        viewModel.jumpToSeconds(bookmarkSeconds)
+                    }
+                )
+            }
+        }
+    }
+}
+
+private enum class PlayerSheetTab {
+    Chapters,
+    Bookmarks
+}
+
+@Composable
+private fun PlayerChapterBookmarkSheet(
+    book: BookSummary,
+    chapters: List<BookChapter>,
+    bookmarks: List<BookBookmark>,
+    selectedTab: PlayerSheetTab,
+    activeChapterIndex: Int,
+    positionSeconds: Double,
+    isPlaying: Boolean,
+    timeLeftLabel: String,
+    onSelectTab: (PlayerSheetTab) -> Unit,
+    onPlayChapter: (Double) -> Unit,
+    onPlayBookmark: (Double) -> Unit
+) {
+    val context = LocalContext.current
+    val density = LocalDensity.current
+    val configuration = LocalConfiguration.current
+    val screenHeightPx = with(density) { configuration.screenHeightDp.dp.toPx() }
+    val statusBarTopPx = remember(context) {
+        val resourceId = context.resources.getIdentifier("status_bar_height", "dimen", "android")
+        if (resourceId > 0) {
+            context.resources.getDimensionPixelSize(resourceId).toFloat()
+        } else {
+            0f
+        }
+    }
+    val sheetHeightFraction = if (screenHeightPx > 0f) {
+        ((screenHeightPx - statusBarTopPx) / screenHeightPx).coerceIn(0.82f, 0.97f)
+    } else {
+        0.93f
+    }
+    val sheetHandleTopGap = (configuration.screenHeightDp * 0.01f).dp.coerceIn(8.dp, 14.dp)
+    val sheetHandleTitleGap = (configuration.screenHeightDp * 0.008f).dp.coerceIn(8.dp, 12.dp)
+    val sortedBookmarks = remember(bookmarks) {
+        bookmarks.sortedWith(
+            compareByDescending<BookBookmark> { it.createdAtMs ?: Long.MIN_VALUE }
+                .thenBy { it.timeSeconds ?: Double.MAX_VALUE }
+        )
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .fillMaxHeight(sheetHeightFraction)
+            .navigationBarsPadding()
+            .padding(horizontal = 14.dp)
+            .padding(top = sheetHandleTopGap, bottom = 8.dp)
+    ) {
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center
+        ) {
+            Box(
+                modifier = Modifier
+                    .width(44.dp)
+                    .height(4.dp)
+                    .clip(RoundedCornerShape(100))
+                    .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f))
+            )
+        }
+        Spacer(modifier = Modifier.height(sheetHandleTitleGap))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+            ) {
+                BookPoster(
+                    book = book,
+                    width = 48.dp,
+                    height = 48.dp,
+                    fillMaxWidth = true,
+                    shape = RoundedCornerShape(8.dp),
+                    contentScale = ContentScale.Crop
+                )
+            }
+            Spacer(modifier = Modifier.width(10.dp))
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                Text(
+                    text = book.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = book.authorName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = timeLeftLabel,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(14.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.55f))
+                .padding(3.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            PlayerSheetTabButton(
+                title = "Chapters",
+                selected = selectedTab == PlayerSheetTab.Chapters,
+                onClick = { onSelectTab(PlayerSheetTab.Chapters) },
+                modifier = Modifier.weight(1f)
+            )
+            PlayerSheetTabButton(
+                title = "Bookmarks",
+                selected = selectedTab == PlayerSheetTab.Bookmarks,
+                onClick = { onSelectTab(PlayerSheetTab.Bookmarks) },
+                modifier = Modifier.weight(1f)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        when (selectedTab) {
+            PlayerSheetTab.Chapters -> {
+                if (chapters.isEmpty()) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        PlayerSheetEmptyState(
+                            icon = Icons.AutoMirrored.Outlined.ViewList,
+                            title = "This book has no chapters"
+                        )
+                    }
+                } else {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
+                        contentPadding = PaddingValues(bottom = 12.dp)
+                    ) {
+                        itemsIndexed(chapters) { index, chapter ->
+                            val isActiveChapter = index == activeChapterIndex
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clip(RoundedCornerShape(10.dp))
+                                    .background(
+                                        if (isActiveChapter) {
+                                            MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+                                        } else {
+                                            Color.Transparent
+                                        }
+                                    )
+                                    .clickable { onPlayChapter(chapter.startSeconds) }
+                                    .padding(horizontal = 12.dp, vertical = 12.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Column(
+                                    modifier = Modifier.weight(1f),
+                                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                                ) {
+                                    Text(
+                                        text = chapter.title,
+                                        style = MaterialTheme.typography.titleMedium,
+                                        maxLines = 2,
+                                        overflow = TextOverflow.Ellipsis,
+                                        color = if (isActiveChapter) {
+                                            MaterialTheme.colorScheme.primary
+                                        } else {
+                                            MaterialTheme.colorScheme.onSurface
+                                        }
+                                    )
+                                    Text(
+                                        text = formatChapterDurationForRow(
+                                            chapter = chapter,
+                                            index = index,
+                                            chapters = chapters,
+                                            totalDurationSeconds = book.durationSeconds
+                                        ),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                                if (isActiveChapter) {
+                                    ChapterPlaybackIndicator(
+                                        isPlaying = isPlaying,
+                                        tint = MaterialTheme.colorScheme.primary
+                                    )
+                                }
+                            }
+                            HorizontalDivider()
+                        }
+                    }
+                }
+            }
+
+            PlayerSheetTab.Bookmarks -> {
+                if (sortedBookmarks.isEmpty()) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        PlayerSheetEmptyState(
+                            icon = Icons.Outlined.BookmarkBorder,
+                            title = "No bookmarks yet",
+                            iconSize = 58.dp
+                        )
+                    }
+                } else {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
+                        contentPadding = PaddingValues(bottom = 12.dp)
+                    ) {
+                        items(sortedBookmarks, key = { it.id }) { bookmark ->
+                            val bookmarkSeconds = bookmark.timeSeconds
+                            val isActiveBookmark = bookmarkSeconds != null &&
+                                kotlin.math.abs(bookmarkSeconds - positionSeconds) < 1.0
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clip(RoundedCornerShape(10.dp))
+                                    .background(
+                                        if (isActiveBookmark) {
+                                            MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+                                        } else {
+                                            Color.Transparent
+                                        }
+                                    )
+                                    .clickable(enabled = bookmarkSeconds != null) {
+                                        onPlayBookmark(bookmarkSeconds ?: 0.0)
+                                    }
+                                    .padding(horizontal = 12.dp, vertical = 12.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Column(
+                                    modifier = Modifier.width(110.dp),
+                                    verticalArrangement = Arrangement.spacedBy(3.dp)
+                                ) {
+                                    Text(
+                                        text = formatBookmarkDate(bookmark.createdAtMs),
+                                        style = MaterialTheme.typography.bodySmall
+                                    )
+                                    Text(
+                                        text = bookmark.timeSeconds?.let { formatSecondsAsHms(it) } ?: "--:--",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                                Spacer(modifier = Modifier.width(12.dp))
+                                Column(
+                                    modifier = Modifier.weight(1f),
+                                    verticalArrangement = Arrangement.spacedBy(3.dp)
+                                ) {
+                                    Text(
+                                        text = formatBookmarkTime24(bookmark.createdAtMs),
+                                        style = MaterialTheme.typography.titleSmall,
+                                        color = if (isActiveBookmark) {
+                                            MaterialTheme.colorScheme.primary
+                                        } else {
+                                            MaterialTheme.colorScheme.onSurface
+                                        }
+                                    )
+                                    Text(
+                                        text = bookmark.title?.ifBlank { null } ?: "Bookmark",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        maxLines = 2,
+                                        overflow = TextOverflow.Ellipsis,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                                if (isActiveBookmark) {
+                                    ChapterPlaybackIndicator(
+                                        isPlaying = isPlaying,
+                                        tint = MaterialTheme.colorScheme.primary
+                                    )
+                                }
+                            }
+                            HorizontalDivider()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlayerSheetTabButton(
+    title: String,
+    selected: Boolean,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(11.dp))
+            .background(
+                if (selected) {
+                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.15f)
+                } else {
+                    Color.Transparent
+                }
+            )
+            .clickable(onClick = onClick)
+            .padding(vertical = 8.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+            color = if (selected) {
+                MaterialTheme.colorScheme.onSurface
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
+            maxLines = 1
+        )
+    }
+}
+
+@Composable
+private fun PlayerSheetEmptyState(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    title: String,
+    iconSize: Dp = 46.dp
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(iconSize)
+        )
+        Text(
+            text = title,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
     }
 }
 
@@ -5045,6 +5747,60 @@ private fun PlayerBottomToolItem(
             textAlign = TextAlign.Center,
             modifier = Modifier.fillMaxWidth()
         )
+    }
+}
+
+@Composable
+private fun BookListenProgressButton(
+    text: String,
+    progress: Float,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val buttonShape = ButtonDefaults.shape
+    val baseColor = MaterialTheme.colorScheme.onSurface
+    val contentColor = MaterialTheme.colorScheme.surface
+    val remainingColor = listenButtonRemainingColor(baseColor)
+    val clampedProgress = progress.coerceIn(0f, 1f)
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(40.dp)
+            .clip(buttonShape)
+            .background(remainingColor)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .fillMaxWidth(clampedProgress)
+                .background(baseColor)
+        )
+        Button(
+            onClick = onClick,
+            modifier = Modifier.fillMaxSize(),
+            shape = buttonShape,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color.Transparent,
+                contentColor = contentColor
+            )
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.PlayArrow,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp)
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(text)
+        }
+    }
+}
+
+private fun listenButtonRemainingColor(baseColor: Color): Color {
+    return if (baseColor.luminance() < 0.5f) {
+        lerp(baseColor, Color.White, 0.22f)
+    } else {
+        lerp(baseColor, Color.Black, 0.12f)
     }
 }
 
@@ -6184,7 +6940,7 @@ private fun List<BookSummary>.filterByStatus(filter: BooksStatusFilter): List<Bo
         BooksStatusFilter.All -> this
         BooksStatusFilter.Finished -> filter { it.hasFinishedProgress() }
         BooksStatusFilter.InProgress -> filter { it.hasStartedProgress() && !it.hasFinishedProgress() }
-        BooksStatusFilter.NotStarted -> filter { !it.hasStartedProgress() }
+        BooksStatusFilter.NotStarted -> filter { !it.hasStartedProgress() && !it.hasFinishedProgress() }
         BooksStatusFilter.NotFinished -> filter { !it.hasFinishedProgress() }
     }
 }
@@ -6204,6 +6960,7 @@ private fun sortComparator(sortKey: BooksSortKey): Comparator<BookSummary> {
 }
 
 private fun BookSummary.hasStartedProgress(): Boolean {
+    if (hasFinishedProgress()) return true
     val normalized = normalizedProgressPercent()
     return normalized != null && normalized > 0.001
 }
@@ -6267,6 +7024,49 @@ private fun formatDurationHoursMinutes(durationSeconds: Double?): String {
     } else {
         "${max(minutes, 1)}m"
     }
+}
+
+private fun formatHoursMinutesPrecise(durationSeconds: Double?): String {
+    val totalSeconds = durationSeconds?.coerceAtLeast(0.0) ?: 0.0
+    val totalMinutes = (totalSeconds / 60.0).toLong()
+    val hours = totalMinutes / 60
+    val minutes = totalMinutes % 60
+    return "${hours}h ${minutes}m"
+}
+
+private fun formatProgressPercentLabel(progressFraction: Float): String {
+    val percent = (progressFraction.coerceIn(0f, 1f) * 100f).toDouble()
+    return if (percent < 1.0) {
+        String.format(Locale.getDefault(), "%.1f%%", percent)
+    } else {
+        "${percent.toInt().coerceIn(0, 100)}%"
+    }
+}
+
+private fun formatTimeLeftLabel(durationSeconds: Double, positionSeconds: Double): String {
+    val remainingSeconds = (durationSeconds - positionSeconds).coerceAtLeast(0.0)
+    val readable = formatDurationHoursMinutes(remainingSeconds)
+    return if (readable.isBlank()) "0m left" else "$readable left"
+}
+
+private fun formatBookmarkDate(createdAtMs: Long?): String {
+    val timestamp = createdAtMs ?: return "Unknown date"
+    val formatter = DateTimeFormatter.ofPattern("M/d/yyyy", Locale.getDefault())
+    return runCatching {
+        Instant.ofEpochMilli(timestamp)
+            .atZone(ZoneId.systemDefault())
+            .format(formatter)
+    }.getOrDefault("Unknown date")
+}
+
+private fun formatBookmarkTime24(createdAtMs: Long?): String {
+    val timestamp = createdAtMs ?: return "--:--"
+    val formatter = DateTimeFormatter.ofPattern("HH:mm", Locale.getDefault())
+    return runCatching {
+        Instant.ofEpochMilli(timestamp)
+            .atZone(ZoneId.systemDefault())
+            .format(formatter)
+    }.getOrDefault("--:--")
 }
 
 private fun formatTimeLeft(item: ContinueListeningItem): String {

--- a/app/src/main/java/com/stillshelf/app/ui/screens/PlayerViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/PlayerViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.stillshelf.app.core.datastore.SessionPreferences
 import com.stillshelf.app.core.model.BookChapter
+import com.stillshelf.app.core.model.BookBookmark
 import com.stillshelf.app.core.model.ContinueListeningItem
 import com.stillshelf.app.core.util.AppResult
 import com.stillshelf.app.data.repo.SessionRepository
@@ -36,27 +37,31 @@ class PlayerViewModel @Inject constructor(
     val previewItem: StateFlow<ContinueListeningItem?> = mutablePreviewItem.asStateFlow()
     private val mutableChapters = MutableStateFlow<List<BookChapter>>(emptyList())
     val chapters: StateFlow<List<BookChapter>> = mutableChapters.asStateFlow()
+    private val mutableBookmarks = MutableStateFlow<List<BookBookmark>>(emptyList())
+    val bookmarks: StateFlow<List<BookBookmark>> = mutableBookmarks.asStateFlow()
+    private val mutableActionMessage = MutableStateFlow<String?>(null)
+    val actionMessage: StateFlow<String?> = mutableActionMessage.asStateFlow()
     private val mutableControlPrefs = MutableStateFlow(PlayerControlPrefs())
     val controlPrefs: StateFlow<PlayerControlPrefs> = mutableControlPrefs.asStateFlow()
-    private var chaptersBookId: String? = null
+    private var loadedBookId: String? = null
 
     init {
         observeControlPrefs()
         val bookId = savedStateHandle.get<String>(MainRoute.PLAYER_BOOK_ID_ARG).orEmpty()
         if (bookId.isNotBlank()) {
-            loadChapters(bookId)
+            loadBookMetadata(bookId)
             playbackController.playBook(bookId)
         } else if (playbackController.uiState.value.book == null) {
             val cachedItem = playbackController.getCachedContinueListeningItem()
             if (cachedItem != null) {
                 mutablePreviewItem.value = cachedItem
-                loadChapters(cachedItem.book.id)
+                loadBookMetadata(cachedItem.book.id)
             } else {
                 viewModelScope.launch {
                     when (val result = sessionRepository.fetchMiniPlayerItem()) {
                         is AppResult.Success -> {
                             mutablePreviewItem.value = result.value
-                            result.value?.book?.id?.let(::loadChapters)
+                            result.value?.book?.id?.let(::loadBookMetadata)
                         }
 
                         is AppResult.Error -> Unit
@@ -69,7 +74,7 @@ class PlayerViewModel @Inject constructor(
             playbackController.uiState.collect { playbackState ->
                 if (playbackState.book != null) {
                     mutablePreviewItem.value = null
-                    loadChapters(playbackState.book.id)
+                    loadBookMetadata(playbackState.book.id)
                 }
             }
         }
@@ -111,17 +116,68 @@ class PlayerViewModel @Inject constructor(
         playbackController.seekToPositionMs(positionMs = positionMs, commit = commit)
     }
 
-    private fun loadChapters(bookId: String) {
-        if (bookId.isBlank() || chaptersBookId == bookId) return
-        chaptersBookId = bookId
+    fun jumpToSeconds(seconds: Double) {
+        val bookId = uiState.value.book?.id ?: previewItem.value?.book?.id ?: return
+        val positionMs = (seconds.coerceAtLeast(0.0) * 1000.0).toLong()
+        val playbackState = uiState.value
+        if (playbackState.book?.id == bookId) {
+            playbackController.seekToPositionMs(positionMs = positionMs, commit = true)
+            if (!playbackState.isPlaying) {
+                playbackController.togglePlayPause()
+            }
+        } else {
+            playbackController.playBookFromPosition(bookId = bookId, startPositionMs = positionMs)
+        }
+    }
+
+    fun addBookmark(positionSeconds: Double, title: String?) {
+        val bookId = uiState.value.book?.id ?: previewItem.value?.book?.id
+        if (bookId.isNullOrBlank()) {
+            mutableActionMessage.value = "Unable to add bookmark right now."
+            return
+        }
         viewModelScope.launch {
-            when (val result = sessionRepository.fetchBookDetail(bookId)) {
+            when (
+                val result = sessionRepository.createBookmark(
+                    bookId = bookId,
+                    timeSeconds = positionSeconds.coerceAtLeast(0.0),
+                    title = title?.trim().takeUnless { it.isNullOrBlank() }
+                )
+            ) {
                 is AppResult.Success -> {
-                    mutableChapters.value = result.value.chapters
+                    mutableActionMessage.value = "Bookmark added."
+                    loadBookMetadata(bookId = bookId, forceRefresh = true)
                 }
 
                 is AppResult.Error -> {
-                    mutableChapters.value = emptyList()
+                    mutableActionMessage.value = result.message
+                }
+            }
+        }
+    }
+
+    fun clearActionMessage() {
+        mutableActionMessage.value = null
+    }
+
+    private fun loadBookMetadata(bookId: String, forceRefresh: Boolean = false) {
+        if (bookId.isBlank()) return
+        if (!forceRefresh && loadedBookId == bookId) return
+        loadedBookId = bookId
+        viewModelScope.launch {
+            when (val result = sessionRepository.fetchBookDetail(bookId, forceRefresh = forceRefresh)) {
+                is AppResult.Success -> {
+                    mutableChapters.value = result.value.chapters
+                    mutableBookmarks.value = result.value.bookmarks
+                }
+
+                is AppResult.Error -> {
+                    if (forceRefresh) {
+                        mutableActionMessage.value = result.message
+                    } else {
+                        mutableChapters.value = emptyList()
+                        mutableBookmarks.value = emptyList()
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Fix auth/navigation and service edge cases raised in review
- Make collections/playlists refresh/caching behavior faster and less disruptive
- Improve collection/playlist visuals, cover stacks, and menu behavior
- Fix sort/status filters and wire previously non-functional menu actions
- Rework fullscreen player spacing, marquee title, and metadata readouts
- Add draggable chapters/bookmarks player sheet and real bookmark creation
- Improve mini-player title/subtitle behavior and progress consistency
- Refine Book Detail continue-listening progress button and tab reset behavior

## Validation
- :app:compileDebugKotlin
- :app:testDebugUnitTest (NO-SOURCE)