### PR TITLE
Polish player flow and ship stable v0.1.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.stillshelf.app"
         minSdk = 24
         targetSdk = 36
-        versionCode = 16
-        versionName = "0.1.0-rc1.8"
+        versionCode = 17
+        versionName = "0.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/stillshelf/app/playback/controller/PlaybackController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/controller/PlaybackController.kt
@@ -4,8 +4,12 @@ import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
 import android.graphics.Bitmap
 import android.media.AudioDeviceCallback
 import android.media.AudioDeviceInfo
@@ -29,6 +33,7 @@ import com.stillshelf.app.core.datastore.SessionPreferences
 import com.stillshelf.app.core.model.BookChapter
 import com.stillshelf.app.core.model.BookSummary
 import com.stillshelf.app.core.model.ContinueListeningItem
+import com.stillshelf.app.core.model.PlaybackProgress
 import com.stillshelf.app.core.network.authorizationHeaderValue
 import com.stillshelf.app.core.network.splitAuthenticatedUrl
 import com.stillshelf.app.core.util.AppResult
@@ -128,6 +133,7 @@ class PlaybackController @Inject constructor(
     private var preferredOutputDeviceId: Int? = null
     private var outputRouteDeviceIdsByRouteKey: Map<String, List<Int>> = emptyMap()
     private var outputRouteKeyByDisplayedId: Map<Int, String> = emptyMap()
+    private var lastKnownOutputDeviceIds: Set<Int> = emptySet()
     private val attemptedAutoAdvanceTargetsMs = mutableSetOf<Long>()
     private var suppressNextAutoAdvanceOnCompletion = false
     private var lastNotificationSignature: NotificationSignature? = null
@@ -135,13 +141,39 @@ class PlaybackController @Inject constructor(
     private val mediaSession = MediaSessionCompat(appContext, "StillShelfPlayback")
     private val audioManager: AudioManager =
         appContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    private val playbackAudioAttributes: AudioAttributes by lazy {
+        AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_MEDIA)
+            .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+            .build()
+    }
+    private val audioFocusChangeListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
+        scope.launch(Dispatchers.Main.immediate) {
+            handleAudioFocusChange(focusChange)
+        }
+    }
+    private var audioFocusRequest: AudioFocusRequest? = null
+    private var hasAudioFocus: Boolean = false
+    private var pendingPlayAfterAudioFocusGain: Boolean = false
+    private var pendingPlayStartsProgressUpdates: Boolean = false
+    private var wasPausedForTransientAudioFocusLoss: Boolean = false
+    private var isDuckedForAudioFocus: Boolean = false
+    private val noisyAudioReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action != AudioManager.ACTION_AUDIO_BECOMING_NOISY) return
+            scope.launch(Dispatchers.Main.immediate) {
+                pauseForNoisyOutput()
+            }
+        }
+    }
+    private var noisyAudioReceiverRegistered: Boolean = false
     private val audioDeviceCallback = object : AudioDeviceCallback() {
         override fun onAudioDevicesAdded(addedDevices: Array<out AudioDeviceInfo>?) {
-            refreshAudioOutputDevices()
+            refreshAudioOutputDevices(reason = OutputRefreshReason.DeviceAdded)
         }
 
         override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>?) {
-            refreshAudioOutputDevices()
+            refreshAudioOutputDevices(reason = OutputRefreshReason.DeviceRemoved)
         }
     }
     private var rewindSeconds: Int = 15
@@ -172,6 +204,20 @@ class PlaybackController @Inject constructor(
         val triggeredAtElapsedMs: Long
     )
 
+    private enum class OutputRefreshReason {
+        General,
+        DeviceAdded,
+        DeviceRemoved
+    }
+
+    private enum class PauseReason {
+        User,
+        AudioFocusTransientLoss,
+        AudioFocusLoss,
+        NoisyOutput,
+        Internal
+    }
+
     val uiState: StateFlow<PlaybackUiState> = mutableUiState.asStateFlow()
 
     init {
@@ -187,8 +233,9 @@ class PlaybackController @Inject constructor(
             override fun onSkipToNext() = performLockScreenNextControl()
         })
         mediaSession.isActive = true
+        registerNoisyAudioReceiver()
         audioManager.registerAudioDeviceCallback(audioDeviceCallback, Handler(Looper.getMainLooper()))
-        refreshAudioOutputDevices()
+        refreshAudioOutputDevices(reason = OutputRefreshReason.General)
         observePlaybackPreferences()
         observeActiveServerSelection()
     }
@@ -239,27 +286,44 @@ class PlaybackController @Inject constructor(
                     }
                     is AppResult.Error -> 0L
                 }
-                val resumeMs = startPositionMs ?: serverResumeMs
+                val shouldRestartFromBeginning = startPositionMs == null &&
+                    progressResult.shouldRestartFromBeginning(defaultDurationSeconds = localBook.durationSeconds)
+                val playbackBook = if (shouldRestartFromBeginning) {
+                    localBook.copy(
+                        progressPercent = 0.0,
+                        currentTimeSeconds = 0.0,
+                        isFinished = false
+                    )
+                } else {
+                    localBook
+                }
+                val resumeMs = when {
+                    startPositionMs != null -> startPositionMs
+                    shouldRestartFromBeginning -> 0L
+                    else -> serverResumeMs
+                }
                 val progressPercent = when {
                     startPositionMs != null -> null
+                    shouldRestartFromBeginning -> 0.0
                     progressResult is AppResult.Success -> progressResult.value?.progressPercent
                     else -> null
                 }
                 val currentTimeSeconds = when {
                     startPositionMs != null -> (startPositionMs / 1000.0).coerceAtLeast(0.0)
+                    shouldRestartFromBeginning -> 0.0
                     progressResult is AppResult.Success -> progressResult.value?.currentTimeSeconds
                     else -> null
                 }
                 cachedContinueListeningItem = ContinueListeningItem(
-                    book = localBook,
+                    book = playbackBook,
                     progressPercent = progressPercent,
                     currentTimeSeconds = currentTimeSeconds
                 )
                 if (isStalePlayRequest(requestToken)) return@launch
                 val localUri = Uri.fromFile(File(localDownload.localPath)).toString()
                 prepareAndPlay(
-                    bookId = localBook.id,
-                    book = localBook,
+                    bookId = playbackBook.id,
+                    book = playbackBook,
                     streamUrl = localUri,
                     resumeMs = resumeMs
                 )
@@ -279,26 +343,45 @@ class PlaybackController @Inject constructor(
 
                         is AppResult.Error -> 0L
                     }
-                    val resumeMs = startPositionMs ?: serverResumeMs
+                    val shouldRestartFromBeginning = startPositionMs == null &&
+                        progressResult.shouldRestartFromBeginning(
+                            defaultDurationSeconds = sourceResult.value.book.durationSeconds
+                        )
+                    val playbackBook = if (shouldRestartFromBeginning) {
+                        sourceResult.value.book.copy(
+                            progressPercent = 0.0,
+                            currentTimeSeconds = 0.0,
+                            isFinished = false
+                        )
+                    } else {
+                        sourceResult.value.book
+                    }
+                    val resumeMs = when {
+                        startPositionMs != null -> startPositionMs
+                        shouldRestartFromBeginning -> 0L
+                        else -> serverResumeMs
+                    }
                     val progressPercent = when {
                         startPositionMs != null -> null
+                        shouldRestartFromBeginning -> 0.0
                         progressResult is AppResult.Success -> progressResult.value?.progressPercent
                         else -> null
                     }
                     val currentTimeSeconds = when {
                         startPositionMs != null -> (startPositionMs / 1000.0).coerceAtLeast(0.0)
+                        shouldRestartFromBeginning -> 0.0
                         progressResult is AppResult.Success -> progressResult.value?.currentTimeSeconds
                         else -> null
                     }
                     cachedContinueListeningItem = ContinueListeningItem(
-                        book = sourceResult.value.book,
+                        book = playbackBook,
                         progressPercent = progressPercent,
                         currentTimeSeconds = currentTimeSeconds
                     )
                     if (isStalePlayRequest(requestToken)) return@launch
                     prepareAndPlay(
-                        sourceResult.value.book.id,
-                        sourceResult.value.book,
+                        playbackBook.id,
+                        playbackBook,
                         sourceResult.value.streamUrl,
                         resumeMs = resumeMs
                     )
@@ -365,6 +448,144 @@ class PlaybackController @Inject constructor(
 
     fun seekToPositionMs(positionMs: Long, commit: Boolean) {
         seekToPosition(targetMs = positionMs.coerceAtLeast(0L), forceSync = commit)
+    }
+
+    fun stopAndResetBookToStart(bookId: String): Boolean {
+        if (bookId.isBlank()) return false
+        if (currentBookId != bookId) return false
+        val player = mediaPlayer ?: return false
+        if (uiState.value.isPlaying) {
+            pause(reason = PauseReason.Internal)
+        } else {
+            clearDucking(player)
+            runCatching { player.pause() }
+            updateUiState { it.copy(isPlaying = false) }
+        }
+        val state = uiState.value
+        val resolvedDurationMs = safeDuration(player)
+            .takeIf { it > 0L }
+            ?: state.durationMs.takeIf { it > 0L }
+            ?: state.book?.durationSeconds?.times(1000.0)?.toLong()?.coerceAtLeast(0L)
+            ?: 0L
+        seekToPosition(targetMs = resolvedDurationMs, forceSync = false)
+        updateUiState { state ->
+            val currentBook = state.book
+            if (currentBook != null && currentBook.id == bookId) {
+                state.copy(
+                    book = currentBook.copy(
+                        isFinished = true,
+                        progressPercent = 1.0,
+                        currentTimeSeconds = resolvedDurationMs / 1000.0
+                    ),
+                    positionMs = resolvedDurationMs,
+                    durationMs = maxOf(state.durationMs, resolvedDurationMs),
+                    isPlaying = false
+                )
+            } else {
+                state.copy(
+                    positionMs = resolvedDurationMs,
+                    durationMs = maxOf(state.durationMs, resolvedDurationMs),
+                    isPlaying = false
+                )
+            }
+        }
+        updateCachedFromUiState()
+        return true
+    }
+
+    fun stopAndResetBookToBeginning(bookId: String): Boolean {
+        if (bookId.isBlank()) return false
+        if (currentBookId != bookId) return false
+        val player = mediaPlayer ?: return false
+        if (uiState.value.isPlaying) {
+            pause(reason = PauseReason.Internal)
+        } else {
+            clearDucking(player)
+            runCatching { player.pause() }
+            updateUiState { it.copy(isPlaying = false) }
+        }
+        seekToPosition(targetMs = 0L, forceSync = false)
+        updateUiState { state ->
+            val currentBook = state.book
+            if (currentBook != null && currentBook.id == bookId) {
+                state.copy(
+                    book = currentBook.copy(
+                        isFinished = false,
+                        progressPercent = 0.0,
+                        currentTimeSeconds = 0.0
+                    ),
+                    positionMs = 0L,
+                    isPlaying = false
+                )
+            } else {
+                state.copy(
+                    positionMs = 0L,
+                    isPlaying = false
+                )
+            }
+        }
+        updateCachedFromUiState()
+        return true
+    }
+
+    fun stopAndRestoreBookProgress(
+        bookId: String,
+        currentTimeSeconds: Double,
+        durationSeconds: Double?,
+        isFinished: Boolean
+    ): Boolean {
+        if (bookId.isBlank()) return false
+        if (currentBookId != bookId) return false
+        val player = mediaPlayer ?: return false
+        if (uiState.value.isPlaying) {
+            pause(reason = PauseReason.Internal)
+        } else {
+            clearDucking(player)
+            runCatching { player.pause() }
+            updateUiState { it.copy(isPlaying = false) }
+        }
+        val state = uiState.value
+        val resolvedDurationMs = safeDuration(player)
+            .takeIf { it > 0L }
+            ?: state.durationMs.takeIf { it > 0L }
+            ?: durationSeconds?.times(1000.0)?.toLong()?.coerceAtLeast(0L)
+            ?: state.book?.durationSeconds?.times(1000.0)?.toLong()?.coerceAtLeast(0L)
+            ?: 0L
+        val rawTargetMs = (currentTimeSeconds.coerceAtLeast(0.0) * 1000.0).toLong()
+        val targetMs = if (resolvedDurationMs > 0L) {
+            rawTargetMs.coerceIn(0L, resolvedDurationMs)
+        } else {
+            rawTargetMs.coerceAtLeast(0L)
+        }
+        seekToPosition(targetMs = targetMs, forceSync = false)
+        val progressPercent = when {
+            isFinished -> 1.0
+            resolvedDurationMs > 0L -> (targetMs.toDouble() / resolvedDurationMs.toDouble()).coerceIn(0.0, 1.0)
+            else -> null
+        }
+        updateUiState { latest ->
+            val currentBook = latest.book
+            if (currentBook != null && currentBook.id == bookId) {
+                latest.copy(
+                    book = currentBook.copy(
+                        isFinished = isFinished,
+                        progressPercent = progressPercent,
+                        currentTimeSeconds = targetMs / 1000.0
+                    ),
+                    positionMs = targetMs,
+                    durationMs = maxOf(latest.durationMs, resolvedDurationMs),
+                    isPlaying = false
+                )
+            } else {
+                latest.copy(
+                    positionMs = targetMs,
+                    durationMs = maxOf(latest.durationMs, resolvedDurationMs),
+                    isPlaying = false
+                )
+            }
+        }
+        updateCachedFromUiState()
+        return true
     }
 
     fun setPlaybackSpeed(speed: Float) {
@@ -453,11 +674,27 @@ class PlaybackController @Inject constructor(
     }
 
     fun refreshAudioOutputDevices() {
+        refreshAudioOutputDevices(reason = OutputRefreshReason.General)
+    }
+
+    private fun refreshAudioOutputDevices(reason: OutputRefreshReason) {
         val available = queryOutputDevices()
+        val availableIds = available.mapNotNull { it.id }.toSet()
+        val bluetoothOutputId = available.firstOrNull { output ->
+            val displayedId = output.id ?: return@firstOrNull false
+            outputRouteKeyByDisplayedId[displayedId]?.startsWith("bt:") == true
+        }?.id
+        val shouldAutoSwitchToBluetooth = reason == OutputRefreshReason.DeviceAdded &&
+            bluetoothOutputId != null &&
+            bluetoothOutputId !in lastKnownOutputDeviceIds
         val validPreferredId = preferredOutputDeviceId?.takeIf { preferredId ->
             available.any { it.id == preferredId }
         }
-        val resolvedPreferredId = validPreferredId ?: available.firstOrNull()?.id
+        val resolvedPreferredId = when {
+            shouldAutoSwitchToBluetooth -> bluetoothOutputId
+            validPreferredId != null -> validPreferredId
+            else -> available.firstOrNull()?.id
+        }
         if (preferredOutputDeviceId != resolvedPreferredId) {
             preferredOutputDeviceId = resolvedPreferredId
         }
@@ -470,6 +707,7 @@ class PlaybackController @Inject constructor(
                 selectedOutputDeviceId = preferredOutputDeviceId
             )
         }
+        lastKnownOutputDeviceIds = availableIds
     }
 
     fun selectAudioOutputDevice(deviceId: Int?): Boolean {
@@ -524,17 +762,35 @@ class PlaybackController @Inject constructor(
     }
 
     private fun pause() {
-        val player = mediaPlayer ?: return
-        runCatching { player.pause() }
-        updateProgress(player)
-        syncProgress(force = true, isFinished = false)
-        updateUiState { it.copy(isPlaying = false) }
+        pause(reason = PauseReason.User)
     }
 
     private fun resume() {
         val player = mediaPlayer ?: return
-        runCatching { player.start() }
-        updateUiState { it.copy(isPlaying = true, errorMessage = null) }
+        clearDucking(player)
+        wasPausedForTransientAudioFocusLoss = false
+        val focusResult = requestAudioFocusForPlayback()
+        if (focusResult == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+            pendingPlayAfterAudioFocusGain = false
+            pendingPlayStartsProgressUpdates = false
+            runCatching { player.start() }
+            updateUiState { it.copy(isPlaying = true, errorMessage = null) }
+            return
+        }
+        if (focusResult == AudioManager.AUDIOFOCUS_REQUEST_DELAYED) {
+            pendingPlayAfterAudioFocusGain = true
+            pendingPlayStartsProgressUpdates = false
+            updateUiState { it.copy(isPlaying = false, errorMessage = null) }
+            return
+        }
+        pendingPlayAfterAudioFocusGain = false
+        pendingPlayStartsProgressUpdates = false
+        updateUiState {
+            it.copy(
+                isPlaying = false,
+                errorMessage = "Could not take audio output right now."
+            )
+        }
     }
 
     private fun prepareAndPlay(bookId: String, book: BookSummary, streamUrl: String, resumeMs: Long) {
@@ -548,6 +804,7 @@ class PlaybackController @Inject constructor(
         mediaPlayer = player
         currentBookId = bookId
         playbackSyncGate.reset()
+        configurePlayerAudioAttributes(player)
         applyPreferredOutputDevice(player)
         updateUiState {
             it.copy(
@@ -577,18 +834,39 @@ class PlaybackController @Inject constructor(
             if (clampedResume > 0L) {
                 runCatching { prepared.seekTo(clampedResume.toInt()) }
             }
-            runCatching { prepared.start() }
+            val focusResult = requestAudioFocusForPlayback()
             updateUiState {
                 it.copy(
                     isLoading = false,
-                    isPlaying = true,
+                    isPlaying = false,
                     playbackSpeed = currentPlaybackSpeed,
                     positionMs = clampedResume,
                     durationMs = duration
                 )
             }
             updateCachedFromUiState()
-            startProgressUpdates()
+            when (focusResult) {
+                AudioManager.AUDIOFOCUS_REQUEST_GRANTED -> {
+                    pendingPlayAfterAudioFocusGain = false
+                    pendingPlayStartsProgressUpdates = false
+                    runCatching { prepared.start() }
+                    updateUiState { it.copy(isPlaying = true, errorMessage = null) }
+                    startProgressUpdates()
+                }
+
+                AudioManager.AUDIOFOCUS_REQUEST_DELAYED -> {
+                    pendingPlayAfterAudioFocusGain = true
+                    pendingPlayStartsProgressUpdates = true
+                }
+
+                else -> {
+                    pendingPlayAfterAudioFocusGain = false
+                    pendingPlayStartsProgressUpdates = false
+                    updateUiState {
+                        it.copy(errorMessage = "Could not take audio output right now.")
+                    }
+                }
+            }
         }
         player.setOnCompletionListener { completed ->
             val duration = safeDuration(completed)
@@ -621,6 +899,7 @@ class PlaybackController @Inject constructor(
             }
             player.prepareAsync()
         }.onFailure { throwable ->
+            abandonAudioFocus()
             updateUiState {
                 it.copy(
                     isLoading = false,
@@ -631,17 +910,197 @@ class PlaybackController @Inject constructor(
         }
     }
 
+    private fun pause(reason: PauseReason) {
+        val player = mediaPlayer
+        if (player != null) {
+            clearDucking(player)
+            runCatching { player.pause() }
+            updateProgress(player)
+        }
+        pendingPlayAfterAudioFocusGain = false
+        pendingPlayStartsProgressUpdates = false
+        if (reason != PauseReason.AudioFocusTransientLoss) {
+            wasPausedForTransientAudioFocusLoss = false
+        }
+        if (
+            reason == PauseReason.User ||
+            reason == PauseReason.NoisyOutput ||
+            reason == PauseReason.Internal
+        ) {
+            abandonAudioFocus()
+        }
+        syncProgress(force = true, isFinished = false)
+        updateUiState { it.copy(isPlaying = false) }
+    }
+
+    private fun configurePlayerAudioAttributes(player: MediaPlayer) {
+        runCatching {
+            if (SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                player.setAudioAttributes(playbackAudioAttributes)
+            } else {
+                @Suppress("DEPRECATION")
+                player.setAudioStreamType(AudioManager.STREAM_MUSIC)
+            }
+        }
+    }
+
+    private fun requestAudioFocusForPlayback(): Int {
+        if (hasAudioFocus) return AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        val requestResult = if (SDK_INT >= Build.VERSION_CODES.O) {
+            val request = audioFocusRequest ?: AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+                .setAudioAttributes(playbackAudioAttributes)
+                .setAcceptsDelayedFocusGain(true)
+                .setOnAudioFocusChangeListener(audioFocusChangeListener, Handler(Looper.getMainLooper()))
+                .build()
+            audioFocusRequest = request
+            audioManager.requestAudioFocus(request)
+        } else {
+            @Suppress("DEPRECATION")
+            audioManager.requestAudioFocus(
+                audioFocusChangeListener,
+                AudioManager.STREAM_MUSIC,
+                AudioManager.AUDIOFOCUS_GAIN
+            )
+        }
+        if (requestResult == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+            hasAudioFocus = true
+        }
+        return requestResult
+    }
+
+    private fun abandonAudioFocus() {
+        hasAudioFocus = false
+        val request = audioFocusRequest
+        if (SDK_INT >= Build.VERSION_CODES.O && request != null) {
+            runCatching { audioManager.abandonAudioFocusRequest(request) }
+        } else {
+            @Suppress("DEPRECATION")
+            runCatching { audioManager.abandonAudioFocus(audioFocusChangeListener) }
+        }
+    }
+
+    private fun handleAudioFocusChange(focusChange: Int) {
+        when (focusChange) {
+            AudioManager.AUDIOFOCUS_GAIN -> {
+                hasAudioFocus = true
+                clearDucking(mediaPlayer)
+                if (pendingPlayAfterAudioFocusGain) {
+                    val player = mediaPlayer
+                    if (player != null) {
+                        pendingPlayAfterAudioFocusGain = false
+                        val shouldStartProgress = pendingPlayStartsProgressUpdates
+                        pendingPlayStartsProgressUpdates = false
+                        wasPausedForTransientAudioFocusLoss = false
+                        runCatching { player.start() }
+                        updateUiState { it.copy(isPlaying = true, errorMessage = null) }
+                        if (shouldStartProgress) {
+                            startProgressUpdates()
+                        }
+                    }
+                } else if (wasPausedForTransientAudioFocusLoss) {
+                    wasPausedForTransientAudioFocusLoss = false
+                    resume()
+                }
+            }
+
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
+                hasAudioFocus = false
+                val player = mediaPlayer ?: return
+                val isPlayingNow = runCatching { player.isPlaying }.getOrDefault(false)
+                if (isPlayingNow) {
+                    applyDucking(player)
+                }
+            }
+
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
+                hasAudioFocus = false
+                clearDucking(mediaPlayer)
+                val player = mediaPlayer ?: return
+                val isPlayingNow = runCatching { player.isPlaying }.getOrDefault(false)
+                if (isPlayingNow) {
+                    wasPausedForTransientAudioFocusLoss = true
+                    pause(reason = PauseReason.AudioFocusTransientLoss)
+                }
+            }
+
+            AudioManager.AUDIOFOCUS_LOSS -> {
+                hasAudioFocus = false
+                clearDucking(mediaPlayer)
+                pendingPlayAfterAudioFocusGain = false
+                pendingPlayStartsProgressUpdates = false
+                wasPausedForTransientAudioFocusLoss = false
+                val player = mediaPlayer
+                val isPlayingNow = player?.let { runCatching { it.isPlaying }.getOrDefault(false) } ?: false
+                if (isPlayingNow) {
+                    pause(reason = PauseReason.AudioFocusLoss)
+                } else {
+                    updateUiState { it.copy(isPlaying = false) }
+                }
+            }
+        }
+    }
+
+    private fun applyDucking(player: MediaPlayer) {
+        runCatching {
+            player.setVolume(0.30f, 0.30f)
+            isDuckedForAudioFocus = true
+        }
+    }
+
+    private fun clearDucking(player: MediaPlayer?) {
+        if (!isDuckedForAudioFocus || player == null) return
+        runCatching { player.setVolume(1.0f, 1.0f) }
+        isDuckedForAudioFocus = false
+    }
+
+    private fun registerNoisyAudioReceiver() {
+        if (noisyAudioReceiverRegistered) return
+        val filter = IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY)
+        val registered = runCatching {
+            if (SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                appContext.registerReceiver(noisyAudioReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
+            } else {
+                @Suppress("DEPRECATION")
+                appContext.registerReceiver(noisyAudioReceiver, filter)
+            }
+            true
+        }.getOrDefault(false)
+        noisyAudioReceiverRegistered = registered
+    }
+
+    private fun pauseForNoisyOutput() {
+        val player = mediaPlayer ?: return
+        val isPlayingNow = runCatching { player.isPlaying }.getOrDefault(false)
+        if (!isPlayingNow) return
+        pause(reason = PauseReason.NoisyOutput)
+    }
+
     private fun startProgressUpdates() {
         progressJob?.cancel()
         progressJob = scope.launch {
             while (isActive) {
                 mediaPlayer?.let {
                     updateProgress(it)
-                    syncProgress(force = false, isFinished = false)
+                    if (uiState.value.isPlaying) {
+                        syncProgress(force = false, isFinished = false)
+                    }
                 }
                 delay(500L)
             }
         }
+    }
+
+    private fun AppResult<PlaybackProgress?>.shouldRestartFromBeginning(
+        defaultDurationSeconds: Double?
+    ): Boolean {
+        val progress = (this as? AppResult.Success)?.value ?: return false
+        val progressPercent = progress.progressPercent
+        if (progressPercent != null && progressPercent >= 0.995) {
+            return true
+        }
+        val current = progress.currentTimeSeconds ?: return false
+        val duration = (progress.durationSeconds ?: defaultDurationSeconds)?.takeIf { it > 0.0 } ?: return false
+        return (current / duration) >= 0.995
     }
 
     private fun updateProgress(player: MediaPlayer) {
@@ -673,9 +1132,14 @@ class PlaybackController @Inject constructor(
         }
         progressJob?.cancel()
         progressJob = null
+        pendingPlayAfterAudioFocusGain = false
+        pendingPlayStartsProgressUpdates = false
+        wasPausedForTransientAudioFocusLoss = false
         releaseAudioEffects()
+        clearDucking(mediaPlayer)
         mediaPlayer?.runCatching { release() }
         mediaPlayer = null
+        abandonAudioFocus()
         updatePlaybackSurface()
     }
 
@@ -1776,6 +2240,11 @@ class PlaybackController @Inject constructor(
     private fun completePlayback(durationMs: Long) {
         cancelSleepTimer(updateUi = false)
         suppressNextAutoAdvanceOnCompletion = false
+        clearDucking(mediaPlayer)
+        pendingPlayAfterAudioFocusGain = false
+        pendingPlayStartsProgressUpdates = false
+        wasPausedForTransientAudioFocusLoss = false
+        abandonAudioFocus()
         updateUiState {
             it.copy(
                 isPlaying = false,

--- a/app/src/main/java/com/stillshelf/app/ui/common/CoverImageModels.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/common/CoverImageModels.kt
@@ -79,7 +79,9 @@ fun FramedCoverImage(
     contentScale: ContentScale = ContentScale.Fit,
     backgroundBlur: Dp = WideCoverBackgroundBlur,
     frameOverlayAlphaMultiplier: Float = 1f,
-    disableBlurredFrame: Boolean = false
+    disableBlurredFrame: Boolean = false,
+    limitInsetToAvoidVerticalLetterbox: Boolean = true,
+    forcedSideInset: Dp? = null
 ) {
     val model = rememberCoverImageModel(coverUrl)
     val frameBackgroundAlpha = if (disableBlurredFrame) 0f else 0.26f
@@ -116,11 +118,16 @@ fun FramedCoverImage(
         }
         val isSquareLikeCover = resolvedAspectRatio in SquareCoverMinAspectRatio..SquareCoverMaxAspectRatio
         val shouldUseBlurredFrame = !isSquareLikeCover && !disableBlurredFrame
-        val preferredInset = (maxWidth * 0.20f).coerceIn(2.dp, 34.dp)
+        val preferredInset = forcedSideInset?.coerceIn(0.dp, maxWidth / 2f)
+            ?: (maxWidth * 0.20f).coerceIn(2.dp, 34.dp)
         val maxInsetWithoutVerticalLetterbox =
-            ((maxWidth - (maxHeight * TypicalCoverAspectRatio)) / 2f).coerceAtLeast(0.dp)
+            ((maxWidth - (maxHeight * resolvedAspectRatio)) / 2f).coerceAtLeast(0.dp)
         val sideInset = if (shouldUseBlurredFrame) {
-            minOf(preferredInset, maxInsetWithoutVerticalLetterbox)
+            if (limitInsetToAvoidVerticalLetterbox) {
+                minOf(preferredInset, maxInsetWithoutVerticalLetterbox)
+            } else {
+                preferredInset
+            }
         } else {
             0.dp
         }

--- a/app/src/main/java/com/stillshelf/app/ui/screens/AboutViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/AboutViewModel.kt
@@ -1,6 +1,7 @@
 package com.stillshelf.app.ui.screens
 
 import android.content.Context
+import androidx.core.content.pm.PackageInfoCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -69,7 +70,7 @@ class AboutViewModel @Inject constructor(
             appContext.packageManager.getPackageInfo(appContext.packageName, 0)
         }.getOrNull()
         installedVersionName = packageInfo?.versionName.orEmpty()
-        installedVersionCode = packageInfo?.longVersionCode?.toInt() ?: 0
+        installedVersionCode = packageInfo?.let { PackageInfoCompat.getLongVersionCode(it).toInt() } ?: 0
         mutableUiState = MutableStateFlow(
             AboutUiState(
                 versionName = installedVersionName,

--- a/app/src/main/java/com/stillshelf/app/ui/screens/BookDetailViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/BookDetailViewModel.kt
@@ -17,8 +17,11 @@ import com.stillshelf.app.ui.navigation.DetailRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.math.abs
@@ -42,10 +45,20 @@ class BookDetailViewModel @Inject constructor(
     private val playbackController: PlaybackController,
     private val bookDownloadManager: BookDownloadManager
 ) : ViewModel() {
+    private data class FinishedUndoSnapshot(
+        val currentTimeSeconds: Double,
+        val durationSeconds: Double?,
+        val progressPercent: Double?,
+        val wasFinished: Boolean
+    )
+
     private val bookId: String = savedStateHandle.get<String>(DetailRoute.BOOK_ID_ARG).orEmpty()
     private val mutableUiState = MutableStateFlow(BookDetailUiState(isLoading = true))
     val uiState: StateFlow<BookDetailUiState> = mutableUiState.asStateFlow()
     val playbackUiState: StateFlow<PlaybackUiState> = playbackController.uiState
+    private val mutableMarkFinishedUndoEvents = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val markFinishedUndoEvents: SharedFlow<Unit> = mutableMarkFinishedUndoEvents.asSharedFlow()
+    private var pendingFinishedUndoSnapshot: FinishedUndoSnapshot? = null
 
     init {
         observePreferences()
@@ -109,12 +122,78 @@ class BookDetailViewModel @Inject constructor(
     fun markAsFinished() {
         if (bookId.isBlank()) return
         viewModelScope.launch {
+            val undoSnapshot = captureFinishedUndoSnapshot()
             when (val result = sessionRepository.markBookFinished(bookId = bookId, finished = true)) {
                 is AppResult.Success -> {
-                    mutableUiState.update { it.copy(actionMessage = "Marked as finished. Progress is now 100%.") }
+                    if (playbackUiState.value.book?.id == bookId) {
+                        playbackController.stopAndResetBookToStart(bookId)
+                    }
+                    pendingFinishedUndoSnapshot = undoSnapshot
+                    mutableMarkFinishedUndoEvents.tryEmit(Unit)
+                    mutableUiState.update { state ->
+                        val detailDuration = state.detail?.book?.durationSeconds?.coerceAtLeast(0.0) ?: 0.0
+                        state.copy(
+                            detail = state.detail?.copy(
+                                book = state.detail.book.copy(
+                                    isFinished = true,
+                                    progressPercent = 1.0,
+                                    currentTimeSeconds = detailDuration
+                                )
+                            ),
+                            progressPercent = 1.0,
+                            currentTimeSeconds = detailDuration
+                        )
+                    }
                     refresh(forceRefresh = true)
                 }
                 is AppResult.Error -> {
+                    mutableUiState.update { it.copy(actionMessage = result.message) }
+                }
+            }
+        }
+    }
+
+    fun undoMarkAsFinished() {
+        val snapshot = pendingFinishedUndoSnapshot ?: return
+        if (bookId.isBlank()) return
+        pendingFinishedUndoSnapshot = null
+        viewModelScope.launch {
+            when (
+                val result = sessionRepository.syncPlaybackProgress(
+                    bookId = bookId,
+                    currentTimeSeconds = snapshot.currentTimeSeconds,
+                    durationSeconds = snapshot.durationSeconds,
+                    isFinished = snapshot.wasFinished
+                )
+            ) {
+                is AppResult.Success -> {
+                    if (playbackUiState.value.book?.id == bookId) {
+                        playbackController.stopAndRestoreBookProgress(
+                            bookId = bookId,
+                            currentTimeSeconds = snapshot.currentTimeSeconds,
+                            durationSeconds = snapshot.durationSeconds,
+                            isFinished = snapshot.wasFinished
+                        )
+                    }
+                    mutableUiState.update { state ->
+                        state.copy(
+                            detail = state.detail?.copy(
+                                book = state.detail.book.copy(
+                                    isFinished = snapshot.wasFinished,
+                                    progressPercent = snapshot.progressPercent,
+                                    currentTimeSeconds = snapshot.currentTimeSeconds
+                                )
+                            ),
+                            progressPercent = snapshot.progressPercent,
+                            currentTimeSeconds = snapshot.currentTimeSeconds,
+                            actionMessage = "Undid mark as finished."
+                        )
+                    }
+                    refresh(forceRefresh = true)
+                }
+
+                is AppResult.Error -> {
+                    pendingFinishedUndoSnapshot = snapshot
                     mutableUiState.update { it.copy(actionMessage = result.message) }
                 }
             }
@@ -126,6 +205,10 @@ class BookDetailViewModel @Inject constructor(
         viewModelScope.launch {
             when (val result = sessionRepository.markBookFinished(bookId = bookId, finished = false)) {
                 is AppResult.Success -> {
+                    pendingFinishedUndoSnapshot = null
+                    if (playbackUiState.value.book?.id == bookId) {
+                        playbackController.stopAndResetBookToBeginning(bookId)
+                    }
                     mutableUiState.update { it.copy(actionMessage = "Marked as unfinished. Progress reset to 0%.") }
                     refresh(forceRefresh = true)
                 }
@@ -303,6 +386,41 @@ class BookDetailViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private suspend fun captureFinishedUndoSnapshot(): FinishedUndoSnapshot {
+        val detailBook = uiState.value.detail?.book
+        val progress = when (val result = sessionRepository.fetchPlaybackProgress(bookId)) {
+            is AppResult.Success -> result.value
+            is AppResult.Error -> null
+        }
+        val progressCurrentSeconds = progress?.currentTimeSeconds
+        val progressPercentFromServer = progress?.progressPercent
+        val currentTimeSeconds = when {
+            playbackUiState.value.book?.id == bookId -> playbackUiState.value.positionMs.coerceAtLeast(0L) / 1000.0
+            progressCurrentSeconds != null -> progressCurrentSeconds.coerceAtLeast(0.0)
+            else -> (uiState.value.currentTimeSeconds ?: 0.0).coerceAtLeast(0.0)
+        }
+        val durationSeconds = progress?.durationSeconds ?: detailBook?.durationSeconds
+        val progressPercent = when {
+            progressPercentFromServer != null -> progressPercentFromServer.coerceIn(0.0, 1.0)
+            durationSeconds != null && durationSeconds > 0.0 -> {
+                (currentTimeSeconds / durationSeconds).coerceIn(0.0, 1.0)
+            }
+            else -> null
+        }
+        val wasFinished = when {
+            detailBook?.isFinished == true -> true
+            progressPercent != null -> progressPercent >= 0.995
+            durationSeconds != null && durationSeconds > 0.0 -> (currentTimeSeconds / durationSeconds) >= 0.995
+            else -> false
+        }
+        return FinishedUndoSnapshot(
+            currentTimeSeconds = currentTimeSeconds,
+            durationSeconds = durationSeconds,
+            progressPercent = progressPercent,
+            wasFinished = wasFinished
+        )
     }
 
     private fun bookmarkMatches(source: BookBookmark, target: BookBookmark): Boolean {

--- a/app/src/main/java/com/stillshelf/app/ui/screens/MainScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/MainScreens.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.MarqueeSpacing
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
@@ -121,6 +122,9 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -140,6 +144,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
@@ -191,6 +196,7 @@ import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
 import coil.compose.SubcomposeAsyncImage
 import coil.compose.SubcomposeAsyncImageContent
+import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import coil.imageLoader
 import com.stillshelf.app.core.network.authorizationHeaderValue
@@ -5387,10 +5393,23 @@ fun BookDetailScreen(
     var editingDetailBookmark by remember { mutableStateOf<BookBookmark?>(null) }
     var editingDetailBookmarkTitle by rememberSaveable { mutableStateOf("") }
     var deletingDetailBookmark by remember { mutableStateOf<BookBookmark?>(null) }
+    val detailSnackbarHostState = remember { SnackbarHostState() }
     LaunchedEffect(uiState.actionMessage) {
         val message = uiState.actionMessage ?: return@LaunchedEffect
         Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         viewModel.clearActionMessage()
+    }
+    LaunchedEffect(viewModel, detailSnackbarHostState) {
+        viewModel.markFinishedUndoEvents.collect {
+            val result = detailSnackbarHostState.showSnackbar(
+                message = "Marked as finished",
+                actionLabel = "Undo",
+                withDismissAction = true
+            )
+            if (result == SnackbarResult.ActionPerformed) {
+                viewModel.undoMarkAsFinished()
+            }
+        }
     }
     LaunchedEffect(addToListBookId) {
         if (!addToListBookId.isNullOrBlank()) {
@@ -5432,20 +5451,31 @@ fun BookDetailScreen(
     val resolvedDetailProgress = max(detailProgressPercent, detailProgressFromTime ?: 0.0)
     val finishedFromDetailProgress = resolvedDetailProgress >= 0.995
     val effectiveDetailFinished = when {
-        isPlayingDetailBookNow && resolvedDetailProgress < 0.995 && (detailCurrentSeconds ?: 0.0) > 0.5 -> false
+        isPlayingDetailBookNow &&
+            playbackUiState.isPlaying &&
+            resolvedDetailProgress < 0.995 &&
+            (detailCurrentSeconds ?: 0.0) > 0.5 -> false
         else -> (detailBook?.isFinished == true) || finishedFromDetailProgress
     }
 
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = AppScreenHorizontalPadding, vertical = 14.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-        contentPadding = PaddingValues(bottom = 120.dp)
-    ) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(
+                    start = AppScreenHorizontalPadding,
+                    end = AppScreenHorizontalPadding,
+                    top = 2.dp,
+                    bottom = 14.dp
+                ),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(bottom = 120.dp)
+        ) {
         item {
             Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 4.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 CircleActionButton(
@@ -5566,9 +5596,11 @@ fun BookDetailScreen(
                 }
                 val serverPlaybackSeconds = uiState.currentTimeSeconds?.coerceAtLeast(0.0) ?: 0.0
                 val effectiveBookFinished = effectiveDetailFinished
-                val hasProgress = livePlaybackSeconds > 0.5 ||
-                    serverPlaybackSeconds > 0.5 ||
-                    (uiState.progressPercent ?: 0.0) > 0.001
+                val hasProgress = !effectiveBookFinished && (
+                    livePlaybackSeconds > 0.5 ||
+                        serverPlaybackSeconds > 0.5 ||
+                        (uiState.progressPercent ?: 0.0) > 0.001
+                    )
                 val listenLabel = if (effectiveBookFinished) {
                     "Start Listening"
                 } else if (hasProgress) {
@@ -5576,24 +5608,28 @@ fun BookDetailScreen(
                 } else {
                     "Start Listening"
                 }
-                val listenProgressFraction = run {
-                    val duration = when {
-                        book.durationSeconds != null && book.durationSeconds > 0.0 -> book.durationSeconds
-                        playbackUiState.book?.id == book.id && playbackUiState.durationMs > 0L -> {
-                            playbackUiState.durationMs / 1000.0
+                val listenProgressFraction = if (effectiveBookFinished) {
+                    0f
+                } else {
+                    run {
+                        val duration = when {
+                            book.durationSeconds != null && book.durationSeconds > 0.0 -> book.durationSeconds
+                            playbackUiState.book?.id == book.id && playbackUiState.durationMs > 0L -> {
+                                playbackUiState.durationMs / 1000.0
+                            }
+                            else -> null
                         }
-                        else -> null
+                        val resolved = when {
+                            duration != null && duration > 0.0 && livePlaybackSeconds > 0.0 -> {
+                                (livePlaybackSeconds / duration).coerceIn(0.0, 1.0)
+                            }
+                            duration != null && duration > 0.0 && serverPlaybackSeconds > 0.0 -> {
+                                (serverPlaybackSeconds / duration).coerceIn(0.0, 1.0)
+                            }
+                            else -> (uiState.progressPercent ?: 0.0).coerceIn(0.0, 1.0)
+                        }
+                        resolved.toFloat().coerceIn(0f, 1f)
                     }
-                    val resolved = when {
-                        duration != null && duration > 0.0 && livePlaybackSeconds > 0.0 -> {
-                            (livePlaybackSeconds / duration).coerceIn(0.0, 1.0)
-                        }
-                        duration != null && duration > 0.0 && serverPlaybackSeconds > 0.0 -> {
-                            (serverPlaybackSeconds / duration).coerceIn(0.0, 1.0)
-                        }
-                        else -> (uiState.progressPercent ?: 0.0).coerceIn(0.0, 1.0)
-                    }
-                    resolved.toFloat().coerceIn(0f, 1f)
                 }
                 val chapterPositionSeconds = if (playbackUiState.book?.id == book.id) {
                     (playbackUiState.positionMs.coerceAtLeast(0L) / 1000.0)
@@ -5610,30 +5646,66 @@ fun BookDetailScreen(
                 )
 
                 item {
+                    val detailCoverModel = rememberCoverImageModel(book.coverUrl)
+                    val detailCoverPainter = rememberAsyncImagePainter(model = detailCoverModel)
+                    val detailCoverSuccessState = detailCoverPainter.state as? AsyncImagePainter.State.Success
+                    val detailCoverIntrinsicWidth = detailCoverSuccessState?.result?.drawable?.intrinsicWidth?.takeIf { it > 0 }
+                    val detailCoverIntrinsicHeight = detailCoverSuccessState?.result?.drawable?.intrinsicHeight?.takeIf { it > 0 }
+                    val detailCoverAspectRatio = if (detailCoverIntrinsicWidth != null && detailCoverIntrinsicHeight != null) {
+                        detailCoverIntrinsicWidth.toFloat() / detailCoverIntrinsicHeight.toFloat()
+                    } else {
+                        0.66f
+                    }
+                    val isSquareLikeDetailCover = detailCoverAspectRatio in 0.97f..1.03f
+                    val detailCoverWidth = 240.dp
+                    val detailFrameWidth = if (isSquareLikeDetailCover) detailCoverWidth else 276.dp
+                    val detailCoverSlotHeight = if (isSquareLikeDetailCover) 240.dp else 296.dp
+                    val detailCoverHeight = if (isSquareLikeDetailCover) 224.dp else 272.dp
+                    val detailCoverContentScale = if (isSquareLikeDetailCover) ContentScale.Crop else ContentScale.Fit
+                    val detailForcedFrameSideInset = if (isSquareLikeDetailCover) null else 36.dp
+                    val detailSeriesBadgeYOffset = if (isSquareLikeDetailCover) 4.dp else (-4).dp
                     Box(
                         modifier = Modifier.fillMaxWidth(),
                         contentAlignment = Alignment.Center
                     ) {
+                        // Keep this painter in composition so square-cover detection updates once loaded.
+                        Image(
+                            painter = detailCoverPainter,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .size(1.dp)
+                                .alpha(0f)
+                        )
                         Box(
                             modifier = Modifier
-                                .width(240.dp)
-                                .height(320.dp)
+                                .width(detailCoverWidth)
+                                .height(detailCoverSlotHeight)
                         ) {
-                            BookPoster(
-                                book = book,
-                                width = 240.dp,
-                                height = 320.dp,
-                                fillMaxWidth = true,
-                                shape = RoundedCornerShape(10.dp),
-                                contentScale = ContentScale.Fit,
-                                showDownloadIndicator = uiState.downloadedBookIds.contains(book.id),
-                                downloadProgressPercent = uiState.downloadProgressPercent
-                            )
+                            Box(
+                                modifier = Modifier
+                                    .align(Alignment.Center)
+                                    .width(detailFrameWidth)
+                                    .height(detailCoverHeight)
+                            ) {
+                                BookPoster(
+                                    book = book,
+                                    width = detailFrameWidth,
+                                    height = detailCoverHeight,
+                                    fillMaxWidth = true,
+                                    shape = RoundedCornerShape(10.dp),
+                                    contentScale = detailCoverContentScale,
+                                    limitInsetToAvoidVerticalLetterbox = true,
+                                    forcedFrameSideInset = detailForcedFrameSideInset,
+                                    disableBlurredFrame = false,
+                                    showDownloadIndicator = uiState.downloadedBookIds.contains(book.id),
+                                    downloadProgressPercent = uiState.downloadProgressPercent
+                                )
+                            }
                             seriesOrderLabel?.let { order ->
                                 Box(
                                     modifier = Modifier
                                         .align(Alignment.TopStart)
-                                        .offset(x = (-4).dp, y = (-4).dp)
+                                        .offset(x = (-4).dp, y = detailSeriesBadgeYOffset)
                                         .clip(RoundedCornerShape(6.dp))
                                         .background(MaterialTheme.colorScheme.surface)
                                         .padding(horizontal = 6.dp, vertical = 2.dp)
@@ -5690,47 +5762,24 @@ fun BookDetailScreen(
                         Text(
                             text = topMetadata,
                             style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.fillMaxWidth()
                         )
                     }
                 }
                 item {
-                    if (hasProgress) {
-                        BookListenProgressButton(
-                            text = listenLabel,
-                            progress = listenProgressFraction,
-                            materialDesignEnabled = appearanceUiState.materialDesignEnabled,
-                            onClick = { onStartListening(book.id) }
-                        )
-                    } else {
-                        val startListenContainerColor = if (appearanceUiState.materialDesignEnabled) {
-                            MaterialTheme.colorScheme.primary
-                        } else {
-                            MaterialTheme.colorScheme.onSurface
-                        }
-                        val startListenContentColor = if (appearanceUiState.materialDesignEnabled) {
-                            if (startListenContainerColor.luminance() > 0.55f) Color.Black else Color.White
-                        } else {
-                            MaterialTheme.colorScheme.surface
-                        }
-                        Button(
-                            onClick = { onStartListening(book.id) },
-                            modifier = Modifier.fillMaxWidth(),
-                            colors = ButtonDefaults.buttonColors(
-                                containerColor = startListenContainerColor,
-                                contentColor = startListenContentColor
-                            )
-                        ) {
-                            Icon(
-                                imageVector = Icons.Outlined.PlayArrow,
-                                contentDescription = null,
-                                modifier = Modifier.size(16.dp)
-                            )
-                            Spacer(modifier = Modifier.width(6.dp))
-                            Text(listenLabel)
-                        }
-                    }
+                    BookListenProgressButton(
+                        text = listenLabel,
+                        progress = if (hasProgress) listenProgressFraction else 0f,
+                        materialDesignEnabled = appearanceUiState.materialDesignEnabled,
+                        onClick = { onStartListening(book.id) },
+                        modifier = Modifier.padding(top = 12.dp)
+                    )
                 }
+                item { Spacer(modifier = Modifier.height(8.dp)) }
                 item {
                     Row(
                         modifier = Modifier
@@ -5988,6 +6037,13 @@ fun BookDetailScreen(
                 }
             }
         }
+        }
+        SnackbarHost(
+            hostState = detailSnackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(horizontal = 16.dp, vertical = 84.dp)
+        )
     }
 
     editingDetailBookmark?.let { targetBookmark ->
@@ -6214,6 +6270,7 @@ fun PlayerScreen(
     var timerSheetSessionKey by rememberSaveable { mutableIntStateOf(0) }
     val speedSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var showSpeedSheet by rememberSaveable { mutableStateOf(false) }
+    val playerSnackbarHostState = remember { SnackbarHostState() }
     val speedLabel = formatPlaybackSpeedShort(playbackUiState.playbackSpeed)
     val speedToolValue = "Speed $speedLabel"
     val timerMode = playbackUiState.sleepTimerMode
@@ -6243,8 +6300,26 @@ fun PlayerScreen(
     } else {
         MaterialTheme.colorScheme.surfaceContainerHigh
     }
+    val isMaterialNonImmersive = appearanceUiState.materialDesignEnabled && !immersiveEnabled
+    val materialProgressAccent = if (MaterialTheme.colorScheme.background.luminance() > 0.5f) {
+        // Light themes: deepen accent so the timeline reads as a strong "marker" stroke.
+        lerp(MaterialTheme.colorScheme.primary, Color.Black, 0.14f)
+    } else {
+        // Dark themes: lift accent so it still pops on dark surfaces.
+        lerp(MaterialTheme.colorScheme.primary, Color.White, 0.2f)
+    }
+    val progressActiveColor = if (immersiveEnabled) {
+        Color.White.copy(alpha = 0.92f)
+    } else if (appearanceUiState.materialDesignEnabled) {
+        materialProgressAccent
+    } else {
+        MaterialTheme.colorScheme.onSurface
+    }
+    val menuItemTextColor = MaterialTheme.colorScheme.onSurface
     val bottomToolsPrimaryColor = if (immersiveEnabled) {
         Color.White
+    } else if (isMaterialNonImmersive) {
+        menuItemTextColor
     } else if (bottomToolsBaseColor.luminance() > 0.52f) {
         Color(0xFF1C1C1C)
     } else {
@@ -6252,6 +6327,8 @@ fun PlayerScreen(
     }
     val bottomToolsSecondaryColor = if (immersiveEnabled) {
         Color.White.copy(alpha = 0.72f)
+    } else if (isMaterialNonImmersive) {
+        menuItemTextColor
     } else if (bottomToolsBaseColor.luminance() > 0.52f) {
         Color(0xFF666666)
     } else {
@@ -6311,7 +6388,7 @@ fun PlayerScreen(
         useSlimStripTools -> if (nonMaterialDockMenuMatch) {
             nonMaterialMenuLikeBorder
         } else {
-            immersiveDockBorderColor
+            if (isMaterialNonImmersive) progressActiveColor else immersiveDockBorderColor
         }
         else -> Color.Transparent
     }
@@ -6329,8 +6406,8 @@ fun PlayerScreen(
     val toolsItemBorderColor = when {
         useFloatingChipsTools -> if (immersiveEnabled) {
             immersiveDockBorderColor
-        } else if (appearanceUiState.materialDesignEnabled) {
-            immersiveDockBorderColor
+        } else if (isMaterialNonImmersive) {
+            progressActiveColor
         } else {
             menuLikeBorderColor
         }
@@ -6369,6 +6446,7 @@ fun PlayerScreen(
         immersiveEnabled -> Color.Transparent
         !appearanceUiState.materialDesignEnabled -> nonMaterialMenuLikeBorder
         bottomToolsStyle == PlayerBottomToolsStyle.Flat -> Color.Transparent
+        isMaterialNonImmersive -> progressActiveColor
         else -> immersiveDockBorderColor
     }
     val mainPlayButtonIconTint = if (immersiveEnabled) {
@@ -6377,11 +6455,6 @@ fun PlayerScreen(
         Color.Black
     } else {
         Color.White
-    }
-    val progressActiveColor = if (immersiveEnabled) {
-        Color.White.copy(alpha = 0.92f)
-    } else {
-        MaterialTheme.colorScheme.onSurface
     }
     val progressTrackColor = if (immersiveEnabled) {
         Color.White.copy(alpha = 0.24f)
@@ -6394,6 +6467,7 @@ fun PlayerScreen(
     } else {
         MaterialTheme.colorScheme.onSurfaceVariant
     }
+    val seekControlTint = if (isMaterialNonImmersive) progressActiveColor else primaryTextColor
     val configuration = LocalConfiguration.current
     val density = LocalDensity.current
     val effectiveHeightDp = (configuration.screenHeightDp.toFloat() / density.fontScale).coerceAtLeast(520f)
@@ -6413,6 +6487,18 @@ fun PlayerScreen(
         val latest = actionMessage ?: return@LaunchedEffect
         Toast.makeText(context, latest, Toast.LENGTH_SHORT).show()
         viewModel.clearActionMessage()
+    }
+    LaunchedEffect(viewModel, playerSnackbarHostState) {
+        viewModel.markFinishedUndoEvents.collect {
+            val result = playerSnackbarHostState.showSnackbar(
+                message = "Marked as finished",
+                actionLabel = "Undo",
+                withDismissAction = true
+            )
+            if (result == SnackbarResult.ActionPerformed) {
+                viewModel.undoMarkAsFinished()
+            }
+        }
     }
     LaunchedEffect(addToListBookId) {
         if (!addToListBookId.isNullOrBlank()) {
@@ -6725,7 +6811,7 @@ fun PlayerScreen(
                 Seek15Button(
                     forward = false,
                     seconds = controlPrefs.skipBackwardSeconds,
-                    tint = primaryTextColor,
+                    tint = seekControlTint,
                     isImmersive = immersiveEnabled,
                     onClick = viewModel::onRewindClick
                 )
@@ -6744,22 +6830,27 @@ fun PlayerScreen(
                 ) {
                     val mainPlayButtonIcon = if (playbackUiState.isPlaying) {
                         Icons.Outlined.Pause
-                    } else if (immersiveEnabled) {
+                    } else if (immersiveEnabled || isMaterialNonImmersive) {
                         Icons.Filled.PlayArrow
                     } else {
                         Icons.Outlined.PlayArrow
                     }
+                    val mainPlayIconTint = if (!playbackUiState.isPlaying && isMaterialNonImmersive) {
+                        progressActiveColor
+                    } else {
+                        mainPlayButtonIconTint
+                    }
                     Icon(
                         imageVector = mainPlayButtonIcon,
                         contentDescription = if (playbackUiState.isPlaying) "Pause" else "Play",
-                        tint = mainPlayButtonIconTint,
+                        tint = mainPlayIconTint,
                         modifier = Modifier.size(36.dp)
                     )
                 }
                 Seek15Button(
                     forward = true,
                     seconds = controlPrefs.skipForwardSeconds,
-                    tint = primaryTextColor,
+                    tint = seekControlTint,
                     isImmersive = immersiveEnabled,
                     onClick = viewModel::onForwardClick
                 )
@@ -7039,6 +7130,13 @@ fun PlayerScreen(
             }
         }
         }
+
+        SnackbarHost(
+            hostState = playerSnackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(horizontal = 16.dp, vertical = 92.dp)
+        )
 
         if (playbackUiState.sleepTimerExpiredPromptVisible) {
             ModalBottomSheet(
@@ -7685,8 +7783,8 @@ private fun PlayerProgressBar(
     modifier: Modifier = Modifier
 ) {
     val clampedProgress = progress.coerceIn(0f, 1f)
-    val thumbSize = 11.dp
-    val barHeight = 5.dp
+    val touchTargetHeight = 28.dp
+    val barHeight = 8.dp
     var widthPx by remember { mutableStateOf(0f) }
     var dragProgress by remember { mutableStateOf(clampedProgress) }
     var isDragging by remember { mutableStateOf(false) }
@@ -7712,7 +7810,7 @@ private fun PlayerProgressBar(
 
     BoxWithConstraints(
         modifier = modifier
-            .height(thumbSize)
+            .height(touchTargetHeight)
             .onSizeChanged { widthPx = it.width.toFloat() }
             .pointerInput(widthPx, clampedProgress) {
                 detectTapGestures { offset ->
@@ -7751,15 +7849,6 @@ private fun PlayerProgressBar(
                 .height(barHeight)
                 .align(Alignment.CenterStart)
                 .clip(barShape)
-                .background(activeColor)
-        )
-        val maxOffset = (maxWidth - thumbSize).coerceAtLeast(0.dp)
-        Box(
-            modifier = Modifier
-                .align(Alignment.CenterStart)
-                .offset(x = maxOffset * displayProgress)
-                .size(thumbSize)
-                .clip(CircleShape)
                 .background(activeColor)
         )
     }
@@ -8839,6 +8928,7 @@ private fun BookListenProgressButton(
     modifier: Modifier = Modifier
 ) {
     val buttonShape = ButtonDefaults.shape
+    val labelStyle = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold)
     val accentColor = MaterialTheme.colorScheme.primary
     val baseColor = if (materialDesignEnabled) {
         // Keep the unshaved area as a darker accent tone.
@@ -8870,7 +8960,7 @@ private fun BookListenProgressButton(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(40.dp)
+            .height(50.dp)
             .clip(buttonShape)
             .background(baseColor)
     ) {
@@ -8890,12 +8980,12 @@ private fun BookListenProgressButton(
             )
         ) {
             Icon(
-                imageVector = Icons.Outlined.PlayArrow,
+                imageVector = Icons.Filled.PlayArrow,
                 contentDescription = null,
-                modifier = Modifier.size(16.dp)
+                modifier = Modifier.size(24.dp)
             )
             Spacer(modifier = Modifier.width(6.dp))
-            Text(text)
+            Text(text = text, style = labelStyle)
         }
     }
 }
@@ -10091,6 +10181,9 @@ private fun BookPoster(
     shape: RoundedCornerShape = RoundedCornerShape(8.dp),
     contentScale: ContentScale = ContentScale.Crop,
     backgroundBlur: Dp = WideCoverBackgroundBlur,
+    limitInsetToAvoidVerticalLetterbox: Boolean = true,
+    forcedFrameSideInset: Dp? = null,
+    disableBlurredFrame: Boolean = false,
     showDownloadIndicator: Boolean = false,
     downloadProgressPercent: Int? = null
 ) {
@@ -10111,7 +10204,10 @@ private fun BookPoster(
             modifier = Modifier.matchParentSize(),
             shape = shape,
             contentScale = contentScale,
-            backgroundBlur = backgroundBlur
+            backgroundBlur = backgroundBlur,
+            limitInsetToAvoidVerticalLetterbox = limitInsetToAvoidVerticalLetterbox,
+            forcedSideInset = forcedFrameSideInset,
+            disableBlurredFrame = disableBlurredFrame
         )
         val progress = downloadProgressPercent?.coerceIn(0, 100)
         val showProgress = progress != null && progress in 0..99

--- a/app/src/main/java/com/stillshelf/app/ui/screens/PlayerViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/PlayerViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.stillshelf.app.core.datastore.SessionPreferences
 import com.stillshelf.app.core.model.BookChapter
 import com.stillshelf.app.core.model.BookBookmark
+import com.stillshelf.app.core.model.BookSummary
 import com.stillshelf.app.core.model.ContinueListeningItem
 import com.stillshelf.app.core.util.AppResult
 import com.stillshelf.app.data.repo.SessionRepository
@@ -18,8 +19,11 @@ import com.stillshelf.app.ui.navigation.MainRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.math.abs
@@ -42,6 +46,13 @@ class PlayerViewModel @Inject constructor(
     private val sessionPreferences: SessionPreferences,
     private val bookDownloadManager: BookDownloadManager
 ) : ViewModel() {
+    private data class FinishedUndoSnapshot(
+        val bookId: String,
+        val currentTimeSeconds: Double,
+        val durationSeconds: Double?,
+        val wasFinished: Boolean
+    )
+
     val uiState: StateFlow<PlaybackUiState> = playbackController.uiState
     private val mutablePreviewItem = MutableStateFlow<ContinueListeningItem?>(null)
     val previewItem: StateFlow<ContinueListeningItem?> = mutablePreviewItem.asStateFlow()
@@ -57,9 +68,12 @@ class PlayerViewModel @Inject constructor(
     val downloadedBookIds: StateFlow<Set<String>> = mutableDownloadedBookIds.asStateFlow()
     private val mutableDownloadProgressPercent = MutableStateFlow<Int?>(null)
     val downloadProgressPercent: StateFlow<Int?> = mutableDownloadProgressPercent.asStateFlow()
+    private val mutableMarkFinishedUndoEvents = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val markFinishedUndoEvents: SharedFlow<Unit> = mutableMarkFinishedUndoEvents.asSharedFlow()
     private var currentDownloadItems: List<DownloadItem> = emptyList()
     private var loadedBookId: String? = null
     private var pendingSleepTimerRequest: PendingSleepTimerRequest? = null
+    private var pendingFinishedUndoSnapshot: FinishedUndoSnapshot? = null
 
     init {
         observeControlPrefs()
@@ -234,6 +248,55 @@ class PlayerViewModel @Inject constructor(
         setBookFinishedState(finished = false)
     }
 
+    fun undoMarkAsFinished() {
+        val snapshot = pendingFinishedUndoSnapshot ?: return
+        pendingFinishedUndoSnapshot = null
+        viewModelScope.launch {
+            when (
+                val result = sessionRepository.syncPlaybackProgress(
+                    bookId = snapshot.bookId,
+                    currentTimeSeconds = snapshot.currentTimeSeconds,
+                    durationSeconds = snapshot.durationSeconds,
+                    isFinished = snapshot.wasFinished
+                )
+            ) {
+                is AppResult.Success -> {
+                    if (uiState.value.book?.id == snapshot.bookId) {
+                        playbackController.stopAndRestoreBookProgress(
+                            bookId = snapshot.bookId,
+                            currentTimeSeconds = snapshot.currentTimeSeconds,
+                            durationSeconds = snapshot.durationSeconds,
+                            isFinished = snapshot.wasFinished
+                        )
+                    } else {
+                        val preview = previewItem.value
+                        if (preview?.book?.id == snapshot.bookId) {
+                            val restoredProgressPercent = snapshot.durationSeconds
+                                ?.takeIf { it > 0.0 }
+                                ?.let { duration -> (snapshot.currentTimeSeconds / duration).coerceIn(0.0, 1.0) }
+                            mutablePreviewItem.value = preview.copy(
+                                book = preview.book.copy(
+                                    isFinished = snapshot.wasFinished,
+                                    progressPercent = restoredProgressPercent,
+                                    currentTimeSeconds = snapshot.currentTimeSeconds
+                                ),
+                                progressPercent = restoredProgressPercent,
+                                currentTimeSeconds = snapshot.currentTimeSeconds
+                            )
+                        }
+                    }
+                    mutableActionMessage.value = "Undid mark as finished."
+                    loadBookMetadata(bookId = snapshot.bookId, forceRefresh = true)
+                }
+
+                is AppResult.Error -> {
+                    pendingFinishedUndoSnapshot = snapshot
+                    mutableActionMessage.value = result.message
+                }
+            }
+        }
+    }
+
     fun jumpToSeconds(seconds: Double) {
         val bookId = uiState.value.book?.id ?: previewItem.value?.book?.id ?: return
         val positionMs = (seconds.coerceAtLeast(0.0) * 1000.0).toLong()
@@ -380,18 +443,53 @@ class PlayerViewModel @Inject constructor(
     }
 
     private fun setBookFinishedState(finished: Boolean) {
-        val bookId = uiState.value.book?.id ?: previewItem.value?.book?.id
+        val activeBook = uiState.value.book ?: previewItem.value?.book
+        val bookId = activeBook?.id
         if (bookId.isNullOrBlank()) {
             mutableActionMessage.value = "Book details not ready yet."
             return
         }
         viewModelScope.launch {
+            val undoSnapshot = if (finished) captureFinishedUndoSnapshot(book = activeBook) else null
             when (val result = sessionRepository.markBookFinished(bookId = bookId, finished = finished)) {
                 is AppResult.Success -> {
-                    mutableActionMessage.value = if (finished) {
-                        "Marked as finished. Progress is now 100%."
+                    if (finished) {
+                        pendingFinishedUndoSnapshot = undoSnapshot
+                        if (uiState.value.book?.id == bookId) {
+                            playbackController.stopAndResetBookToStart(bookId)
+                        }
+                        mutableMarkFinishedUndoEvents.tryEmit(Unit)
+                        if (uiState.value.book?.id != bookId) {
+                            val duration = activeBook.durationSeconds?.coerceAtLeast(0.0) ?: 0.0
+                            mutablePreviewItem.value = ContinueListeningItem(
+                                book = activeBook.copy(
+                                    isFinished = true,
+                                    progressPercent = 1.0,
+                                    currentTimeSeconds = duration
+                                ),
+                                progressPercent = 1.0,
+                                currentTimeSeconds = duration
+                            )
+                        }
+                    }
+                    if (finished) {
+                        mutableActionMessage.value = null
                     } else {
-                        "Marked as unfinished. Progress reset to 0%."
+                        pendingFinishedUndoSnapshot = null
+                        if (uiState.value.book?.id == bookId) {
+                            playbackController.stopAndResetBookToBeginning(bookId)
+                        } else {
+                            mutablePreviewItem.value = ContinueListeningItem(
+                                book = activeBook.copy(
+                                    isFinished = false,
+                                    progressPercent = 0.0,
+                                    currentTimeSeconds = 0.0
+                                ),
+                                progressPercent = 0.0,
+                                currentTimeSeconds = 0.0
+                            )
+                        }
+                        mutableActionMessage.value = "Marked as unfinished. Progress reset to 0%."
                     }
                     loadBookMetadata(bookId = bookId, forceRefresh = true)
                 }
@@ -401,6 +499,43 @@ class PlayerViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private suspend fun captureFinishedUndoSnapshot(book: BookSummary?): FinishedUndoSnapshot {
+        val fallbackCurrentTime = when {
+            uiState.value.book?.id == book?.id -> uiState.value.positionMs.coerceAtLeast(0L) / 1000.0
+            else -> previewItem.value?.currentTimeSeconds
+                ?: previewItem.value?.book?.currentTimeSeconds
+                ?: 0.0
+        }
+        val progress = when (val result = sessionRepository.fetchPlaybackProgress(book?.id.orEmpty())) {
+            is AppResult.Success -> result.value
+            is AppResult.Error -> null
+        }
+        val progressCurrentSeconds = progress?.currentTimeSeconds
+        val progressPercentFromServer = progress?.progressPercent
+        val currentTimeSeconds = progressCurrentSeconds?.coerceAtLeast(0.0)
+            ?: fallbackCurrentTime.coerceAtLeast(0.0)
+        val durationSeconds = progress?.durationSeconds ?: book?.durationSeconds
+        val progressPercent = when {
+            progressPercentFromServer != null -> progressPercentFromServer.coerceIn(0.0, 1.0)
+            durationSeconds != null && durationSeconds > 0.0 -> {
+                (currentTimeSeconds / durationSeconds).coerceIn(0.0, 1.0)
+            }
+            else -> null
+        }
+        val wasFinished = when {
+            book?.isFinished == true -> true
+            progressPercent != null -> progressPercent >= 0.995
+            durationSeconds != null && durationSeconds > 0.0 -> (currentTimeSeconds / durationSeconds) >= 0.995
+            else -> false
+        }
+        return FinishedUndoSnapshot(
+            bookId = book?.id.orEmpty(),
+            currentTimeSeconds = currentTimeSeconds,
+            durationSeconds = durationSeconds,
+            wasFinished = wasFinished
+        )
     }
 
     private fun loadBookMetadata(bookId: String, forceRefresh: Boolean = false) {


### PR DESCRIPTION
## Summary
- Finalize player UX polish for Material/non-immersive controls and progress styling.
- Add robust mark-finished/undo flows in player and book detail, synced with playback state.
- Improve audio focus/noisy-output handling and Bluetooth auto-route behavior.
- Harden cover framing behavior for square and non-square detail covers.
- Fix About page version-code API compatibility for minSdk 24.
- Bump app version to stable `0.1.0` (versionCode 17).

## Verification
- `./gradlew :app:testDebugUnitTest :app:lintDebug :app:assembleRelease --stacktrace`

## Release Artifact
- Signed APK generated locally from this commit (release keystore).
