### PR TITLE
Fix Home server re-auth regression and ship beta.4

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.stillshelf.app"
         minSdk = 24
         targetSdk = 36
-        versionCode = 6
-        versionName = "0.1.0-beta.3"
+        versionCode = 7
+        versionName = "0.1.0-beta.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/stillshelf/app/ui/screens/HomeMenuViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/HomeMenuViewModel.kt
@@ -29,6 +29,10 @@ data class HomeMenuUiState(
 
 sealed interface HomeMenuEvent {
     data object NavigateToLibraryPicker : HomeMenuEvent
+    data class NavigateToLogin(
+        val serverName: String,
+        val baseUrl: String
+    ) : HomeMenuEvent
 }
 
 @HiltViewModel
@@ -63,6 +67,7 @@ class HomeMenuViewModel @Inject constructor(
 
     fun onServerSelected(serverId: String) {
         if (uiState.value.isSwitchingServer) return
+        val selectedServer = uiState.value.servers.firstOrNull { it.id == serverId }
         if (serverId == uiState.value.activeServerId) {
             viewModelScope.launch {
                 mutableEvents.emit(HomeMenuEvent.NavigateToLibraryPicker)
@@ -79,11 +84,27 @@ class HomeMenuViewModel @Inject constructor(
                 }
 
                 is AppResult.Error -> {
-                    mutableUiState.update {
-                        it.copy(
-                            isSwitchingServer = false,
-                            errorMessage = result.message
+                    val requiresReauth = result.message.contains("no saved session", ignoreCase = true)
+                    if (requiresReauth && selectedServer != null) {
+                        mutableUiState.update {
+                            it.copy(
+                                isSwitchingServer = false,
+                                errorMessage = null
+                            )
+                        }
+                        mutableEvents.emit(
+                            HomeMenuEvent.NavigateToLogin(
+                                serverName = selectedServer.name,
+                                baseUrl = selectedServer.baseUrl
+                            )
                         )
+                    } else {
+                        mutableUiState.update {
+                            it.copy(
+                                isSwitchingServer = false,
+                                errorMessage = result.message
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/stillshelf/app/ui/screens/PlaceholderScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/PlaceholderScreens.kt
@@ -197,6 +197,7 @@ import com.stillshelf.app.ui.common.StandardGridCoverWidth
 import com.stillshelf.app.ui.common.FramedCoverImage
 import com.stillshelf.app.ui.common.WideCoverBackgroundBlur
 import com.stillshelf.app.ui.common.rememberCoverImageModel
+import com.stillshelf.app.ui.navigation.AuthRoute
 import com.stillshelf.app.ui.navigation.BrowseRoute
 import com.stillshelf.app.ui.navigation.MainRoute
 import com.stillshelf.app.ui.navigation.MainTab
@@ -376,6 +377,8 @@ fun HomePlaceholderScreen(
         menuViewModel.events.collect { event ->
             when (event) {
                 HomeMenuEvent.NavigateToLibraryPicker -> onNavigateToRoute(MainRoute.LIBRARY_PICKER)
+                is HomeMenuEvent.NavigateToLogin ->
+                    onNavigateToRoute(AuthRoute.loginRoute(event.serverName, event.baseUrl))
             }
         }
     }


### PR DESCRIPTION
## Summary
- restore Home server switch recovery when active server session is missing
- navigate to login for re-auth instead of leaving users stuck on Home
- bump Android app version to 0.1.0-beta.4 (versionCode 7)

## Validation
- ./gradlew :app:compileDebugKotlin --stacktrace --console=plain
