### PR TITLE
Fix library selector dropdown layout

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.stillshelf.app"
         minSdk = 24
         targetSdk = 36
-        versionCode = 19
-        versionName = "0.1.2"
+        versionCode = 20
+        versionName = "0.1.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/stillshelf/app/ui/screens/MainScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/MainScreens.kt
@@ -158,7 +158,6 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -268,6 +267,8 @@ enum class BooksSortKey(
 }
 
 private val BackTitleSpacing = 12.dp
+private val HomeTopBarLibrarySelectorMinWidth = 184.dp
+private val HomeTopBarLibrarySelectorPreferredWidth = 236.dp
 
 private val SeriesStackMinLayerExtent = 42.dp
 private val SeriesStackStep = 5.dp
@@ -392,7 +393,6 @@ fun HomeScreen(
     }
     var isMenuExpanded by remember { mutableStateOf(false) }
     var isLibraryMenuExpanded by remember { mutableStateOf(false) }
-    var libraryMenuAnchorWidthPx by remember { mutableIntStateOf(0) }
     var addToListBookId by rememberSaveable { mutableStateOf<String?>(null) }
     val refreshState = rememberPullRefreshState(
         refreshing = uiState.isLoading,
@@ -537,17 +537,17 @@ fun HomeScreen(
                         .padding(start = homeStartInset, end = homeEndInset),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Box(
+                    BoxWithConstraints(
                         modifier = Modifier.weight(1f)
                     ) {
                         val hasLibraries = menuUiState.libraries.isNotEmpty()
-                        val libraryMenuWidth = with(LocalDensity.current) { libraryMenuAnchorWidthPx.toDp() }
+                        val libraryMenuWidth = HomeTopBarLibrarySelectorPreferredWidth
+                            .coerceAtMost(maxWidth)
+                            .coerceAtLeast(HomeTopBarLibrarySelectorMinWidth.coerceAtMost(maxWidth))
                         Row(
                             modifier = Modifier
+                                .width(libraryMenuWidth)
                                 .clip(RoundedCornerShape(10.dp))
-                                .onGloballyPositioned { coordinates ->
-                                    libraryMenuAnchorWidthPx = coordinates.size.width
-                                }
                                 .clickable(enabled = hasLibraries && !menuUiState.isSwitchingLibrary) {
                                     isLibraryMenuExpanded = true
                                 }
@@ -577,16 +577,18 @@ fun HomeScreen(
                         AppDropdownMenu(
                             expanded = isLibraryMenuExpanded && hasLibraries,
                             onDismissRequest = { isLibraryMenuExpanded = false },
-                            modifier = if (libraryMenuAnchorWidthPx > 0) {
-                                Modifier.width(libraryMenuWidth)
-                            } else {
-                                Modifier
-                            }
+                            modifier = Modifier.width(libraryMenuWidth)
                         ) {
                             menuUiState.libraries.forEach { library ->
                                 val isActive = menuUiState.activeLibraryId == library.id
                                 AppDropdownMenuItem(
-                                    text = { Text(library.name) },
+                                    text = {
+                                        Text(
+                                            text = library.name,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis
+                                        )
+                                    },
                                     trailingIcon = {
                                         if (isActive) {
                                             Icon(


### PR DESCRIPTION
## Summary
- fix the home library selector so its trigger width stays stable instead of collapsing to short library names
- make the dropdown use the same wider width as the trigger to avoid the vertical wrapped menu bug
- keep library names to one line with ellipsis so menu height only grows with additional libraries
- bump the app version to 0.1.3 for release

## Verification
- `GRADLE_USER_HOME=/tmp/gradle ./gradlew :app:compileGithubDebugKotlin --stacktrace`
