### PR TITLE
Prepare 0.1.0-rc1 with settings sync/update and lock-screen controls

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.stillshelf.app"
         minSdk = 24
         targetSdk = 36
-        versionCode = 7
-        versionName = "0.1.0-beta.4"
+        versionCode = 8
+        versionName = "0.1.0-rc1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <application
         android:name=".StillShelfApplication"
@@ -18,6 +19,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.StillShelf">
             <intent-filter>
@@ -36,6 +38,16 @@
             android:enabled="true"
             android:exported="false"
             android:foregroundServiceType="mediaPlayback" />
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/update_file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/stillshelf/app/MainActivity.kt
+++ b/app/src/main/java/com/stillshelf/app/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.stillshelf.app
 
+import android.app.AlertDialog
 import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -19,6 +20,7 @@ class MainActivity : ComponentActivity() {
     private val startupViewModel: StartupViewModel by viewModels()
     @Volatile
     private var keepSplashOnScreen: Boolean = true
+    private var startupUpdateDialog: AlertDialog? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
@@ -27,6 +29,31 @@ class MainActivity : ComponentActivity() {
         lifecycleScope.launch {
             startupViewModel.isReady.collect { isReady ->
                 keepSplashOnScreen = !isReady
+            }
+        }
+        lifecycleScope.launch {
+            startupViewModel.startupUpdatePrompt.collect { release ->
+                if (release == null) {
+                    startupUpdateDialog?.dismiss()
+                    startupUpdateDialog = null
+                    return@collect
+                }
+                if (startupUpdateDialog?.isShowing == true) {
+                    return@collect
+                }
+                startupUpdateDialog = AlertDialog.Builder(this@MainActivity)
+                    .setTitle("Update available")
+                    .setMessage("StillShelf ${release.versionName} is available. Update now?")
+                    .setPositiveButton("Update") { _, _ ->
+                        startupViewModel.installStartupUpdate()
+                    }
+                    .setNegativeButton("Cancel") { _, _ ->
+                        startupViewModel.dismissStartupUpdatePrompt()
+                    }
+                    .setOnDismissListener {
+                        startupUpdateDialog = null
+                    }
+                    .show()
             }
         }
         enableEdgeToEdge(

--- a/app/src/main/java/com/stillshelf/app/core/datastore/SessionPreferences.kt
+++ b/app/src/main/java/com/stillshelf/app/core/datastore/SessionPreferences.kt
@@ -52,6 +52,11 @@ class SessionPreferences @Inject constructor(
     private val cachedHomeFeedLibraryIdKey = stringPreferencesKey("cached_home_feed_library_id")
     private val cachedHomeFeedPayloadKey = stringPreferencesKey("cached_home_feed_payload")
     private val cachedHomeFeedSavedAtKey = longPreferencesKey("cached_home_feed_saved_at")
+    private val lastLibrarySyncAtMsKey = longPreferencesKey("last_library_sync_at_ms")
+    private val updateCheckOnStartupKey = booleanPreferencesKey("update_check_on_startup")
+    private val updateIncludePrereleasesKey = booleanPreferencesKey("update_include_prereleases")
+    private val pendingUpdateApkPathKey = stringPreferencesKey("pending_update_apk_path")
+    private val pendingUpdateVersionNameKey = stringPreferencesKey("pending_update_version_name")
 
     val state: Flow<SessionPreferenceState> = dataStore.data.map { prefs ->
         SessionPreferenceState(
@@ -84,7 +89,12 @@ class SessionPreferences @Inject constructor(
             lockScreenControlMode = prefs[lockScreenControlModeKey] ?: "skip",
             lastBookDetailTab = prefs[lastBookDetailTabKey] ?: "About",
             downloadedBookIds = parseCsv(prefs[downloadedBookIdsKey]),
-            serverAvatarUris = parseServerAvatarUris(prefs[serverAvatarUrisKey])
+            serverAvatarUris = parseServerAvatarUris(prefs[serverAvatarUrisKey]),
+            lastLibrarySyncAtMs = prefs[lastLibrarySyncAtMsKey],
+            updateCheckOnStartup = prefs[updateCheckOnStartupKey] ?: true,
+            updateIncludePrereleases = prefs[updateIncludePrereleasesKey] ?: false,
+            pendingUpdateApkPath = prefs[pendingUpdateApkPathKey],
+            pendingUpdateVersionName = prefs[pendingUpdateVersionNameKey]
         )
     }
 
@@ -319,6 +329,43 @@ class SessionPreferences @Inject constructor(
         }
     }
 
+    suspend fun setLastLibrarySyncAtMs(timestampMs: Long?) {
+        dataStore.edit { prefs ->
+            if (timestampMs == null) {
+                prefs.remove(lastLibrarySyncAtMsKey)
+            } else {
+                prefs[lastLibrarySyncAtMsKey] = timestampMs.coerceAtLeast(0L)
+            }
+        }
+    }
+
+    suspend fun setUpdateCheckOnStartup(enabled: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[updateCheckOnStartupKey] = enabled
+        }
+    }
+
+    suspend fun setUpdateIncludePrereleases(enabled: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[updateIncludePrereleasesKey] = enabled
+        }
+    }
+
+    suspend fun setPendingUpdateInstall(apkPath: String?, versionName: String?) {
+        dataStore.edit { prefs ->
+            if (apkPath.isNullOrBlank()) {
+                prefs.remove(pendingUpdateApkPathKey)
+            } else {
+                prefs[pendingUpdateApkPathKey] = apkPath.trim()
+            }
+            if (versionName.isNullOrBlank()) {
+                prefs.remove(pendingUpdateVersionNameKey)
+            } else {
+                prefs[pendingUpdateVersionNameKey] = versionName.trim()
+            }
+        }
+    }
+
     suspend fun setDownloadedBookIds(ids: Set<String>) {
         dataStore.edit { prefs ->
             if (ids.isEmpty()) {
@@ -477,7 +524,12 @@ data class SessionPreferenceState(
     val lockScreenControlMode: String = "skip",
     val lastBookDetailTab: String = "About",
     val downloadedBookIds: Set<String> = emptySet(),
-    val serverAvatarUris: Map<String, String> = emptyMap()
+    val serverAvatarUris: Map<String, String> = emptyMap(),
+    val lastLibrarySyncAtMs: Long? = null,
+    val updateCheckOnStartup: Boolean = true,
+    val updateIncludePrereleases: Boolean = false,
+    val pendingUpdateApkPath: String? = null,
+    val pendingUpdateVersionName: String? = null
 )
 
 data class CachedHomeFeedPayload(

--- a/app/src/main/java/com/stillshelf/app/playback/controller/PlaybackController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/controller/PlaybackController.kt
@@ -26,6 +26,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.graphics.drawable.toBitmap
 import com.stillshelf.app.core.datastore.SessionPreferences
+import com.stillshelf.app.core.model.BookChapter
 import com.stillshelf.app.core.model.BookSummary
 import com.stillshelf.app.core.model.ContinueListeningItem
 import com.stillshelf.app.core.network.authorizationHeaderValue
@@ -97,6 +98,12 @@ class PlaybackController @Inject constructor(
         private const val CHANNEL_ID = "stillshelf_playback_v4"
         private const val CHANNEL_NAME = "Playback"
         private const val NOTIFICATION_ID = 1101
+        private const val LOCK_SCREEN_MODE_SKIP = "skip"
+        private const val LOCK_SCREEN_MODE_NEXT = "next"
+        private const val LOCK_SCREEN_SECOND_PREVIOUS_POSITION_WINDOW_MS = 1_500L
+        private const val LOCK_SCREEN_PREVIOUS_DOUBLE_PRESS_WINDOW_MS = 6_000L
+        private const val LOCK_SCREEN_BOOK_NAV_PAGE_SIZE = 200
+        private const val LOCK_SCREEN_BOOK_NAV_MAX_PAGES = 20
 
         const val ACTION_PLAY_PAUSE = "com.stillshelf.app.playback.action.PLAY_PAUSE"
         const val ACTION_REWIND = "com.stillshelf.app.playback.action.REWIND"
@@ -139,12 +146,14 @@ class PlaybackController @Inject constructor(
     }
     private var rewindSeconds: Int = 15
     private var forwardSeconds: Int = 15
+    private var lockScreenControlMode: String = LOCK_SCREEN_MODE_SKIP
     private var currentPlaybackSpeed: Float = 1.0f
     private var currentSoftToneLevel: Float = 0f
     private var currentBoostLevel: Float = 0f
     private var audioEffectsSessionId: Int? = null
     private var loudnessEnhancer: LoudnessEnhancer? = null
     private var equalizer: Equalizer? = null
+    private var previousRestartState: PreviousRestartState? = null
 
     private data class NotificationSignature(
         val bookId: String,
@@ -152,6 +161,13 @@ class PlaybackController @Inject constructor(
         val author: String?,
         val isPlaying: Boolean,
         val hasArtwork: Boolean
+    )
+
+    private data class PreviousRestartState(
+        val bookId: String,
+        val restartStartMs: Long,
+        val chapterMode: Boolean,
+        val triggeredAtElapsedMs: Long
     )
 
     val uiState: StateFlow<PlaybackUiState> = mutableUiState.asStateFlow()
@@ -165,8 +181,8 @@ class PlaybackController @Inject constructor(
         mediaSession.setCallback(object : MediaSessionCompat.Callback() {
             override fun onPlay() = resume()
             override fun onPause() = pause()
-            override fun onSkipToPrevious() = performRewindControl()
-            override fun onSkipToNext() = performForwardControl()
+            override fun onSkipToPrevious() = performLockScreenPreviousControl()
+            override fun onSkipToNext() = performLockScreenNextControl()
         })
         mediaSession.isActive = true
         audioManager.registerAudioDeviceCallback(audioDeviceCallback, Handler(Looper.getMainLooper()))
@@ -720,6 +736,7 @@ class PlaybackController @Inject constructor(
             sessionPreferences.state.collect { pref ->
                 rewindSeconds = pref.skipBackwardSeconds.coerceIn(10, 60)
                 forwardSeconds = pref.skipForwardSeconds.coerceIn(10, 60)
+                lockScreenControlMode = normalizeLockScreenControlMode(pref.lockScreenControlMode)
                 val desiredSoftTone = pref.softToneLevel.coerceIn(0f, 1f)
                 val desiredBoost = pref.boostLevel.coerceIn(0f, 1f)
                 val toneChanged = abs(currentSoftToneLevel - desiredSoftTone) > 0.001f
@@ -749,6 +766,171 @@ class PlaybackController @Inject constructor(
 
     private fun performForwardControl() {
         seekBy(deltaMs = (forwardSeconds * 1000L))
+    }
+
+    private fun performLockScreenPreviousControl() {
+        if (lockScreenControlMode != LOCK_SCREEN_MODE_NEXT) {
+            previousRestartState = null
+            performRewindControl()
+            return
+        }
+        scope.launch {
+            navigateLockScreenPrevious()
+        }
+    }
+
+    private fun performLockScreenNextControl() {
+        if (lockScreenControlMode != LOCK_SCREEN_MODE_NEXT) {
+            previousRestartState = null
+            performForwardControl()
+            return
+        }
+        previousRestartState = null
+        scope.launch {
+            navigateLockScreenNext()
+        }
+    }
+
+    private suspend fun navigateLockScreenNext() {
+        val bookId = currentBookId ?: uiState.value.book?.id ?: return
+        val chapterStartsMs = resolveChapterStartsMs(bookId)
+        if (chapterStartsMs.isNotEmpty()) {
+            val currentPositionMs = uiState.value.positionMs.coerceAtLeast(0L)
+            val currentChapterIndex = resolveCurrentChapterIndex(chapterStartsMs, currentPositionMs)
+            val nextChapterStartMs = chapterStartsMs.getOrNull(currentChapterIndex + 1)
+            if (nextChapterStartMs != null) {
+                seekToPosition(targetMs = nextChapterStartMs, forceSync = true)
+                return
+            }
+        }
+        playAdjacentBook(direction = 1)
+    }
+
+    private suspend fun navigateLockScreenPrevious() {
+        val bookId = currentBookId ?: uiState.value.book?.id ?: return
+        val currentPositionMs = uiState.value.positionMs.coerceAtLeast(0L)
+        val chapterStartsMs = resolveChapterStartsMs(bookId)
+        if (chapterStartsMs.isNotEmpty()) {
+            val currentChapterIndex = resolveCurrentChapterIndex(chapterStartsMs, currentPositionMs)
+            val currentChapterStartMs = chapterStartsMs
+                .getOrNull(currentChapterIndex)
+                ?.coerceAtLeast(0L)
+                ?: 0L
+            if (!shouldGoToPreviousAfterRestart(bookId, currentChapterStartMs, chapterMode = true, currentPositionMs)) {
+                rememberRestart(bookId, currentChapterStartMs, chapterMode = true)
+                seekToPosition(targetMs = currentChapterStartMs, forceSync = true)
+                return
+            }
+            previousRestartState = null
+            val previousChapterStartMs = chapterStartsMs.getOrNull(currentChapterIndex - 1)
+            if (previousChapterStartMs != null) {
+                seekToPosition(targetMs = previousChapterStartMs, forceSync = true)
+                return
+            }
+            playAdjacentBook(direction = -1)
+            return
+        }
+
+        if (!shouldGoToPreviousAfterRestart(bookId, 0L, chapterMode = false, currentPositionMs)) {
+            rememberRestart(bookId, restartStartMs = 0L, chapterMode = false)
+            seekToPosition(targetMs = 0L, forceSync = true)
+            return
+        }
+        previousRestartState = null
+        playAdjacentBook(direction = -1)
+    }
+
+    private suspend fun playAdjacentBook(direction: Int) {
+        if (direction != -1 && direction != 1) return
+        val currentId = currentBookId ?: uiState.value.book?.id ?: return
+        val books = fetchBooksForLockScreenNavigation()
+        if (books.isEmpty()) return
+        val currentIndex = books.indexOfFirst { it.id == currentId }
+        if (currentIndex < 0) return
+        val targetBook = books.getOrNull(currentIndex + direction) ?: return
+        previousRestartState = null
+        playBookFromPosition(bookId = targetBook.id, startPositionMs = 0L)
+    }
+
+    private suspend fun fetchBooksForLockScreenNavigation(): List<BookSummary> {
+        val collected = mutableListOf<BookSummary>()
+        var page = 0
+        while (page < LOCK_SCREEN_BOOK_NAV_MAX_PAGES) {
+            when (
+                val result = sessionRepository.fetchBooksForActiveLibrary(
+                    limit = LOCK_SCREEN_BOOK_NAV_PAGE_SIZE,
+                    page = page
+                )
+            ) {
+                is AppResult.Success -> {
+                    val batch = result.value
+                    if (batch.isEmpty()) break
+                    collected += batch
+                    if (batch.size < LOCK_SCREEN_BOOK_NAV_PAGE_SIZE) break
+                }
+
+                is AppResult.Error -> return emptyList()
+            }
+            page += 1
+        }
+        return collected.distinctBy { it.id }
+    }
+
+    private suspend fun resolveChapterStartsMs(bookId: String): List<Long> {
+        return when (val detail = sessionRepository.fetchBookDetail(bookId = bookId, forceRefresh = false)) {
+            is AppResult.Success -> detail.value.chapters
+                .toChapterStartsMs()
+            is AppResult.Error -> emptyList()
+        }
+    }
+
+    private fun resolveCurrentChapterIndex(chapterStartsMs: List<Long>, positionMs: Long): Int {
+        if (chapterStartsMs.isEmpty()) return 0
+        val seekPositionMs = positionMs.coerceAtLeast(0L) + 200L
+        return chapterStartsMs.indexOfLast { startMs -> startMs <= seekPositionMs }
+            .takeIf { index -> index >= 0 }
+            ?: 0
+    }
+
+    private fun normalizeLockScreenControlMode(rawMode: String?): String {
+        return if (rawMode.equals(LOCK_SCREEN_MODE_NEXT, ignoreCase = true)) {
+            LOCK_SCREEN_MODE_NEXT
+        } else {
+            LOCK_SCREEN_MODE_SKIP
+        }
+    }
+
+    private fun shouldGoToPreviousAfterRestart(
+        bookId: String,
+        restartStartMs: Long,
+        chapterMode: Boolean,
+        currentPositionMs: Long
+    ): Boolean {
+        val state = previousRestartState ?: return false
+        if (state.bookId != bookId) return false
+        if (state.restartStartMs != restartStartMs) return false
+        if (state.chapterMode != chapterMode) return false
+        val elapsedSinceTriggerMs = SystemClock.elapsedRealtime() - state.triggeredAtElapsedMs
+        if (elapsedSinceTriggerMs > LOCK_SCREEN_PREVIOUS_DOUBLE_PRESS_WINDOW_MS) return false
+        return currentPositionMs <= (restartStartMs + LOCK_SCREEN_SECOND_PREVIOUS_POSITION_WINDOW_MS)
+    }
+
+    private fun rememberRestart(bookId: String, restartStartMs: Long, chapterMode: Boolean) {
+        previousRestartState = PreviousRestartState(
+            bookId = bookId,
+            restartStartMs = restartStartMs.coerceAtLeast(0L),
+            chapterMode = chapterMode,
+            triggeredAtElapsedMs = SystemClock.elapsedRealtime()
+        )
+    }
+
+    private fun List<BookChapter>.toChapterStartsMs(): List<Long> {
+        if (isEmpty()) return emptyList()
+        return asSequence()
+            .map { chapter -> (chapter.startSeconds * 1000.0).toLong().coerceAtLeast(0L) }
+            .distinct()
+            .sorted()
+            .toList()
     }
 
     private inline fun updateUiState(transform: (PlaybackUiState) -> PlaybackUiState) {

--- a/app/src/main/java/com/stillshelf/app/ui/StartupViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/StartupViewModel.kt
@@ -3,6 +3,9 @@ package com.stillshelf.app.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.stillshelf.app.core.datastore.SessionPreferences
+import com.stillshelf.app.core.util.AppResult
+import com.stillshelf.app.update.AppUpdateManager
+import com.stillshelf.app.update.AppUpdateRelease
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,15 +16,44 @@ import kotlinx.coroutines.launch
 
 @HiltViewModel
 class StartupViewModel @Inject constructor(
-    sessionPreferences: SessionPreferences
+    private val sessionPreferences: SessionPreferences,
+    private val appUpdateManager: AppUpdateManager
 ) : ViewModel() {
     private val mutableIsReady = MutableStateFlow(false)
     val isReady: StateFlow<Boolean> = mutableIsReady.asStateFlow()
+    private val mutableStartupUpdatePrompt = MutableStateFlow<AppUpdateRelease?>(null)
+    val startupUpdatePrompt: StateFlow<AppUpdateRelease?> = mutableStartupUpdatePrompt.asStateFlow()
 
     init {
         viewModelScope.launch {
-            runCatching { sessionPreferences.state.first() }
+            val pref = runCatching { sessionPreferences.state.first() }.getOrNull()
+            runCatching { appUpdateManager.cleanupInstalledUpdateApkIfNeeded() }
             mutableIsReady.value = true
+            if (pref != null && pref.updateCheckOnStartup) {
+                when (
+                    val updateResult = appUpdateManager.checkForUpdate(
+                        includePrereleases = pref.updateIncludePrereleases
+                    )
+                ) {
+                    is AppResult.Success -> {
+                        mutableStartupUpdatePrompt.value = updateResult.value
+                    }
+
+                    is AppResult.Error -> Unit
+                }
+            }
+        }
+    }
+
+    fun dismissStartupUpdatePrompt() {
+        mutableStartupUpdatePrompt.value = null
+    }
+
+    fun installStartupUpdate() {
+        val release = mutableStartupUpdatePrompt.value ?: return
+        mutableStartupUpdatePrompt.value = null
+        viewModelScope.launch {
+            appUpdateManager.downloadAndInstallUpdate(release)
         }
     }
 }

--- a/app/src/main/java/com/stillshelf/app/ui/screens/HomeViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/HomeViewModel.kt
@@ -134,7 +134,10 @@ class HomeViewModel @Inject constructor(
 
     fun refresh() {
         viewModelScope.launch {
-            refreshNetwork(showLoading = true)
+            val refreshed = refreshNetwork(showLoading = true)
+            if (refreshed) {
+                sessionPreferences.setLastLibrarySyncAtMs(System.currentTimeMillis())
+            }
         }
     }
 
@@ -234,9 +237,9 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private suspend fun refreshNetwork(showLoading: Boolean) {
-        if (isHomeFeedRefreshInFlight) return
-        if (uiState.value.isLoading) return
+    private suspend fun refreshNetwork(showLoading: Boolean): Boolean {
+        if (isHomeFeedRefreshInFlight) return false
+        if (uiState.value.isLoading) return false
         isHomeFeedRefreshInFlight = true
         if (showLoading) {
             mutableUiState.update { it.copy(isLoading = true, errorMessage = null) }
@@ -244,6 +247,7 @@ class HomeViewModel @Inject constructor(
             mutableUiState.update { it.copy(errorMessage = null) }
         }
 
+        var didRefresh = false
         try {
             when (
                 val result = sessionRepository.fetchHomeFeed(
@@ -253,6 +257,7 @@ class HomeViewModel @Inject constructor(
             ) {
                 is AppResult.Success -> {
                     lastHomeFeedRefreshAtMs = System.currentTimeMillis()
+                    didRefresh = true
                     val resolvedRecentSeries = resolveRecentSeries(
                         backendRecentSeries = result.value.recentSeries,
                         recentlyAdded = result.value.recentlyAdded
@@ -298,6 +303,7 @@ class HomeViewModel @Inject constructor(
         } finally {
             isHomeFeedRefreshInFlight = false
         }
+        return didRefresh
     }
 
     private fun resolveRecentSeries(

--- a/app/src/main/java/com/stillshelf/app/ui/screens/MainScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/MainScreens.kt
@@ -4098,6 +4098,7 @@ fun SettingsScreen(
     onBackClick: (() -> Unit)? = null,
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
+    val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val avatarPickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
@@ -4107,6 +4108,7 @@ fun SettingsScreen(
     var infoMessage by remember { mutableStateOf<String?>(null) }
     var skipForwardDialogVisible by remember { mutableStateOf(false) }
     var skipBackwardDialogVisible by remember { mutableStateOf(false) }
+    var signOutDialogVisible by remember { mutableStateOf(false) }
     val skipSecondChoices = remember { listOf(10, 15, 30, 45, 60) }
     val sectionCardColor = if (uiState.materialDesignEnabled) {
         MaterialTheme.colorScheme.surfaceContainerHigh
@@ -4117,6 +4119,14 @@ fun SettingsScreen(
         BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.42f))
     } else {
         null
+    }
+    val lastSyncedValue = uiState.lastLibrarySyncAtMs
+        ?.let { timestamp -> "Last synced ${formatLastSyncedTimestamp(timestamp)}" }
+
+    LaunchedEffect(uiState.syncToastMessage) {
+        val toastMessage = uiState.syncToastMessage ?: return@LaunchedEffect
+        Toast.makeText(context, toastMessage, Toast.LENGTH_SHORT).show()
+        viewModel.consumeSyncToastMessage()
     }
 
     Column(
@@ -4309,16 +4319,62 @@ fun SettingsScreen(
             )
         }
 
+        Text(
+            text = "APP UPDATES",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
         Card(
             colors = CardDefaults.cardColors(containerColor = sectionCardColor),
             shape = RoundedCornerShape(18.dp),
             border = sectionCardBorder
         ) {
             SettingsRow(
-                title = "About",
-                onClick = onOpenAbout
+                title = "Check for Updates",
+                showChevronWhenUnselected = false,
+                onClick = {
+                    infoMessage = null
+                    if (!uiState.isCheckingForUpdates) {
+                        viewModel.onCheckForUpdatesClick()
+                    }
+                }
             )
+            HorizontalDivider()
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 14.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    "Check on Startup",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f)
+                )
+                Switch(
+                    checked = uiState.updateCheckOnStartupEnabled,
+                    onCheckedChange = viewModel::setUpdateCheckOnStartupEnabled
+                )
+            }
+            HorizontalDivider()
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 14.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    "Include Pre-releases",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f)
+                )
+                Switch(
+                    checked = uiState.includePrereleaseUpdates,
+                    onCheckedChange = viewModel::setIncludePrereleaseUpdates
+                )
+            }
         }
+
         Card(
             colors = CardDefaults.cardColors(containerColor = sectionCardColor),
             shape = RoundedCornerShape(18.dp),
@@ -4327,11 +4383,32 @@ fun SettingsScreen(
             SettingsRow(title = "Manage Servers", onClick = onManageServers)
             HorizontalDivider()
             SettingsRow(
+                title = "Sync Libraries",
+                value = lastSyncedValue,
+                showChevronWhenValue = false,
+                showChevronWhenUnselected = false,
+                onClick = {
+                    infoMessage = null
+                    viewModel.onSyncLibrariesClick()
+                }
+            )
+            HorizontalDivider()
+            SettingsRow(
                 title = "Sign Out",
                 onClick = {
                     infoMessage = null
-                    viewModel.onSignOutClick()
+                    signOutDialogVisible = true
                 }
+            )
+        }
+        Card(
+            colors = CardDefaults.cardColors(containerColor = sectionCardColor),
+            shape = RoundedCornerShape(18.dp),
+            border = sectionCardBorder
+        ) {
+            SettingsRow(
+                title = "About",
+                onClick = onOpenAbout
             )
         }
         uiState.errorMessage?.let { message ->
@@ -4351,7 +4428,6 @@ fun SettingsScreen(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
-
         if (skipForwardDialogVisible) {
             AlertDialog(
                 onDismissRequest = { skipForwardDialogVisible = false },
@@ -4403,6 +4479,65 @@ fun SettingsScreen(
                 dismissButton = {
                     TextButton(onClick = { skipBackwardDialogVisible = false }) {
                         Text("Close")
+                    }
+                }
+            )
+        }
+
+        if (signOutDialogVisible) {
+            AlertDialog(
+                onDismissRequest = { signOutDialogVisible = false },
+                title = { Text("Sign out of server?") },
+                text = {
+                    Text(
+                        text = "You will be signed out from ${uiState.serverDisplayName}."
+                    )
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            signOutDialogVisible = false
+                            viewModel.onSignOutClick()
+                        }
+                    ) {
+                        Text("Sign Out")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { signOutDialogVisible = false }) {
+                        Text("Cancel")
+                    }
+                }
+            )
+        }
+
+        uiState.availableUpdate?.let { release ->
+            AlertDialog(
+                onDismissRequest = viewModel::dismissAvailableUpdateDialog,
+                title = { Text("Update available") },
+                text = {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text("StillShelf ${release.versionName} is available.")
+                        release.body
+                            ?.trim()
+                            ?.takeIf { it.isNotEmpty() }
+                            ?.let { notes ->
+                                Text(
+                                    text = notes.take(240),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                    }
+                },
+                confirmButton = {
+                    TextButton(onClick = viewModel::installAvailableUpdate) {
+                        Text("Update")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = viewModel::dismissAvailableUpdateDialog) {
+                        Text("Cancel")
                     }
                 }
             )
@@ -4545,6 +4680,7 @@ private fun SettingsRow(
     title: String,
     value: String? = null,
     selected: Boolean = false,
+    showChevronWhenValue: Boolean = true,
     showChevronWhenUnselected: Boolean = true,
     onClick: (() -> Unit)? = null
 ) {
@@ -4564,12 +4700,14 @@ private fun SettingsRow(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Spacer(modifier = Modifier.width(4.dp))
-            Icon(
-                imageVector = Icons.Outlined.ChevronRight,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+            if (showChevronWhenValue) {
+                Spacer(modifier = Modifier.width(4.dp))
+                Icon(
+                    imageVector = Icons.Outlined.ChevronRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         } else if (selected) {
             Icon(imageVector = Icons.Filled.Check, contentDescription = null)
         } else if (showChevronWhenUnselected) {
@@ -4580,6 +4718,11 @@ private fun SettingsRow(
             )
         }
     }
+}
+
+private fun formatLastSyncedTimestamp(timestampMs: Long): String {
+    val formatter = SimpleDateFormat("MMM d, h:mm a", Locale.getDefault())
+    return formatter.format(Date(timestampMs))
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -5998,6 +6141,8 @@ fun PlayerScreen(
     } else {
         Color.White.copy(alpha = 0.2f)
     }
+    val immersiveDockContainerColor = bottomToolsBaseColor.copy(alpha = 0.24f)
+    val immersiveDockBorderColor = bottomToolsBorderColor.copy(alpha = 0.4f)
     val useFloatingChipsTools = bottomToolsStyle == PlayerBottomToolsStyle.FloatingChips
     val useSlimStripTools = bottomToolsStyle == PlayerBottomToolsStyle.SlimStrip
     val menuLikeContainerColor = if (appearanceUiState.materialDesignEnabled) {
@@ -6028,7 +6173,7 @@ fun PlayerScreen(
         useSlimStripTools -> if (nonMaterialDockMenuMatch) {
             nonMaterialMenuLikeContainer
         } else {
-            bottomToolsBaseColor.copy(alpha = if (immersiveEnabled) 0.24f else 0.28f)
+            if (immersiveEnabled) immersiveDockContainerColor else bottomToolsBaseColor.copy(alpha = 0.28f)
         }
         else -> Color.Transparent
     }
@@ -6037,54 +6182,50 @@ fun PlayerScreen(
         useSlimStripTools -> if (nonMaterialDockMenuMatch) {
             nonMaterialMenuLikeBorder
         } else {
-            bottomToolsBorderColor.copy(alpha = 0.4f)
+            immersiveDockBorderColor
         }
         else -> Color.Transparent
     }
     val toolsItemContainerColor = when {
-        useFloatingChipsTools -> menuLikeContainerColor
+        useFloatingChipsTools -> if (immersiveEnabled) immersiveDockContainerColor else menuLikeContainerColor
         useSlimStripTools -> Color.Transparent
         else -> Color.Transparent
     }
     val toolsItemBorderColor = when {
-        useFloatingChipsTools -> menuLikeBorderColor
+        useFloatingChipsTools -> if (immersiveEnabled) immersiveDockBorderColor else menuLikeBorderColor
         useSlimStripTools -> Color.Transparent
         else -> Color.Transparent
     }
     val toolsRowHorizontalPadding = when {
         useFloatingChipsTools -> 6.dp
-        useSlimStripTools -> 8.dp
-        else -> 0.dp
-    }
-    val toolsRowVerticalPadding = when {
-        useFloatingChipsTools -> 5.dp
         useSlimStripTools -> 6.dp
         else -> 0.dp
     }
-    val toolsRowSpacing = when {
-        useFloatingChipsTools -> 4.dp
+    val toolsRowVerticalPadding = when {
+        useFloatingChipsTools -> 2.dp
         useSlimStripTools -> 2.dp
+        else -> 0.dp
+    }
+    val toolsRowSpacing = when {
+        useFloatingChipsTools -> 3.dp
+        useSlimStripTools -> 3.dp
         else -> 4.dp
     }
     val toolsShowIconBubble = useFloatingChipsTools
     val toolsItemHeight = when {
-        useFloatingChipsTools -> 76.dp
-        useSlimStripTools -> 74.dp
+        useFloatingChipsTools -> 62.dp
+        useSlimStripTools -> 62.dp
         else -> 70.dp
     }
     val mainPlayButtonContainer = if (immersiveEnabled) {
-        MaterialTheme.colorScheme.surface.copy(alpha = 0.84f)
+        immersiveDockContainerColor
     } else if (!appearanceUiState.materialDesignEnabled) {
         nonMaterialMenuLikeContainer
     } else {
         MaterialTheme.colorScheme.surfaceVariant
     }
     val mainPlayButtonBorderColor = when {
-        immersiveEnabled -> if (useSlimStripTools) {
-            toolsOuterBorderColor
-        } else {
-            bottomToolsBorderColor.copy(alpha = 0.4f)
-        }
+        immersiveEnabled -> immersiveDockBorderColor
         !appearanceUiState.materialDesignEnabled -> nonMaterialMenuLikeBorder
         else -> Color.Transparent
     }
@@ -6121,7 +6262,7 @@ fun PlayerScreen(
     val coverTargetWidth = (effectiveHeightDp * 0.42f).dp.coerceIn(286.dp, 332.dp)
     val controlsRowPadding = (effectiveHeightDp * 0.04f).dp.coerceIn(24.dp, 38.dp)
     val bottomToolsTopPadding = (effectiveHeightDp * 0.012f).dp.coerceIn(8.dp, 14.dp)
-    val bottomToolsBottomPadding = (effectiveHeightDp * 0.01f).dp.coerceIn(6.dp, 10.dp)
+    val bottomToolsBottomPadding = (effectiveHeightDp * 0.006f).dp.coerceIn(2.dp, 6.dp)
     val playerTopOffset = (effectiveHeightDp * 0.02f).dp.coerceIn(8.dp, 16.dp)
 
     LaunchedEffect(actionMessage) {
@@ -6567,6 +6708,7 @@ fun PlayerScreen(
                             containerColor = toolsItemContainerColor,
                             containerBorderColor = toolsItemBorderColor,
                             showIconBubble = toolsShowIconBubble,
+                            showSecondaryLabelWhenValue = false,
                             onClick = { bottomMenuExpanded = true }
                         )
                         AppDropdownMenu(
@@ -7517,7 +7659,7 @@ private fun PlayerBottomToolItem(
                 shape = itemShape
             )
             .clickable(onClick = onClick)
-            .padding(horizontal = 4.dp, vertical = 4.dp),
+            .padding(start = 4.dp, end = 4.dp, top = 1.dp, bottom = 4.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
@@ -7567,7 +7709,7 @@ private fun PlayerBottomToolItem(
                 textAlign = TextAlign.Center,
                 modifier = Modifier.fillMaxWidth()
             )
-        } else {
+        } else if (showSecondaryLabelWhenValue) {
             Spacer(modifier = Modifier.height(11.dp))
         }
     }

--- a/app/src/main/java/com/stillshelf/app/ui/screens/SettingsViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/SettingsViewModel.kt
@@ -8,6 +8,8 @@ import com.stillshelf.app.core.datastore.SessionPreferences
 import com.stillshelf.app.core.util.AppResult
 import com.stillshelf.app.data.repo.SessionRepository
 import com.stillshelf.app.ui.theme.AppThemeMode
+import com.stillshelf.app.update.AppUpdateManager
+import com.stillshelf.app.update.AppUpdateRelease
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -31,6 +33,13 @@ data class SettingsUiState(
     val skipForwardSeconds: Int = 15,
     val skipBackwardSeconds: Int = 15,
     val lockScreenControlMode: String = "skip",
+    val isSyncingLibraries: Boolean = false,
+    val lastLibrarySyncAtMs: Long? = null,
+    val syncToastMessage: String? = null,
+    val updateCheckOnStartupEnabled: Boolean = true,
+    val includePrereleaseUpdates: Boolean = false,
+    val isCheckingForUpdates: Boolean = false,
+    val availableUpdate: AppUpdateRelease? = null,
     val errorMessage: String? = null
 )
 
@@ -38,6 +47,7 @@ data class SettingsUiState(
 class SettingsViewModel @Inject constructor(
     private val sessionRepository: SessionRepository,
     private val sessionPreferences: SessionPreferences,
+    private val appUpdateManager: AppUpdateManager,
     @param:ApplicationContext private val appContext: Context
 ) : ViewModel() {
     private val mutableUiState = MutableStateFlow(SettingsUiState())
@@ -60,7 +70,10 @@ class SettingsViewModel @Inject constructor(
                         materialDesignEnabled = pref.materialDesignEnabled,
                         skipForwardSeconds = pref.skipForwardSeconds,
                         skipBackwardSeconds = pref.skipBackwardSeconds,
-                        lockScreenControlMode = pref.lockScreenControlMode
+                        lockScreenControlMode = pref.lockScreenControlMode,
+                        lastLibrarySyncAtMs = pref.lastLibrarySyncAtMs,
+                        updateCheckOnStartupEnabled = pref.updateCheckOnStartup,
+                        includePrereleaseUpdates = pref.updateIncludePrereleases
                     )
                 } else {
                     SettingsUiState(
@@ -73,12 +86,118 @@ class SettingsViewModel @Inject constructor(
                         materialDesignEnabled = pref.materialDesignEnabled,
                         skipForwardSeconds = pref.skipForwardSeconds,
                         skipBackwardSeconds = pref.skipBackwardSeconds,
-                        lockScreenControlMode = pref.lockScreenControlMode
+                        lockScreenControlMode = pref.lockScreenControlMode,
+                        lastLibrarySyncAtMs = pref.lastLibrarySyncAtMs,
+                        updateCheckOnStartupEnabled = pref.updateCheckOnStartup,
+                        includePrereleaseUpdates = pref.updateIncludePrereleases
                     )
                 }
             }.collect { state ->
                 mutableUiState.update { previous ->
-                    state.copy(errorMessage = previous.errorMessage)
+                    state.copy(
+                        isSyncingLibraries = previous.isSyncingLibraries,
+                        syncToastMessage = previous.syncToastMessage,
+                        isCheckingForUpdates = previous.isCheckingForUpdates,
+                        availableUpdate = previous.availableUpdate,
+                        errorMessage = previous.errorMessage
+                    )
+                }
+            }
+        }
+    }
+
+    fun onCheckForUpdatesClick() {
+        if (uiState.value.isCheckingForUpdates) return
+        viewModelScope.launch {
+            mutableUiState.update {
+                it.copy(
+                    isCheckingForUpdates = true,
+                    availableUpdate = null,
+                    syncToastMessage = null,
+                    errorMessage = null
+                )
+            }
+            when (
+                val result = appUpdateManager.checkForUpdate(
+                    includePrereleases = uiState.value.includePrereleaseUpdates
+                )
+            ) {
+                is AppResult.Success -> {
+                    val update = result.value
+                    mutableUiState.update {
+                        it.copy(
+                            isCheckingForUpdates = false,
+                            availableUpdate = update,
+                            syncToastMessage = if (update == null) "No updates found." else null
+                        )
+                    }
+                }
+
+                is AppResult.Error -> {
+                    mutableUiState.update {
+                        it.copy(
+                            isCheckingForUpdates = false,
+                            syncToastMessage = "Update check failed"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun dismissAvailableUpdateDialog() {
+        mutableUiState.update { it.copy(availableUpdate = null) }
+    }
+
+    fun installAvailableUpdate() {
+        val release = uiState.value.availableUpdate ?: return
+        mutableUiState.update { it.copy(availableUpdate = null) }
+        viewModelScope.launch {
+            when (val result = appUpdateManager.downloadAndInstallUpdate(release)) {
+                is AppResult.Success -> {
+                    mutableUiState.update {
+                        it.copy(syncToastMessage = "Update started")
+                    }
+                }
+
+                is AppResult.Error -> {
+                    mutableUiState.update { it.copy(errorMessage = result.message) }
+                }
+            }
+        }
+    }
+
+    fun onSyncLibrariesClick() {
+        if (uiState.value.isSyncingLibraries) return
+        viewModelScope.launch {
+            mutableUiState.update {
+                it.copy(
+                    isSyncingLibraries = true,
+                    syncToastMessage = null,
+                    errorMessage = null
+                )
+            }
+            when (val result = sessionRepository.refreshLibrariesForActiveServer()) {
+                is AppResult.Success -> {
+                    val syncedAtMs = System.currentTimeMillis()
+                    sessionPreferences.setLastLibrarySyncAtMs(syncedAtMs)
+                    mutableUiState.update {
+                        it.copy(
+                            isSyncingLibraries = false,
+                            lastLibrarySyncAtMs = syncedAtMs,
+                            syncToastMessage = "Library synced",
+                            errorMessage = null
+                        )
+                    }
+                }
+
+                is AppResult.Error -> {
+                    mutableUiState.update {
+                        it.copy(
+                            isSyncingLibraries = false,
+                            syncToastMessage = "Sync failed"
+                        )
+                    }
                 }
             }
         }
@@ -100,6 +219,22 @@ class SettingsViewModel @Inject constructor(
 
     fun clearError() {
         mutableUiState.update { it.copy(errorMessage = null) }
+    }
+
+    fun consumeSyncToastMessage() {
+        mutableUiState.update { it.copy(syncToastMessage = null) }
+    }
+
+    fun setUpdateCheckOnStartupEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            sessionPreferences.setUpdateCheckOnStartup(enabled)
+        }
+    }
+
+    fun setIncludePrereleaseUpdates(enabled: Boolean) {
+        viewModelScope.launch {
+            sessionPreferences.setUpdateIncludePrereleases(enabled)
+        }
     }
 
     fun setImmersivePlayerEnabled(enabled: Boolean) {

--- a/app/src/main/java/com/stillshelf/app/update/AppUpdateManager.kt
+++ b/app/src/main/java/com/stillshelf/app/update/AppUpdateManager.kt
@@ -1,0 +1,331 @@
+package com.stillshelf.app.update
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.FileProvider
+import com.stillshelf.app.core.datastore.SessionPreferences
+import com.stillshelf.app.core.util.AppResult
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONArray
+
+data class AppUpdateRelease(
+    val tagName: String,
+    val versionName: String,
+    val htmlUrl: String,
+    val body: String?,
+    val apkDownloadUrl: String?
+)
+
+@Singleton
+class AppUpdateManager @Inject constructor(
+    @param:ApplicationContext private val appContext: Context,
+    private val okHttpClient: OkHttpClient,
+    private val sessionPreferences: SessionPreferences
+) {
+    companion object {
+        private const val RELEASES_API_URL = "https://api.github.com/repos/kalzEOS/stillshelf/releases"
+        private const val RELEASES_PAGE_URL = "https://github.com/kalzEOS/stillshelf/releases"
+        private const val APK_MIME_TYPE = "application/vnd.android.package-archive"
+    }
+
+    suspend fun checkForUpdate(includePrereleases: Boolean): AppResult<AppUpdateRelease?> {
+        return withContext(Dispatchers.IO) {
+            runCatching {
+                val request = Request.Builder()
+                    .url(RELEASES_API_URL)
+                    .header("Accept", "application/vnd.github+json")
+                    .header("User-Agent", "StillShelf/${installedVersionName()}")
+                    .build()
+                okHttpClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        throw IllegalStateException("Unable to check updates (${response.code}).")
+                    }
+                    val responseBody = response.body?.string().orEmpty()
+                    val releases = parseReleases(responseBody)
+                    val currentVersion = SemanticVersion.parse(installedVersionName())
+                    val latest = releases
+                        .asSequence()
+                        .filter { includePrereleases || !it.isPrerelease }
+                        .sortedWith(compareByDescending<ParsedRelease> { it.version })
+                        .firstOrNull { parsed ->
+                            if (currentVersion == null) {
+                                true
+                            } else {
+                                parsed.version > currentVersion
+                            }
+                        }
+                    latest?.toRelease()
+                }
+            }.fold(
+                onSuccess = { AppResult.Success(it) },
+                onFailure = { AppResult.Error(it.message ?: "Unable to check updates.", it) }
+            )
+        }
+    }
+
+    suspend fun downloadAndInstallUpdate(release: AppUpdateRelease): AppResult<Unit> {
+        return withContext(Dispatchers.IO) {
+            val downloadUrl = release.apkDownloadUrl
+            if (downloadUrl.isNullOrBlank()) {
+                openReleasePage(release.htmlUrl)
+                return@withContext AppResult.Success(Unit)
+            }
+
+            runCatching {
+                val updatesDir = File(appContext.cacheDir, "updates").apply { mkdirs() }
+                val safeVersion = release.versionName
+                    .ifBlank { release.tagName }
+                    .replace(Regex("[^a-zA-Z0-9._-]"), "_")
+                val apkFile = File(updatesDir, "stillshelf-$safeVersion.apk")
+                if (apkFile.exists()) {
+                    apkFile.delete()
+                }
+                val request = Request.Builder()
+                    .url(downloadUrl)
+                    .header("User-Agent", "StillShelf/${installedVersionName()}")
+                    .build()
+                okHttpClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        throw IllegalStateException("Download failed (${response.code}).")
+                    }
+                    val body = response.body ?: throw IllegalStateException("Download returned empty data.")
+                    apkFile.outputStream().use { output ->
+                        body.byteStream().use { input ->
+                            input.copyTo(output)
+                        }
+                    }
+                }
+                if (!apkFile.exists() || apkFile.length() <= 0L) {
+                    throw IllegalStateException("Downloaded APK is invalid.")
+                }
+                sessionPreferences.setPendingUpdateInstall(
+                    apkPath = apkFile.absolutePath,
+                    versionName = release.versionName
+                )
+                if (!launchInstaller(apkFile)) {
+                    throw IllegalStateException("Unable to open package installer on this device.")
+                }
+            }.fold(
+                onSuccess = { AppResult.Success(Unit) },
+                onFailure = { throwable ->
+                    AppResult.Error(throwable.message ?: "Unable to update app.", throwable)
+                }
+            )
+        }
+    }
+
+    suspend fun cleanupInstalledUpdateApkIfNeeded() {
+        val pref = sessionPreferences.state.first()
+        val apkPath = pref.pendingUpdateApkPath.orEmpty().trim()
+        if (apkPath.isBlank()) return
+        val apkFile = File(apkPath)
+        val targetVersion = SemanticVersion.parse(pref.pendingUpdateVersionName)
+        val currentVersion = SemanticVersion.parse(installedVersionName())
+        val didUpgrade = when {
+            targetVersion == null || currentVersion == null -> false
+            else -> currentVersion >= targetVersion
+        }
+        if (!apkFile.exists() || didUpgrade) {
+            runCatching { apkFile.delete() }
+            sessionPreferences.setPendingUpdateInstall(apkPath = null, versionName = null)
+        }
+    }
+
+    fun releasesPageUrl(): String = RELEASES_PAGE_URL
+
+    fun openReleasePage(url: String = RELEASES_PAGE_URL) {
+        runCatching {
+            val intent = Intent(Intent.ACTION_VIEW).apply {
+                data = android.net.Uri.parse(url)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            appContext.startActivity(intent)
+        }
+    }
+
+    private fun launchInstaller(apkFile: File): Boolean {
+        val authority = "${appContext.packageName}.fileprovider"
+        val apkUri = runCatching {
+            FileProvider.getUriForFile(appContext, authority, apkFile)
+        }.getOrNull() ?: return false
+
+        val packageManager = appContext.packageManager
+        val installIntent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(apkUri, APK_MIME_TYPE)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        if (installIntent.resolveActivity(packageManager) != null) {
+            appContext.startActivity(installIntent)
+            return true
+        }
+        val fallbackIntent = Intent(Intent.ACTION_INSTALL_PACKAGE).apply {
+            data = apkUri
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        if (fallbackIntent.resolveActivity(packageManager) == null) {
+            return false
+        }
+        appContext.startActivity(fallbackIntent)
+        return true
+    }
+
+    private fun installedVersionName(): String {
+        return runCatching {
+            val packageInfo = appContext.packageManager.getPackageInfo(appContext.packageName, 0)
+            packageInfo.versionName.orEmpty()
+        }.getOrDefault("")
+    }
+
+    private fun parseReleases(raw: String): List<ParsedRelease> {
+        if (raw.isBlank()) return emptyList()
+        val source = runCatching { JSONArray(raw) }.getOrNull() ?: return emptyList()
+        val releases = mutableListOf<ParsedRelease>()
+        for (index in 0 until source.length()) {
+            val node = source.optJSONObject(index) ?: continue
+            if (node.optBoolean("draft", false)) continue
+            val tagName = node.optString("tag_name").trim()
+            val htmlUrl = node.optString("html_url").trim().ifBlank { RELEASES_PAGE_URL }
+            val version = SemanticVersion.parse(tagName) ?: continue
+            val body = node.optString("body").takeIf { it.isNotBlank() }
+            val isPrerelease = node.optBoolean("prerelease", false)
+            val assets = node.optJSONArray("assets")
+            var apkUrl: String? = null
+            if (assets != null) {
+                for (assetIndex in 0 until assets.length()) {
+                    val asset = assets.optJSONObject(assetIndex) ?: continue
+                    val name = asset.optString("name").trim()
+                    if (!name.endsWith(".apk", ignoreCase = true)) continue
+                    val browserDownloadUrl = asset.optString("browser_download_url").trim()
+                    if (browserDownloadUrl.isNotBlank()) {
+                        apkUrl = browserDownloadUrl
+                        break
+                    }
+                }
+            }
+            releases += ParsedRelease(
+                tagName = tagName,
+                version = version,
+                isPrerelease = isPrerelease,
+                body = body,
+                htmlUrl = htmlUrl,
+                apkDownloadUrl = apkUrl
+            )
+        }
+        return releases
+    }
+
+    private data class ParsedRelease(
+        val tagName: String,
+        val version: SemanticVersion,
+        val isPrerelease: Boolean,
+        val body: String?,
+        val htmlUrl: String,
+        val apkDownloadUrl: String?
+    ) {
+        fun toRelease(): AppUpdateRelease {
+            return AppUpdateRelease(
+                tagName = tagName,
+                versionName = version.raw,
+                htmlUrl = htmlUrl,
+                body = body,
+                apkDownloadUrl = apkDownloadUrl
+            )
+        }
+    }
+
+    private data class SemanticVersion(
+        val major: Int,
+        val minor: Int,
+        val patch: Int,
+        val preRelease: List<PreReleaseToken>,
+        val raw: String
+    ) : Comparable<SemanticVersion> {
+        override fun compareTo(other: SemanticVersion): Int {
+            if (major != other.major) return major.compareTo(other.major)
+            if (minor != other.minor) return minor.compareTo(other.minor)
+            if (patch != other.patch) return patch.compareTo(other.patch)
+            val thisPre = preRelease
+            val otherPre = other.preRelease
+            if (thisPre.isEmpty() && otherPre.isEmpty()) return 0
+            if (thisPre.isEmpty()) return 1
+            if (otherPre.isEmpty()) return -1
+            val size = maxOf(thisPre.size, otherPre.size)
+            for (index in 0 until size) {
+                val left = thisPre.getOrNull(index)
+                val right = otherPre.getOrNull(index)
+                if (left == null) return -1
+                if (right == null) return 1
+                val compare = left.compareTo(right)
+                if (compare != 0) return compare
+            }
+            return 0
+        }
+
+        companion object {
+            private val VERSION_REGEX = Regex("""^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$""")
+
+            fun parse(rawValue: String?): SemanticVersion? {
+                val raw = rawValue.orEmpty().trim()
+                if (raw.isBlank()) return null
+                val match = VERSION_REGEX.matchEntire(raw) ?: return null
+                val major = match.groupValues[1].toIntOrNull() ?: return null
+                val minor = match.groupValues[2].toIntOrNull() ?: return null
+                val patch = match.groupValues[3].toIntOrNull() ?: return null
+                val preReleaseRaw = match.groupValues.getOrNull(4).orEmpty()
+                val preRelease = if (preReleaseRaw.isBlank()) {
+                    emptyList()
+                } else {
+                    preReleaseRaw
+                        .split(".")
+                        .mapNotNull { part ->
+                            val token = part.trim()
+                            if (token.isBlank()) null else PreReleaseToken.parse(token)
+                        }
+                }
+                return SemanticVersion(
+                    major = major,
+                    minor = minor,
+                    patch = patch,
+                    preRelease = preRelease,
+                    raw = raw.removePrefix("v")
+                )
+            }
+        }
+    }
+
+    private data class PreReleaseToken(
+        val numericValue: Int?,
+        val textValue: String
+    ) : Comparable<PreReleaseToken> {
+        override fun compareTo(other: PreReleaseToken): Int {
+            val leftNumber = numericValue
+            val rightNumber = other.numericValue
+            return when {
+                leftNumber != null && rightNumber != null -> leftNumber.compareTo(rightNumber)
+                leftNumber != null -> -1
+                rightNumber != null -> 1
+                else -> textValue.compareTo(other.textValue)
+            }
+        }
+
+        companion object {
+            fun parse(raw: String): PreReleaseToken {
+                val numeric = raw.toIntOrNull()
+                return PreReleaseToken(
+                    numericValue = numeric,
+                    textValue = raw.lowercase()
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/res/xml/update_file_paths.xml
+++ b/app/src/main/res/xml/update_file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path
+        name="update_cache"
+        path="updates/" />
+</paths>


### PR DESCRIPTION
## Summary
- add settings sign-out confirmation dialog
- add manual library sync row with persistent Last synced timestamp
- persist sync timestamp in DataStore and update it from home pull-to-refresh too
- add app update checks (manual + startup toggle + prerelease toggle)
- add update prompt dialog and APK download/install flow via FileProvider
- clean up pending downloaded update APK after successful upgrade
- implement lock screen Next/Previous mode with chapter-aware and adjacent-book behavior
- lock app to portrait orientation
- bump app version to 0.1.0-rc1 (versionCode 8)

## Validation
- ./gradlew :app:compileDebugKotlin --no-daemon
- ./gradlew :app:testDebugUnitTest
- ./gradlew :app:assembleRelease --no-daemon