### PR TITLE
Fix bookmark fallback duplication and mini-player stale title

### DIFF
--- a/app/src/main/java/com/stillshelf/app/data/api/AudiobookshelfApi.kt
+++ b/app/src/main/java/com/stillshelf/app/data/api/AudiobookshelfApi.kt
@@ -499,18 +499,20 @@ class AudiobookshelfApi @Inject constructor(
                 ?.count { bookmark ->
                     bookmark.libraryItemId.matchesLibraryItemId(normalizedItemId)
                 }
-                ?: 0
             var lastError: Throwable? = null
             requestBuilders.forEach { request ->
                 val attempt = runCatching { executeRequestWithRetry(request) }
                 if (attempt.isSuccess) {
                     invalidateMePayloadCache()
                     val latestBookmarks = getBookmarks(baseUrl, authToken).getOrNull()
+                    if (latestBookmarks == null) {
+                        return@runCatching Unit
+                    }
                     val bookmarksForItem = latestBookmarks
                         ?.filter { bookmark -> bookmark.libraryItemId.matchesLibraryItemId(normalizedItemId) }
                         .orEmpty()
                     val verified = when {
-                        bookmarksForItem.size > baselineForItemCount -> true
+                        baselineForItemCount != null && bookmarksForItem.size > baselineForItemCount -> true
                         else -> {
                             bookmarksForItem.any { bookmark ->
                                 val timeMatches = bookmark.timeSeconds?.let { bookmarkTime ->

--- a/app/src/main/java/com/stillshelf/app/ui/components/MiniPlayerViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/components/MiniPlayerViewModel.kt
@@ -148,7 +148,13 @@ class MiniPlayerViewModel @Inject constructor(
                     hadActivePlayback = false
                     refresh()
                 } else {
-                    mutableUiState.update { it.copy(isPlaying = false, displayTitle = "Nothing playing") }
+                    mutableUiState.update { currentState ->
+                        val cachedItem = currentState.item
+                        currentState.copy(
+                            isPlaying = false,
+                            displayTitle = resolvePlayerTitle(cachedItem)
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- stop bookmark create flow from retrying additional POST variants after a successful create when bookmark verification payload is unavailable
- keep mini-player title resolved from cached item when live playback emits null, instead of forcing "Nothing playing" over a real item row

## Verification
- ./gradlew :app:compileDebugKotlin --stacktrace (with GRADLE_USER_HOME=/tmp/gradle)
