### PR TITLE
Home menu: server switcher + library dropdown

### DIFF
--- a/app/src/main/java/com/stillshelf/app/ui/navigation/MainNavGraph.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/navigation/MainNavGraph.kt
@@ -132,6 +132,7 @@ private fun MainShell() {
             currentRoute != MainTab.Settings.route &&
             currentRoute != MainRoute.SETTINGS &&
             currentRoute != MainRoute.SERVERS &&
+            currentRoute != MainRoute.LIBRARY_PICKER &&
             currentRoute?.startsWith("auth/") != true
     ) { paddingValues ->
         MainTabsNavHost(
@@ -340,6 +341,26 @@ private fun MainTabsNavHost(
                     }
                 },
                 onHomeClick = onHomeClick
+            )
+        }
+        composable(MainRoute.LIBRARY_PICKER) {
+            LibraryPickerRoute(
+                onLibrarySelected = {
+                    if (!navController.popBackStack(MainTab.Home.route, inclusive = false)) {
+                        navController.navigate(MainTab.Home.route) {
+                            popUpTo(navController.graph.findStartDestination().id) {
+                                saveState = true
+                            }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    }
+                },
+                onManageServers = {
+                    navController.navigate(MainRoute.SERVERS) {
+                        launchSingleTop = true
+                    }
+                }
             )
         }
         composable(AuthRoute.ADD_SERVER) {

--- a/app/src/main/java/com/stillshelf/app/ui/navigation/NavRoutes.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/navigation/NavRoutes.kt
@@ -32,6 +32,7 @@ object MainRoute {
     const val PLAYER_PATTERN =
         "$PLAYER?$PLAYER_BOOK_ID_ARG={$PLAYER_BOOK_ID_ARG}&$PLAYER_START_SECONDS_ARG={$PLAYER_START_SECONDS_ARG}"
     const val SERVERS = "main/servers"
+    const val LIBRARY_PICKER = "main/library_picker"
 
     fun player(bookId: String? = null, startSeconds: Double? = null): String {
         if (bookId.isNullOrBlank()) return PLAYER

--- a/app/src/main/java/com/stillshelf/app/ui/screens/HomeMenuViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/HomeMenuViewModel.kt
@@ -3,11 +3,14 @@ package com.stillshelf.app.ui.screens
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.stillshelf.app.core.model.Library
+import com.stillshelf.app.core.model.Server
 import com.stillshelf.app.core.util.AppResult
 import com.stillshelf.app.data.repo.SessionRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
@@ -16,10 +19,17 @@ import kotlinx.coroutines.launch
 
 data class HomeMenuUiState(
     val libraries: List<Library> = emptyList(),
+    val servers: List<Server> = emptyList(),
+    val activeServerId: String? = null,
     val activeLibraryId: String? = null,
+    val isSwitchingServer: Boolean = false,
     val isSwitchingLibrary: Boolean = false,
     val errorMessage: String? = null
 )
+
+sealed interface HomeMenuEvent {
+    data object NavigateToLibraryPicker : HomeMenuEvent
+}
 
 @HiltViewModel
 class HomeMenuViewModel @Inject constructor(
@@ -27,27 +37,67 @@ class HomeMenuViewModel @Inject constructor(
 ) : ViewModel() {
     private val mutableUiState = MutableStateFlow(HomeMenuUiState())
     val uiState: StateFlow<HomeMenuUiState> = mutableUiState.asStateFlow()
+    private val mutableEvents = MutableSharedFlow<HomeMenuEvent>()
+    val events = mutableEvents.asSharedFlow()
 
     init {
         viewModelScope.launch {
             combine(
                 sessionRepository.observeLibrariesForActiveServer(),
-                sessionRepository.observeSessionState()
-            ) { libraries, sessionState ->
-                libraries to sessionState.activeLibraryId
-            }.collect { (libraries, activeLibraryId) ->
+                sessionRepository.observeSessionState(),
+                sessionRepository.observeServers()
+            ) { libraries, sessionState, servers ->
+                Triple(libraries, sessionState, servers)
+            }.collect { (libraries, sessionState, servers) ->
                 mutableUiState.update {
                     it.copy(
                         libraries = libraries,
-                        activeLibraryId = activeLibraryId
+                        servers = servers,
+                        activeServerId = sessionState.activeServerId,
+                        activeLibraryId = sessionState.activeLibraryId
                     )
                 }
             }
         }
     }
 
+    fun onServerSelected(serverId: String) {
+        if (uiState.value.isSwitchingServer) return
+        if (serverId == uiState.value.activeServerId) {
+            viewModelScope.launch {
+                mutableEvents.emit(HomeMenuEvent.NavigateToLibraryPicker)
+            }
+            return
+        }
+        mutableUiState.update { it.copy(isSwitchingServer = true, errorMessage = null) }
+
+        viewModelScope.launch {
+            when (val result = sessionRepository.setActiveServer(serverId)) {
+                is AppResult.Success -> {
+                    mutableUiState.update { it.copy(isSwitchingServer = false) }
+                    mutableEvents.emit(HomeMenuEvent.NavigateToLibraryPicker)
+                }
+
+                is AppResult.Error -> {
+                    mutableUiState.update {
+                        it.copy(
+                            isSwitchingServer = false,
+                            errorMessage = result.message
+                        )
+                    }
+                }
+            }
+        }
+    }
+
     fun switchLibrary(libraryId: String) {
-        if (libraryId == uiState.value.activeLibraryId || uiState.value.isSwitchingLibrary) return
+        if (
+            libraryId == uiState.value.activeLibraryId ||
+            uiState.value.isSwitchingLibrary ||
+            uiState.value.isSwitchingServer
+        ) {
+            return
+        }
         mutableUiState.update { it.copy(isSwitchingLibrary = true, errorMessage = null) }
 
         viewModelScope.launch {
@@ -72,4 +122,3 @@ class HomeMenuViewModel @Inject constructor(
         mutableUiState.update { it.copy(errorMessage = null) }
     }
 }
-

--- a/app/src/main/java/com/stillshelf/app/ui/screens/PlaceholderScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/PlaceholderScreens.kt
@@ -70,6 +70,7 @@ import androidx.compose.material.icons.outlined.ChevronRight
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.CollectionsBookmark
 import androidx.compose.material.icons.outlined.Download
+import androidx.compose.material.icons.outlined.Dns
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material.icons.outlined.FastForward
 import androidx.compose.material.icons.outlined.FastRewind
@@ -143,6 +144,7 @@ import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -207,6 +209,7 @@ import kotlin.math.sin
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -283,6 +286,8 @@ fun HomePlaceholderScreen(
     val appearanceUiState by appearanceViewModel.uiState.collectAsStateWithLifecycle()
     val collectionPickerUiState by collectionPickerViewModel.uiState.collectAsStateWithLifecycle()
     var isMenuExpanded by remember { mutableStateOf(false) }
+    var isLibraryMenuExpanded by remember { mutableStateOf(false) }
+    var libraryMenuAnchorWidthPx by remember { mutableIntStateOf(0) }
     var addToListBookId by rememberSaveable { mutableStateOf<String?>(null) }
     val refreshState = rememberPullRefreshState(
         refreshing = uiState.isLoading,
@@ -367,6 +372,13 @@ fun HomePlaceholderScreen(
         Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         collectionPickerViewModel.clearMessages()
     }
+    LaunchedEffect(menuViewModel) {
+        menuViewModel.events.collect { event ->
+            when (event) {
+                HomeMenuEvent.NavigateToLibraryPicker -> onNavigateToRoute(MainRoute.LIBRARY_PICKER)
+            }
+        }
+    }
     DisposableEffect(lifecycleOwner, viewModel) {
         val observer = LifecycleEventObserver { _, event ->
             when (event) {
@@ -396,13 +408,73 @@ fun HomePlaceholderScreen(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(
-                        text = uiState.libraryName,
-                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
+                    Box(
                         modifier = Modifier.weight(1f)
-                    )
+                    ) {
+                        val hasLibraries = menuUiState.libraries.isNotEmpty()
+                        val libraryMenuWidth = with(LocalDensity.current) { libraryMenuAnchorWidthPx.toDp() }
+                        Row(
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(10.dp))
+                                .onGloballyPositioned { coordinates ->
+                                    libraryMenuAnchorWidthPx = coordinates.size.width
+                                }
+                                .clickable(enabled = hasLibraries && !menuUiState.isSwitchingLibrary) {
+                                    isLibraryMenuExpanded = true
+                                }
+                                .padding(vertical = 2.dp, horizontal = 2.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = uiState.libraryName,
+                                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            if (hasLibraries) {
+                                Spacer(modifier = Modifier.width(4.dp))
+                                Icon(
+                                    imageVector = if (isLibraryMenuExpanded) {
+                                        Icons.Outlined.KeyboardArrowUp
+                                    } else {
+                                        Icons.Outlined.KeyboardArrowDown
+                                    },
+                                    contentDescription = "Switch library",
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.size(18.dp)
+                                )
+                            }
+                        }
+                        DropdownMenu(
+                            expanded = isLibraryMenuExpanded && hasLibraries,
+                            onDismissRequest = { isLibraryMenuExpanded = false },
+                            modifier = if (libraryMenuAnchorWidthPx > 0) {
+                                Modifier.width(libraryMenuWidth)
+                            } else {
+                                Modifier
+                            }
+                        ) {
+                            menuUiState.libraries.forEach { library ->
+                                val isActive = menuUiState.activeLibraryId == library.id
+                                DropdownMenuItem(
+                                    text = { Text(library.name) },
+                                    trailingIcon = {
+                                        if (isActive) {
+                                            Icon(
+                                                imageVector = Icons.Filled.Check,
+                                                contentDescription = "Active library"
+                                            )
+                                        }
+                                    },
+                                    enabled = !menuUiState.isSwitchingLibrary || isActive,
+                                    onClick = {
+                                        menuViewModel.switchLibrary(library.id)
+                                        isLibraryMenuExpanded = false
+                                    }
+                                )
+                            }
+                        }
+                    }
                     if (onHomeClick != null) {
                         CircleActionButton(
                             icon = Icons.Outlined.Home,
@@ -453,23 +525,40 @@ fun HomePlaceholderScreen(
                                     onNavigateToRoute(MainRoute.CUSTOMIZE)
                                 }
                             )
-                            if (menuUiState.libraries.isNotEmpty()) {
+                            if (menuUiState.servers.size > 1) {
                                 HorizontalDivider()
-                                menuUiState.libraries.forEach { library ->
-                                    val isActive = menuUiState.activeLibraryId == library.id
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(
+                                            text = "Servers",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    },
+                                    enabled = false,
+                                    onClick = {}
+                                )
+                                menuUiState.servers.forEach { server ->
+                                    val isActive = menuUiState.activeServerId == server.id
                                     DropdownMenuItem(
-                                        text = { Text(library.name) },
+                                        text = { Text(server.name) },
+                                        leadingIcon = {
+                                            Icon(
+                                                imageVector = Icons.Outlined.Dns,
+                                                contentDescription = null
+                                            )
+                                        },
                                         trailingIcon = {
                                             if (isActive) {
                                                 Icon(
                                                     imageVector = Icons.Filled.Check,
-                                                    contentDescription = "Active library"
+                                                    contentDescription = "Active server"
                                                 )
                                             }
                                         },
-                                        enabled = !menuUiState.isSwitchingLibrary || isActive,
+                                        enabled = !menuUiState.isSwitchingServer,
                                         onClick = {
-                                            menuViewModel.switchLibrary(library.id)
+                                            menuViewModel.onServerSelected(server.id)
                                             isMenuExpanded = false
                                         }
                                     )


### PR DESCRIPTION
## Summary
- add a dedicated Home library picker dropdown anchored to the library title
- keep server switching in the overflow menu with a labeled server section and icons
- route server selection through library picker flow for consistent switching
- restore Bookmarks tab to read-only behavior (open-only rows)

## Verification
- ./gradlew :app:compileDebugKotlin
