### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.stillshelf.app"
         minSdk = 24
         targetSdk = 36
-        versionCode = 18
-        versionName = "0.1.1"
+        versionCode = 19
+        versionName = "0.1.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/fastlane/metadata/android/en-US/changelogs/19.txt
+++ b/fastlane/metadata/android/en-US/changelogs/19.txt
@@ -1,0 +1,5 @@
+- Added a dedicated F-Droid build flavor with the in-app updater disabled there
+- Added Fastlane metadata and screenshots to improve F-Droid store publishing
+- Fixed the startup update prompt so it only appears after you reach Home
+- Fixed the first-open series stack issue seen on some phones
+- Updated build and CI setup to support the new GitHub and F-Droid release variants


### PR DESCRIPTION
## Summary
- bump the app version to `0.1.2` / `versionCode 19`
- add the Fastlane changelog entry for the new release

## Verification
- `GRADLE_USER_HOME=/tmp/gradle ./gradlew :app:compileGithubDebugKotlin :app:testGithubDebugUnitTest :app:assembleGithubRelease :app:assembleFdroidRelease --stacktrace`
