### PR TITLE
Fix server playback isolation and sub-series handling

### DIFF
--- a/app/src/main/java/com/stillshelf/app/core/model/Models.kt
+++ b/app/src/main/java/com/stillshelf/app/core/model/Models.kt
@@ -22,6 +22,8 @@ data class BookSummary(
     val durationSeconds: Double?,
     val coverUrl: String?,
     val seriesName: String? = null,
+    val seriesNames: List<String> = emptyList(),
+    val seriesIds: List<String> = emptyList(),
     val seriesSequence: Double? = null,
     val genres: List<String> = emptyList(),
     val publishedYear: String? = null,

--- a/app/src/main/java/com/stillshelf/app/data/api/AudiobookshelfApi.kt
+++ b/app/src/main/java/com/stillshelf/app/data/api/AudiobookshelfApi.kt
@@ -39,6 +39,8 @@ data class AudiobookshelfLibraryItemDto(
     val narratorName: String?,
     val durationSeconds: Double?,
     val seriesName: String?,
+    val seriesNames: List<String>,
+    val seriesIds: List<String>,
     val seriesSequence: Double?,
     val genres: List<String>,
     val publishedYear: String?,
@@ -93,6 +95,8 @@ data class AudiobookshelfBookDetailDto(
     val description: String?,
     val publishedYear: String?,
     val seriesName: String?,
+    val seriesNames: List<String>,
+    val seriesIds: List<String>,
     val seriesSequence: Double?,
     val genres: List<String>,
     val sizeBytes: Long?,
@@ -2358,6 +2362,25 @@ class AudiobookshelfApi @Inject constructor(
         return addAuthTokenFragment(rawUrl, authToken)
     }
 
+    fun buildImagePathUrl(
+        baseUrl: String,
+        imagePath: String,
+        authToken: String
+    ): String {
+        val path = imagePath.trim()
+        if (path.startsWith("http://") || path.startsWith("https://")) {
+            return path
+        }
+        val normalized = baseUrl.removeSuffix("/")
+        val baseHttpUrl = normalized.toHttpUrlOrNull()
+            ?: return addAuthTokenFragment("${normalized}/${path.removePrefix("/")}", authToken)
+        val rawUrl = baseHttpUrl.newBuilder()
+            .addPathSegments(path.removePrefix("/"))
+            .build()
+            .toString()
+        return addAuthTokenFragment(rawUrl, authToken)
+    }
+
     private fun authHeaderValue(token: String): String = authorizationHeaderValue(token)
 
     private fun parseLibraries(rawJson: String): List<AudiobookshelfLibraryDto> {
@@ -2458,6 +2481,16 @@ class AudiobookshelfApi @Inject constructor(
             progress != null -> progress >= 0.995
             else -> false
         }
+        val seriesNames = extractSeriesNames(
+            metadata = metadata,
+            rootSeriesArray = item.optJSONArray("series"),
+            mediaSeriesArray = media.optJSONArray("series")
+        )
+        val seriesIds = extractSeriesIds(
+            metadata = metadata,
+            rootSeriesArray = item.optJSONArray("series"),
+            mediaSeriesArray = media.optJSONArray("series")
+        )
 
         return AudiobookshelfLibraryItemDto(
             id = id,
@@ -2466,7 +2499,9 @@ class AudiobookshelfApi @Inject constructor(
             authorName = metadata?.optString("authorName").orEmpty().ifBlank { "Unknown Author" },
             narratorName = metadata?.optString("narratorName").orEmpty().ifBlank { null },
             durationSeconds = media.optDoubleOrNull("duration"),
-            seriesName = metadata?.optString("seriesName")?.ifBlank { null },
+            seriesName = seriesNames.firstOrNull(),
+            seriesNames = seriesNames,
+            seriesIds = seriesIds,
             seriesSequence = extractSeriesSequence(metadata),
             genres = metadata.optStringList("genres"),
             publishedYear = metadata?.optString("publishedYear")?.ifBlank { null },
@@ -3180,6 +3215,17 @@ class AudiobookshelfApi @Inject constructor(
             }
         }
 
+        val seriesNames = extractSeriesNames(
+            metadata = metadata,
+            rootSeriesArray = root.optJSONArray("series"),
+            mediaSeriesArray = media.optJSONArray("series")
+        )
+        val seriesIds = extractSeriesIds(
+            metadata = metadata,
+            rootSeriesArray = root.optJSONArray("series"),
+            mediaSeriesArray = media.optJSONArray("series")
+        )
+
         return AudiobookshelfBookDetailDto(
             id = id,
             libraryId = libraryId,
@@ -3189,7 +3235,9 @@ class AudiobookshelfApi @Inject constructor(
             durationSeconds = media.optDoubleOrNull("duration"),
             description = metadata?.optString("description")?.ifBlank { null },
             publishedYear = metadata?.optString("publishedYear")?.ifBlank { null },
-            seriesName = metadata?.optString("seriesName")?.ifBlank { null },
+            seriesName = seriesNames.firstOrNull(),
+            seriesNames = seriesNames,
+            seriesIds = seriesIds,
             seriesSequence = extractSeriesSequence(metadata),
             genres = metadata.optStringList("genres"),
             sizeBytes = media.optLongOrNull("size") ?: root.optLongOrNull("size"),
@@ -3212,6 +3260,67 @@ class AudiobookshelfApi @Inject constructor(
             item.optDoubleOrNull("seriesSequence")?.let { return it }
         }
         return null
+    }
+
+    private fun extractSeriesNames(
+        metadata: JSONObject?,
+        rootSeriesArray: JSONArray? = null,
+        mediaSeriesArray: JSONArray? = null
+    ): List<String> {
+        metadata ?: return emptyList()
+        val names = linkedSetOf<String>()
+        val primaryName = metadata.optString("seriesName").trim()
+        if (primaryName.isNotBlank()) {
+            names += primaryName
+        }
+        listOf(metadata.optJSONArray("series"), rootSeriesArray, mediaSeriesArray).forEach { seriesArray ->
+            if (seriesArray == null) return@forEach
+            for (index in 0 until seriesArray.length()) {
+                val entry = seriesArray.opt(index)
+                when (entry) {
+                    is JSONObject -> {
+                        val name = entry.optString("name")
+                            .ifBlank { entry.optString("seriesName") }
+                            .trim()
+                        if (name.isNotBlank()) {
+                            names += name
+                        }
+                    }
+
+                    is String -> {
+                        val value = entry.trim()
+                        if (value.isNotBlank()) {
+                            names += value
+                        }
+                    }
+                }
+            }
+        }
+        return names.toList()
+    }
+
+    private fun extractSeriesIds(
+        metadata: JSONObject?,
+        rootSeriesArray: JSONArray? = null,
+        mediaSeriesArray: JSONArray? = null
+    ): List<String> {
+        metadata ?: return emptyList()
+        val ids = linkedSetOf<String>()
+        listOf(metadata.optJSONArray("series"), rootSeriesArray, mediaSeriesArray).forEach { seriesArray ->
+            if (seriesArray == null) return@forEach
+            for (index in 0 until seriesArray.length()) {
+                val entry = seriesArray.opt(index)
+                if (entry is JSONObject) {
+                    val id = entry.optString("id")
+                        .ifBlank { entry.optString("_id") }
+                        .trim()
+                    if (id.isNotBlank()) {
+                        ids += id
+                    }
+                }
+            }
+        }
+        return ids.toList()
     }
 
     private fun buildUrl(

--- a/app/src/main/java/com/stillshelf/app/data/repo/SessionRepositoryImpl.kt
+++ b/app/src/main/java/com/stillshelf/app/data/repo/SessionRepositoryImpl.kt
@@ -186,6 +186,8 @@ class SessionRepositoryImpl @Inject constructor(
         }
 
         sessionPreferences.setActiveSelection(serverId = server.id, libraryId = null)
+        sessionPreferences.setLastPlayedBookId(null)
+        sessionPreferences.clearCachedHomeFeed()
         sessionPreferences.setRequiresLibrarySelection(true)
         clearContentCaches()
         return AppResult.Success(Unit)
@@ -332,6 +334,8 @@ class SessionRepositoryImpl @Inject constructor(
 
             secureTokenStorage.saveToken(serverId, token)
             sessionPreferences.setActiveSelection(serverId = serverId, libraryId = null)
+            sessionPreferences.setLastPlayedBookId(null)
+            sessionPreferences.clearCachedHomeFeed()
             sessionPreferences.setRequiresLibrarySelection(true)
             clearContentCaches()
 
@@ -2519,6 +2523,8 @@ class SessionRepositoryImpl @Inject constructor(
             .put("durationSeconds", book.durationSeconds)
             .put("coverUrl", book.coverUrl)
             .put("seriesName", book.seriesName)
+            .put("seriesNames", JSONArray(book.seriesNames))
+            .put("seriesIds", JSONArray(book.seriesIds))
             .put("seriesSequence", book.seriesSequence)
             .put("genres", JSONArray(book.genres))
             .put("publishedYear", book.publishedYear)
@@ -2545,6 +2551,8 @@ class SessionRepositoryImpl @Inject constructor(
             durationSeconds = source.optDoubleOrNull("durationSeconds"),
             coverUrl = source.optStringOrNull("coverUrl"),
             seriesName = source.optStringOrNull("seriesName"),
+            seriesNames = source.optStringList("seriesNames"),
+            seriesIds = source.optStringList("seriesIds"),
             seriesSequence = source.optDoubleOrNull("seriesSequence"),
             genres = genres,
             publishedYear = source.optStringOrNull("publishedYear"),
@@ -2570,6 +2578,17 @@ class SessionRepositoryImpl @Inject constructor(
         return optDouble(key)
     }
 
+    private fun JSONObject.optStringList(key: String): List<String> {
+        if (!has(key) || isNull(key)) return emptyList()
+        val array = optJSONArray(key) ?: return emptyList()
+        return buildList {
+            for (index in 0 until array.length()) {
+                val value = array.optString(index).trim()
+                if (value.isNotBlank()) add(value)
+            }
+        }
+    }
+
     private fun AudiobookshelfLibraryItemDto.toBookSummary(
         baseUrl: String,
         authToken: String
@@ -2583,6 +2602,8 @@ class SessionRepositoryImpl @Inject constructor(
             durationSeconds = durationSeconds,
             coverUrl = audiobookshelfApi.buildCoverUrl(baseUrl, id, authToken),
             seriesName = seriesName,
+            seriesNames = seriesNames,
+            seriesIds = seriesIds,
             seriesSequence = seriesSequence,
             genres = genres,
             publishedYear = publishedYear,
@@ -2628,7 +2649,7 @@ class SessionRepositoryImpl @Inject constructor(
                 imagePath?.takeIf { it.startsWith("http://") || it.startsWith("https://") }
                     ?: audiobookshelfApi.buildAuthorImageUrl(baseUrl, id, authToken)
             } else {
-                null
+                imagePath?.let { audiobookshelfApi.buildImagePathUrl(baseUrl, it, authToken) }
             }
         )
     }
@@ -2647,6 +2668,8 @@ class SessionRepositoryImpl @Inject constructor(
             durationSeconds = durationSeconds,
             coverUrl = audiobookshelfApi.buildCoverUrl(baseUrl, id, authToken),
             seriesName = seriesName,
+            seriesNames = seriesNames,
+            seriesIds = seriesIds,
             seriesSequence = seriesSequence,
             genres = genres,
             publishedYear = publishedYear
@@ -2680,6 +2703,8 @@ class SessionRepositoryImpl @Inject constructor(
             durationSeconds = durationSeconds,
             coverUrl = audiobookshelfApi.buildCoverUrl(baseUrl, id, authToken),
             seriesName = seriesName,
+            seriesNames = seriesNames,
+            seriesIds = seriesIds,
             seriesSequence = seriesSequence,
             genres = genres,
             publishedYear = publishedYear

--- a/app/src/main/java/com/stillshelf/app/playback/controller/PlaybackController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/controller/PlaybackController.kt
@@ -154,6 +154,8 @@ class PlaybackController @Inject constructor(
     private var loudnessEnhancer: LoudnessEnhancer? = null
     private var equalizer: Equalizer? = null
     private var previousRestartState: PreviousRestartState? = null
+    private var observedActiveServerId: String? = null
+    private var hasObservedActiveServerId: Boolean = false
 
     private data class NotificationSignature(
         val bookId: String,
@@ -188,6 +190,7 @@ class PlaybackController @Inject constructor(
         audioManager.registerAudioDeviceCallback(audioDeviceCallback, Handler(Looper.getMainLooper()))
         refreshAudioOutputDevices()
         observePlaybackPreferences()
+        observeActiveServerSelection()
     }
 
     fun playBook(bookId: String, startPositionMs: Long? = null) {
@@ -661,7 +664,13 @@ class PlaybackController @Inject constructor(
     }
 
     private fun releasePlayer() {
-        syncProgress(force = true, isFinished = false)
+        releasePlayer(syncProgressBeforeRelease = true)
+    }
+
+    private fun releasePlayer(syncProgressBeforeRelease: Boolean) {
+        if (syncProgressBeforeRelease) {
+            syncProgress(force = true, isFinished = false)
+        }
         progressJob?.cancel()
         progressJob = null
         releaseAudioEffects()
@@ -757,6 +766,50 @@ class PlaybackController @Inject constructor(
                     )
                 }
             }
+        }
+    }
+
+    private fun observeActiveServerSelection() {
+        scope.launch {
+            sessionPreferences.state.collect { pref ->
+                val nextServerId = pref.activeServerId
+                if (!hasObservedActiveServerId) {
+                    observedActiveServerId = nextServerId
+                    hasObservedActiveServerId = true
+                    return@collect
+                }
+                val previousServerId = observedActiveServerId
+                observedActiveServerId = nextServerId
+                if (previousServerId != nextServerId) {
+                    clearPlaybackForServerSwitch()
+                }
+            }
+        }
+    }
+
+    private fun clearPlaybackForServerSwitch() {
+        playRequestJob?.cancel()
+        playRequestToken += 1L
+        releasePlayer(syncProgressBeforeRelease = false)
+        currentBookId = null
+        cachedContinueListeningItem = null
+        attemptedAutoAdvanceTargetsMs.clear()
+        previousRestartState = null
+        playbackSyncGate.reset()
+        suppressNextAutoAdvanceOnCompletion = false
+        updateUiState { state ->
+            state.copy(
+                isLoading = false,
+                book = null,
+                isPlaying = false,
+                positionMs = 0L,
+                durationMs = 0L,
+                errorMessage = null,
+                sleepTimerMode = SleepTimerMode.Off,
+                sleepTimerRemainingMs = null,
+                sleepTimerTotalMs = null,
+                sleepTimerExpiredPromptVisible = false
+            )
         }
     }
 

--- a/app/src/main/java/com/stillshelf/app/ui/components/MiniPlayerBar.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/components/MiniPlayerBar.kt
@@ -55,7 +55,7 @@ fun MiniPlayerBar(
         state.isLoading -> "Loading playback..."
         item != null -> formatMiniPlayerSubtitle(item)
         !state.errorMessage.isNullOrBlank() -> state.errorMessage
-        else -> "Start a book from Continue Listening"
+        else -> "Start a book to listen."
     }
     val shape = RoundedCornerShape(24.dp)
     val borderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.72f)

--- a/app/src/main/java/com/stillshelf/app/ui/screens/EntityBrowseViewModels.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/EntityBrowseViewModels.kt
@@ -3,6 +3,7 @@ package com.stillshelf.app.ui.screens
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.stillshelf.app.core.datastore.SessionPreferences
+import com.stillshelf.app.core.model.BookSummary
 import com.stillshelf.app.core.model.BookmarkEntry
 import com.stillshelf.app.core.model.NamedEntitySummary
 import com.stillshelf.app.core.util.AppResult
@@ -142,6 +143,11 @@ class SeriesBrowseViewModel @Inject constructor(
     private val sessionRepository: SessionRepository,
     private val sessionPreferences: SessionPreferences
 ) : ViewModel() {
+    companion object {
+        private const val SERIES_BOOKS_PAGE_SIZE = 400
+        private const val SERIES_BOOKS_MAX_PAGES = 100
+    }
+
     private val mutableUiState = MutableStateFlow(SeriesBrowseUiState())
     val uiState: StateFlow<SeriesBrowseUiState> = mutableUiState.asStateFlow()
 
@@ -175,32 +181,43 @@ class SeriesBrowseViewModel @Inject constructor(
         viewModelScope.launch {
             when (val seriesResult = sessionRepository.fetchSeriesForActiveLibrary(forceRefresh = forceRefresh)) {
                 is AppResult.Success -> {
-                    val books = when (
-                        val booksResult = sessionRepository.fetchBooksForActiveLibrary(
-                            limit = 400,
-                            page = 0,
-                            forceRefresh = forceRefresh
-                        )
-                    ) {
-                        is AppResult.Success -> booksResult.value
-                        is AppResult.Error -> emptyList()
+                    val books = fetchAllBooksForSeriesMatching(forceRefresh = forceRefresh)
+                    val booksBySeries = mutableMapOf<String, MutableList<BookSummary>>()
+                    val booksBySeriesId = mutableMapOf<String, MutableList<BookSummary>>()
+                    val detailCache = mutableMapOf<String, BookSummary?>()
+                    books.forEach { book ->
+                        seriesMatchKeys(book).forEach { key ->
+                            booksBySeries.getOrPut(key) { mutableListOf() }.add(book)
+                        }
+                        book.seriesIds.forEach { seriesId ->
+                            val normalizedId = seriesId.trim()
+                            if (normalizedId.isNotBlank()) {
+                                booksBySeriesId.getOrPut(normalizedId) { mutableListOf() }.add(book)
+                            }
+                        }
                     }
-                    val booksBySeries = books
-                        .asSequence()
-                        .filter { !it.seriesName.isNullOrBlank() }
-                        .groupBy { normalizeSeriesName(it.seriesName.orEmpty()) }
 
-                    val cards = seriesResult.value.map { series ->
-                        val matchedBooks = booksBySeries[normalizeSeriesName(series.name)].orEmpty()
-                        val preferredCoverUrl = matchedBooks.firstOrNull { !it.coverUrl.isNullOrBlank() }?.coverUrl
-                            ?: series.imageUrl
-                            ?: matchedBooks.firstOrNull()?.coverUrl
-                        SeriesBrowseCard(
-                            id = series.id,
-                            name = series.name,
-                            subtitle = series.subtitle ?: matchedBooks.takeIf { it.isNotEmpty() }?.size?.let { "$it books" },
-                            coverUrl = preferredCoverUrl
-                        )
+                    val cards = buildList {
+                        seriesResult.value.forEach { series ->
+                            val matchedBooks = booksBySeries[normalizeSeriesName(series.name)].orEmpty()
+                                .ifEmpty { booksBySeriesId[series.id].orEmpty() }
+                            val preferredCoverUrl = matchedBooks.firstOrNull { !it.coverUrl.isNullOrBlank() }?.coverUrl
+                                ?: series.imageUrl
+                                ?: matchedBooks.firstOrNull()?.coverUrl
+                                ?: resolveSeriesCoverFromDetails(
+                                    series = series,
+                                    books = books,
+                                    detailCache = detailCache
+                                )
+                            add(
+                                SeriesBrowseCard(
+                                    id = series.id,
+                                    name = series.name,
+                                    subtitle = series.subtitle ?: matchedBooks.takeIf { it.isNotEmpty() }?.size?.let { "$it books" },
+                                    coverUrl = preferredCoverUrl
+                                )
+                            )
+                        }
                     }
                     mutableUiState.update {
                         it.copy(
@@ -220,6 +237,70 @@ class SeriesBrowseViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private suspend fun fetchAllBooksForSeriesMatching(forceRefresh: Boolean): List<BookSummary> {
+        val books = mutableListOf<BookSummary>()
+        var page = 0
+        while (page < SERIES_BOOKS_MAX_PAGES) {
+            when (
+                val result = sessionRepository.fetchBooksForActiveLibrary(
+                    limit = SERIES_BOOKS_PAGE_SIZE,
+                    page = page,
+                    forceRefresh = forceRefresh
+                )
+            ) {
+                is AppResult.Success -> {
+                    val batch = result.value
+                    if (batch.isEmpty()) break
+                    books += batch
+                    if (batch.size < SERIES_BOOKS_PAGE_SIZE) break
+                    page += 1
+                }
+
+                is AppResult.Error -> break
+            }
+        }
+        return books.distinctBy { it.id }
+    }
+
+    private suspend fun resolveSeriesCoverFromDetails(
+        series: NamedEntitySummary,
+        books: List<BookSummary>,
+        detailCache: MutableMap<String, BookSummary?>
+    ): String? {
+        val normalizedSeriesName = normalizeSeriesName(series.name)
+        books.forEach { book ->
+            val detailBook = detailCache.getOrPut(book.id) {
+                when (val detailResult = sessionRepository.fetchBookDetail(book.id, forceRefresh = false)) {
+                    is AppResult.Success -> detailResult.value.book
+                    is AppResult.Error -> null
+                }
+            } ?: return@forEach
+
+            val matchesById = detailBook.seriesIds.any { candidateId ->
+                seriesIdsLikelyMatch(candidateId, series.id)
+            }
+            val matchesByName = buildList {
+                detailBook.seriesName?.let(::add)
+                addAll(detailBook.seriesNames)
+            }.any { candidateName ->
+                val normalizedCandidate = normalizeSeriesName(candidateName)
+                normalizedCandidate.isNotBlank() &&
+                    (
+                        normalizedCandidate == normalizedSeriesName ||
+                            normalizedCandidate.contains(normalizedSeriesName) ||
+                            normalizedSeriesName.contains(normalizedCandidate)
+                        )
+            }
+            if (matchesById || matchesByName) {
+                val resolvedCover = detailBook.coverUrl ?: book.coverUrl
+                if (!resolvedCover.isNullOrBlank()) {
+                    return resolvedCover
+                }
+            }
+        }
+        return null
     }
 }
 
@@ -660,6 +741,30 @@ private fun normalizeSeriesName(value: String): String {
         .replace(Regex("\\s*#\\d+.*$"), "")
         .replace(Regex("\\s+"), " ")
         .lowercase()
+}
+
+private fun seriesMatchKeys(book: BookSummary): Set<String> {
+    return buildSet {
+        book.seriesName
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+            ?.let { add(normalizeSeriesName(it)) }
+        book.seriesNames.forEach { seriesName ->
+            val normalized = normalizeSeriesName(seriesName)
+            if (normalized.isNotBlank()) {
+                add(normalized)
+            }
+        }
+    }
+}
+
+private fun seriesIdsLikelyMatch(candidateId: String, targetId: String): Boolean {
+    val normalizedCandidate = candidateId.trim()
+    val normalizedTarget = targetId.trim()
+    if (normalizedCandidate.isBlank() || normalizedTarget.isBlank()) return false
+    return normalizedCandidate.equals(normalizedTarget, ignoreCase = true) ||
+        normalizedCandidate.endsWith(normalizedTarget, ignoreCase = true) ||
+        normalizedTarget.endsWith(normalizedCandidate, ignoreCase = true)
 }
 
 private fun isStillShelfProbeCollection(name: String): Boolean {

--- a/app/src/main/java/com/stillshelf/app/ui/screens/FacetDetailScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/FacetDetailScreens.kt
@@ -396,11 +396,21 @@ class SeriesDetailViewModel @Inject constructor(
     private val sessionPreferences: SessionPreferences,
     private val bookDownloadManager: BookDownloadManager
 ) : ViewModel() {
+    companion object {
+        private const val SERIES_BOOKS_PAGE_SIZE = 400
+        private const val SERIES_BOOKS_MAX_PAGES = 100
+    }
+
     private val seriesName = savedStateHandle.get<String>(DetailRoute.SERIES_NAME_ARG).orEmpty()
     private val mutableUiState = MutableStateFlow(FacetBooksUiState(isLoading = true, title = seriesName))
     val uiState: StateFlow<FacetBooksUiState> = mutableUiState.asStateFlow()
     private val mutableListMode = MutableStateFlow(true)
     val listMode: StateFlow<Boolean> = mutableListMode.asStateFlow()
+
+    private data class SeriesMatchTarget(
+        val id: String?,
+        val expectedCount: Int?
+    )
 
     init {
         viewModelScope.launch {
@@ -476,21 +486,48 @@ class SeriesDetailViewModel @Inject constructor(
     private fun refresh(forceRefresh: Boolean) {
         mutableUiState.update { it.copy(isLoading = true, errorMessage = null) }
         viewModelScope.launch {
-            when (
-                val result = sessionRepository.fetchBooksForActiveLibrary(
-                    limit = 400,
-                    page = 0,
-                    forceRefresh = forceRefresh
-                )
-            ) {
+            when (val result = fetchAllBooksForSeriesMatching(forceRefresh = forceRefresh)) {
                 is AppResult.Success -> {
                     val normalizedSeries = normalizeSeriesKey(seriesName)
-                    val matchedBooks = result.value.filter {
-                        if (normalizedSeries.isBlank()) return@filter false
-                        val candidate = it.seriesName?.let(::normalizeSeriesKey) ?: return@filter false
-                        candidate == normalizedSeries ||
-                            candidate.contains(normalizedSeries) ||
-                            normalizedSeries.contains(candidate)
+                    val targetSeries = resolveTargetSeriesTarget(forceRefresh = forceRefresh)
+                    val matchedByListMetadata = result.value.filter {
+                        val matchesByName = if (normalizedSeries.isBlank()) {
+                            false
+                        } else {
+                            val candidateSeries = buildList {
+                                it.seriesName?.let(::add)
+                                addAll(it.seriesNames)
+                            }
+                            candidateSeries.any { candidateName ->
+                                val candidate = normalizeSeriesKey(candidateName)
+                                candidate.isNotBlank() &&
+                                    (
+                                        candidate == normalizedSeries ||
+                                            candidate.contains(normalizedSeries) ||
+                                            normalizedSeries.contains(candidate)
+                                        )
+                            }
+                        }
+                        val matchesById = targetSeries.id != null &&
+                            it.seriesIds.any { candidateId ->
+                                seriesIdsLikelyMatch(candidateId, targetSeries.id)
+                            }
+                        matchesByName || matchesById
+                    }
+                    val matchedBooks = if (matchedByListMetadata.isNotEmpty()) {
+                        matchedByListMetadata
+                    } else if (targetSeries.id != null) {
+                        resolveSeriesBooksFromBookDetails(
+                            books = result.value,
+                            targetSeries = targetSeries,
+                            normalizedSeries = normalizedSeries
+                        )
+                    } else {
+                        emptyList()
+                    }
+                    if (matchedBooks.isEmpty() && !forceRefresh) {
+                        refresh(forceRefresh = true)
+                        return@launch
                     }
                     val books = coroutineScope {
                         matchedBooks
@@ -528,6 +565,114 @@ class SeriesDetailViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private suspend fun resolveTargetSeriesTarget(forceRefresh: Boolean): SeriesMatchTarget {
+        return when (val seriesResult = sessionRepository.fetchSeriesForActiveLibrary(forceRefresh = forceRefresh)) {
+            is AppResult.Success -> {
+                val normalized = normalizeSeriesKey(seriesName)
+                val match = seriesResult.value.firstOrNull { series ->
+                    normalizeSeriesKey(series.name) == normalized
+                }
+                SeriesMatchTarget(
+                    id = match?.id?.trim()?.takeIf { it.isNotBlank() },
+                    expectedCount = match?.subtitle?.let(::extractEntityCount)
+                )
+            }
+
+            is AppResult.Error -> SeriesMatchTarget(id = null, expectedCount = null)
+        }
+    }
+
+    private fun seriesIdsLikelyMatch(candidateId: String, targetId: String): Boolean {
+        val normalizedCandidate = candidateId.trim()
+        val normalizedTarget = targetId.trim()
+        if (normalizedCandidate.isBlank() || normalizedTarget.isBlank()) return false
+        return normalizedCandidate.equals(normalizedTarget, ignoreCase = true) ||
+            normalizedCandidate.endsWith(normalizedTarget, ignoreCase = true) ||
+            normalizedTarget.endsWith(normalizedCandidate, ignoreCase = true)
+    }
+
+    private fun extractEntityCount(subtitle: String?): Int? {
+        val value = subtitle?.trim().orEmpty().substringBefore(" ").toIntOrNull()
+        return value?.takeIf { it >= 0 }
+    }
+
+    private suspend fun resolveSeriesBooksFromBookDetails(
+        books: List<BookSummary>,
+        targetSeries: SeriesMatchTarget,
+        normalizedSeries: String
+    ): List<BookSummary> {
+        val resolved = mutableListOf<BookSummary>()
+        val targetSeriesId = targetSeries.id
+        val expectedCount = targetSeries.expectedCount
+        books.forEach { book ->
+            val detail = when (val detailResult = sessionRepository.fetchBookDetail(book.id, forceRefresh = false)) {
+                is AppResult.Success -> detailResult.value.book
+                is AppResult.Error -> null
+            } ?: return@forEach
+
+            val matchById = targetSeriesId != null &&
+                detail.seriesIds.any { candidateId -> seriesIdsLikelyMatch(candidateId, targetSeriesId) }
+            val matchByName = if (normalizedSeries.isBlank()) {
+                false
+            } else {
+                buildList {
+                    detail.seriesName?.let(::add)
+                    addAll(detail.seriesNames)
+                }.any { candidateName ->
+                    val normalizedCandidate = normalizeSeriesKey(candidateName)
+                    normalizedCandidate.isNotBlank() &&
+                        (
+                            normalizedCandidate == normalizedSeries ||
+                                normalizedCandidate.contains(normalizedSeries) ||
+                                normalizedSeries.contains(normalizedCandidate)
+                            )
+                }
+            }
+            if (matchById || matchByName) {
+                resolved += book.copy(
+                    seriesName = detail.seriesName ?: book.seriesName,
+                    seriesNames = if (detail.seriesNames.isNotEmpty()) detail.seriesNames else book.seriesNames,
+                    seriesIds = if (detail.seriesIds.isNotEmpty()) detail.seriesIds else book.seriesIds,
+                    seriesSequence = detail.seriesSequence ?: book.seriesSequence
+                )
+                if (expectedCount != null && expectedCount > 0 && resolved.size >= expectedCount) {
+                    return resolved.distinctBy { it.id }
+                }
+            }
+        }
+        return resolved.distinctBy { it.id }
+    }
+
+    private suspend fun fetchAllBooksForSeriesMatching(forceRefresh: Boolean): AppResult<List<BookSummary>> {
+        val books = mutableListOf<BookSummary>()
+        var page = 0
+        while (page < SERIES_BOOKS_MAX_PAGES) {
+            when (
+                val result = sessionRepository.fetchBooksForActiveLibrary(
+                    limit = SERIES_BOOKS_PAGE_SIZE,
+                    page = page,
+                    forceRefresh = forceRefresh
+                )
+            ) {
+                is AppResult.Success -> {
+                    val batch = result.value
+                    if (batch.isEmpty()) break
+                    books += batch
+                    if (batch.size < SERIES_BOOKS_PAGE_SIZE) break
+                    page += 1
+                }
+
+                is AppResult.Error -> {
+                    if (books.isEmpty()) {
+                        return result
+                    }
+                    break
+                }
+            }
+        }
+        return AppResult.Success(books.distinctBy { it.id })
     }
 
     private fun observeDownloadedState() {

--- a/app/src/main/java/com/stillshelf/app/ui/screens/MainScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/MainScreens.kt
@@ -6378,7 +6378,7 @@ fun PlayerScreen(
             CenteredEmptyState(
                 icon = Icons.Outlined.PlayArrow,
                 title = "Nothing playing",
-                subtitle = "Start a book from Continue Listening."
+                subtitle = "Start a book to listen."
             )
             return
         }


### PR DESCRIPTION
## Summary
- clear playback/session carryover when switching to a different server profile
- update empty player messaging to neutral wording
- fix sub-series resolution in series browse/detail, including cover fallback rendering

## Validation
- app compiles: :app:compileDebugKotlin
- user validated flows on-device