### PR TITLE
Add Navidrome queue removal support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 80
-val appVersionName = "0.3.8"
+val appVersionCode = 81
+val appVersionName = "0.3.9"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
@@ -101,6 +101,31 @@ internal fun shouldPersistNavidromePlaybackCheckpoint(
     return kotlin.math.abs(currentPositionMs - previousPositionMs) >= 10_000
 }
 
+internal data class NavidromeQueueRemovalResult(
+    val queue: List<NavidromeTrack>,
+    val currentIndex: Int
+)
+
+internal fun removeNavidromeTrackFromQueue(
+    queue: List<NavidromeTrack>,
+    currentIndex: Int,
+    removeIndex: Int
+): NavidromeQueueRemovalResult? {
+    if (queue.isEmpty()) return null
+    if (currentIndex !in queue.indices) return null
+    if (removeIndex !in queue.indices) return null
+    if (removeIndex == currentIndex) return null
+
+    val updatedQueue = queue.toMutableList().apply {
+        removeAt(removeIndex)
+    }
+    val adjustedCurrentIndex = if (removeIndex < currentIndex) currentIndex - 1 else currentIndex
+    return NavidromeQueueRemovalResult(
+        queue = updatedQueue,
+        currentIndex = adjustedCurrentIndex.coerceIn(0, updatedQueue.lastIndex)
+    )
+}
+
 internal data class NavidromeTrackSnapshotPayload(
     val id: String,
     val title: String,
@@ -556,6 +581,48 @@ class NavidromePlayerController @Inject constructor(
         })
         updateStateFromPlayer()
         persistPlaybackSnapshot(force = true)
+    }
+
+    fun removeTrackFromQueue(index: Int): Boolean {
+        val currentIndex = resolveCurrentQueueIndex()
+            .takeIf { it in queueTracks.indices }
+            ?: mutableState.value.currentIndex.takeIf { it in queueTracks.indices }
+            ?: return false
+        val removal = removeNavidromeTrackFromQueue(
+            queue = queueTracks,
+            currentIndex = currentIndex,
+            removeIndex = index
+        ) ?: return false
+
+        invalidatePendingPlaybackRestore()
+        queueTracks = removal.queue
+
+        val activePlayer = player
+        if (activePlayer != null) {
+            activePlayer.removeMediaItem(index)
+            if (activePlayer.currentMediaItemIndex != removal.currentIndex) {
+                activePlayer.seekTo(removal.currentIndex, activePlayer.currentPosition.coerceAtLeast(0L))
+            }
+            updateStateFromPlayer()
+        } else {
+            val currentTrack = queueTracks.getOrNull(removal.currentIndex)
+            mutableState.value = mutableState.value.copy(
+                queue = queueTracks,
+                queueDisplayMode = queueDisplayMode,
+                currentIndex = removal.currentIndex,
+                currentTrack = currentTrack,
+                recentTracks = recentTracks,
+                isLoading = false,
+                isPlaying = false,
+                positionMs = mutableState.value.positionMs.coerceAtLeast(0),
+                durationMs = currentTrack?.let(::resolveTrackDurationMs) ?: 0,
+                errorMessage = null
+            )
+        }
+
+        persistPlaybackSnapshot(force = true)
+        ensureProgressUpdates()
+        return true
     }
 
     fun togglePlayPause() {

--- a/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
@@ -89,6 +89,7 @@ import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.PlaylistPlay
 import androidx.compose.material.icons.automirrored.outlined.OpenInNew
 import androidx.compose.material.icons.automirrored.outlined.ViewList
 import androidx.compose.material.icons.filled.Check
@@ -752,6 +753,9 @@ fun NavidromeAppRoute(
                 onDismissLyrics = playerViewModel::dismissLyrics,
                 onClearLyricsCache = playerViewModel::clearLyricsCache,
                 onLyricsModeChanged = { visible -> lockPlayerSheetDismiss = visible },
+                onPlayNextTrack = { track -> playerViewModel.playTracksNext(listOf(track)) },
+                onAddToQueueTrack = { track -> playerViewModel.addTracksToQueue(listOf(track)) },
+                onRemoveFromQueueTrack = playerViewModel::removeQueueItem,
                 onOpenAlbum = { albumId ->
                     dismissPlayerSheet {
                         navController.navigate(NavidromeRoute.album(albumId))
@@ -3527,6 +3531,14 @@ private fun NavidromePlaylistDetailRoute(
                                         rowMenuExpanded = false
                                         playerViewModel.playTracks(detail.tracks, index)
                                     },
+                                    onPlayNext = {
+                                        rowMenuExpanded = false
+                                        playerViewModel.playTracksNext(listOf(track))
+                                    },
+                                    onAddToQueue = {
+                                        rowMenuExpanded = false
+                                        playerViewModel.addTracksToQueue(listOf(track))
+                                    },
                                     playLabel = if (playerState.currentTrack?.id == track.id) "Play Again" else "Play",
                                     onShowAlbum = track.albumId?.let { albumId ->
                                         {
@@ -3775,6 +3787,14 @@ private fun NavidromeFavoriteSongsRoute(
                                 onPlayTrack = {
                                     rowMenuExpanded = false
                                     playerViewModel.playTracks(uiState.songs, index)
+                                },
+                                onPlayNext = {
+                                    rowMenuExpanded = false
+                                    playerViewModel.playTracksNext(listOf(track))
+                                },
+                                onAddToQueue = {
+                                    rowMenuExpanded = false
+                                    playerViewModel.addTracksToQueue(listOf(track))
                                 },
                                 playLabel = if (playerState.currentTrack?.id == track.id) "Play Again" else "Play",
                                 onShowAlbum = onOpenAlbum?.let { openAlbum ->
@@ -4070,6 +4090,14 @@ private fun NavidromeSongsRoute(
                                         queueDisplayMode = NavidromeQueueDisplayMode.SONGS_TAB_PREVIEW
                                     )
                                 },
+                                onPlayNext = {
+                                    rowMenuExpanded = false
+                                    playerViewModel.playTracksNext(listOf(track))
+                                },
+                                onAddToQueue = {
+                                    rowMenuExpanded = false
+                                    playerViewModel.addTracksToQueue(listOf(track))
+                                },
                                 playLabel = if (playerState.currentTrack?.id == track.id) "Play Again" else "Play",
                                 isDownloaded = downloadUiState.downloadedTrackIds.contains(track.id),
                                 onToggleDownload = {
@@ -4321,6 +4349,14 @@ private fun NavidromeSearchRoute(
                                         rowMenuExpanded = false
                                         viewModel.commitCurrentQuery()
                                         playerViewModel.playTracks(uiState.results.tracks, index)
+                                    },
+                                    onPlayNext = {
+                                        rowMenuExpanded = false
+                                        playerViewModel.playTracksNext(listOf(track))
+                                    },
+                                    onAddToQueue = {
+                                        rowMenuExpanded = false
+                                        playerViewModel.addTracksToQueue(listOf(track))
                                     },
                                     playLabel = if (playerState.currentTrack?.id == track.id) "Play Again" else "Play",
                                     isDownloaded = downloadUiState.downloadedTrackIds.contains(track.id),
@@ -4684,6 +4720,14 @@ private fun NavidromeAlbumDetailRoute(
                                 onPlayTrack = {
                                     rowMenuExpanded = false
                                     playerViewModel.playTracks(detail.tracks, index)
+                                },
+                                onPlayNext = {
+                                    rowMenuExpanded = false
+                                    playerViewModel.playTracksNext(listOf(track))
+                                },
+                                onAddToQueue = {
+                                    rowMenuExpanded = false
+                                    playerViewModel.addTracksToQueue(listOf(track))
                                 },
                                 playLabel = if (playerState.currentTrack?.id == track.id) "Play Again" else "Play",
                                 isDownloaded = downloadUiState.downloadedTrackIds.contains(track.id),
@@ -7024,6 +7068,8 @@ private fun NavidromeContinueListeningCard(
     posterHeight: Dp = 80.dp,
     onPlayPause: () -> Unit,
     onPlayTrack: () -> Unit,
+    onPlayNextTrack: ((NavidromeTrack) -> Unit)? = null,
+    onAddToQueueTrack: ((NavidromeTrack) -> Unit)? = null,
     onToggleDownload: () -> Unit,
     onClick: () -> Unit,
     onOpenAlbum: (() -> Unit)? = null,
@@ -7152,6 +7198,14 @@ private fun NavidromeContinueListeningCard(
                         } else {
                             onPlayTrack()
                         }
+                        menuExpanded = false
+                    },
+                    onPlayNext = {
+                        onPlayNextTrack?.invoke(track)
+                        menuExpanded = false
+                    },
+                    onAddToQueue = {
+                        onAddToQueueTrack?.invoke(track)
                         menuExpanded = false
                     },
                     playLabel = if (isCurrent && isPlaying) "Pause" else if (isCurrent) "Resume" else "Play Now",
@@ -7654,6 +7708,8 @@ private fun NavidromeTrackActionsMenu(
     expanded: Boolean,
     onDismissRequest: () -> Unit,
     onPlayTrack: () -> Unit,
+    onPlayNext: () -> Unit,
+    onAddToQueue: () -> Unit,
     playLabel: String,
     isDownloaded: Boolean = false,
     onToggleDownload: (() -> Unit)? = null,
@@ -7662,6 +7718,7 @@ private fun NavidromeTrackActionsMenu(
     onShowTrackDetails: (() -> Unit)? = null,
     extraActions: (@Composable ColumnScope.() -> Unit)? = null
 ) {
+    val context = LocalContext.current
     AppDropdownMenu(
         expanded = expanded,
         onDismissRequest = onDismissRequest
@@ -7675,6 +7732,32 @@ private fun NavidromeTrackActionsMenu(
                 )
             },
             onClick = onPlayTrack
+        )
+        AppDropdownMenuItem(
+            text = { Text("Play Next") },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Outlined.PlaylistPlay,
+                    contentDescription = null
+                )
+            },
+            onClick = {
+                onPlayNext()
+                Toast.makeText(context, "Playing next", Toast.LENGTH_SHORT).show()
+            }
+        )
+        AppDropdownMenuItem(
+            text = { Text("Add to Queue") },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Outlined.QueueMusic,
+                    contentDescription = null
+                )
+            },
+            onClick = {
+                onAddToQueue()
+                Toast.makeText(context, "Added to queue", Toast.LENGTH_SHORT).show()
+            }
         )
         if (onToggleDownload != null) {
             AppDropdownMenuItem(
@@ -9577,6 +9660,9 @@ private fun NavidromeExpandedPlayerSheet(
     onDismissLyrics: () -> Unit,
     onClearLyricsCache: () -> Unit,
     onLyricsModeChanged: (Boolean) -> Unit,
+    onPlayNextTrack: ((NavidromeTrack) -> Unit)? = null,
+    onAddToQueueTrack: ((NavidromeTrack) -> Unit)? = null,
+    onRemoveFromQueueTrack: (Int) -> Boolean,
     onOpenAlbum: ((String) -> Unit)? = null,
     onOpenArtist: ((String) -> Unit)? = null
 ) {
@@ -10443,7 +10529,92 @@ private fun NavidromeExpandedPlayerSheet(
                                             isDownloaded = item.track.id in downloadedTrackIds,
                                             downloadProgressPercent = trackProgressById[item.track.id],
                                             immersiveEnabled = immersiveEnabled,
-                                            onClick = { onSelectTrack(item.queueIndex) }
+                                            onClick = { onSelectTrack(item.queueIndex) },
+                                            trailingContent = if (onPlayNextTrack != null && onAddToQueueTrack != null) {
+                                                {
+                                                    var rowMenuExpanded by remember { mutableStateOf(false) }
+                                                    Box {
+                                                        IconButton(onClick = { rowMenuExpanded = true }) {
+                                                            Icon(
+                                                                imageVector = Icons.Outlined.MoreHoriz,
+                                                                contentDescription = "Queue item options"
+                                                            )
+                                                        }
+                                                        NavidromeTrackActionsMenu(
+                                                            expanded = rowMenuExpanded,
+                                                            onDismissRequest = { rowMenuExpanded = false },
+                                                            onPlayTrack = {
+                                                                rowMenuExpanded = false
+                                                                if (itemIsCurrent && state.isPlaying) {
+                                                                    onPlayPause()
+                                                                } else {
+                                                                    onSelectTrack(item.queueIndex)
+                                                                }
+                                                            },
+                                                            onPlayNext = {
+                                                                rowMenuExpanded = false
+                                                                onPlayNextTrack?.invoke(item.track)
+                                                            },
+                                                            onAddToQueue = {
+                                                                rowMenuExpanded = false
+                                                                onAddToQueueTrack?.invoke(item.track)
+                                                            },
+                                                            playLabel = when {
+                                                                itemIsCurrent && state.isPlaying -> "Pause"
+                                                                itemIsCurrent -> "Resume"
+                                                                else -> "Play Now"
+                                                            },
+                                                            isDownloaded = item.track.id in downloadedTrackIds,
+                                                            onToggleDownload = onToggleDownload?.let { toggle ->
+                                                                {
+                                                                    rowMenuExpanded = false
+                                                                    toggle(item.track)
+                                                                }
+                                                            },
+                                                            onShowAlbum = item.track.albumId?.let { albumId ->
+                                                                {
+                                                                    rowMenuExpanded = false
+                                                                    onOpenAlbum?.invoke(albumId)
+                                                                }
+                                                            },
+                                                            onShowArtist = item.track.artistId?.let { artistId ->
+                                                                {
+                                                                    rowMenuExpanded = false
+                                                                    onOpenArtist?.invoke(artistId)
+                                                                }
+                                                            },
+                                                            extraActions = if (!itemIsCurrent) {
+                                                                {
+                                                                    HorizontalDivider()
+                                                                    AppDropdownMenuItem(
+                                                                        text = { Text("Remove from queue") },
+                                                                        leadingIcon = {
+                                                                            Icon(
+                                                                                imageVector = Icons.Outlined.Remove,
+                                                                                contentDescription = null
+                                                                            )
+                                                                        },
+                                                                        onClick = {
+                                                                            rowMenuExpanded = false
+                                                                            if (onRemoveFromQueueTrack(item.queueIndex)) {
+                                                                                Toast.makeText(
+                                                                                    context,
+                                                                                    "Removed from queue",
+                                                                                    Toast.LENGTH_SHORT
+                                                                                ).show()
+                                                                            }
+                                                                        }
+                                                                    )
+                                                                }
+                                                            } else {
+                                                                null
+                                                            }
+                                                        )
+                                                    }
+                                                }
+                                            } else {
+                                                null
+                                            }
                                         )
                                 }
                             }
@@ -11619,7 +11790,8 @@ private fun PlayerQueueRow(
     isDownloaded: Boolean = false,
     downloadProgressPercent: Int? = null,
     immersiveEnabled: Boolean = false,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    trailingContent: (@Composable () -> Unit)? = null
 ) {
     val currentBackgroundColor = if (immersiveEnabled) {
         Color.White.copy(alpha = 0.10f)
@@ -11667,18 +11839,18 @@ private fun PlayerQueueRow(
             .padding(horizontal = 8.dp, vertical = 6.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.CenterVertically
-    ) {
-        AlbumArt(
-            url = track.coverUrl,
-            size = 44.dp,
-            showDownloadedIndicator = isDownloaded,
+        ) {
+            AlbumArt(
+                url = track.coverUrl,
+                size = 44.dp,
+                showDownloadedIndicator = isDownloaded,
             downloadProgressPercent = downloadProgressPercent
         )
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = track.title,
-                style = MaterialTheme.typography.titleSmall,
-                color = primaryTextColor,
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = track.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = primaryTextColor,
                 fontWeight = if (isCurrent) FontWeight.SemiBold else FontWeight.Normal,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
@@ -11687,24 +11859,42 @@ private fun PlayerQueueRow(
                 text = track.artistName,
                 style = MaterialTheme.typography.bodySmall,
                 color = secondaryTextColor,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
-        if (isCurrent) {
-            NavidromeNowPlayingVisualizer(
-                isPlaying = isPlaying,
-                color = nowPlayingAccentColor
-            )
-        } else {
-            Text(
-                text = track.durationSeconds?.let(::formatDuration) ?: "--:--",
-                style = MaterialTheme.typography.bodySmall,
-                color = secondaryTextColor
-            )
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            when {
+                trailingContent != null && isCurrent -> {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        NavidromeNowPlayingVisualizer(
+                            isPlaying = isPlaying,
+                            color = nowPlayingAccentColor
+                        )
+                        trailingContent()
+                    }
+                }
+                trailingContent != null -> {
+                    trailingContent()
+                }
+                isCurrent -> {
+                    NavidromeNowPlayingVisualizer(
+                        isPlaying = isPlaying,
+                        color = nowPlayingAccentColor
+                    )
+                }
+                else -> {
+                    Text(
+                        text = track.durationSeconds?.let(::formatDuration) ?: "--:--",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = secondaryTextColor
+                    )
+                }
+            }
         }
     }
-}
 
 @Composable
 private fun navidromeNowPlayingAccentColor(immersiveEnabled: Boolean = false): Color {

--- a/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeViewModels.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeViewModels.kt
@@ -2545,6 +2545,10 @@ class NavidromePlayerViewModel @Inject constructor(
         playerController.appendTracksToQueue(tracks)
     }
 
+    fun removeQueueItem(index: Int): Boolean {
+        return playerController.removeTrackFromQueue(index)
+    }
+
     fun playRadio(radio: NavidromeRadio) {
         playerController.playTracks(listOf(radio.toTrack()), startIndex = 0)
     }

--- a/app/src/test/java/com/stillshelf/app/playback/navidrome/NavidromeQueueRemovalTest.kt
+++ b/app/src/test/java/com/stillshelf/app/playback/navidrome/NavidromeQueueRemovalTest.kt
@@ -1,0 +1,98 @@
+package com.stillshelf.app.playback.navidrome
+
+import com.stillshelf.app.core.model.NavidromeTrack
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NavidromeQueueRemovalTest {
+
+    @Test
+    fun removesTrackAfterCurrentWithoutChangingCurrentIndex() {
+        val queue = (0 until 5).map(::track)
+
+        val result = removeNavidromeTrackFromQueue(
+            queue = queue,
+            currentIndex = 2,
+            removeIndex = 4
+        )
+
+        requireNotNull(result)
+        assertEquals(listOf("track-0", "track-1", "track-2", "track-3"), result.queue.map { it.id })
+        assertEquals(2, result.currentIndex)
+    }
+
+    @Test
+    fun removesTrackBeforeCurrentAndShiftsCurrentIndexBackOne() {
+        val queue = (0 until 5).map(::track)
+
+        val result = removeNavidromeTrackFromQueue(
+            queue = queue,
+            currentIndex = 3,
+            removeIndex = 1
+        )
+
+        requireNotNull(result)
+        assertEquals(listOf("track-0", "track-2", "track-3", "track-4"), result.queue.map { it.id })
+        assertEquals(2, result.currentIndex)
+    }
+
+    @Test
+    fun rejectsRemovingCurrentTrack() {
+        val queue = (0 until 4).map(::track)
+
+        val result = removeNavidromeTrackFromQueue(
+            queue = queue,
+            currentIndex = 2,
+            removeIndex = 2
+        )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun removesByIndexEvenWhenQueueContainsDuplicateTracks() {
+        val duplicate = track(7)
+        val queue = listOf(track(0), duplicate, duplicate, track(3))
+
+        val result = removeNavidromeTrackFromQueue(
+            queue = queue,
+            currentIndex = 3,
+            removeIndex = 1
+        )
+
+        requireNotNull(result)
+        assertEquals(listOf("track-0", "track-7", "track-3"), result.queue.map { it.id })
+        assertEquals(2, result.currentIndex)
+    }
+
+    @Test
+    fun rejectsInvalidRemovalIndex() {
+        val queue = listOf(track(0), track(1))
+
+        val result = removeNavidromeTrackFromQueue(
+            queue = queue,
+            currentIndex = 0,
+            removeIndex = 99
+        )
+
+        assertNull(result)
+    }
+
+    private fun track(index: Int): NavidromeTrack {
+        return NavidromeTrack(
+            id = "track-$index",
+            title = "Track $index",
+            artistName = "Artist",
+            albumName = "Album",
+            albumId = "album-1",
+            artistId = "artist-1",
+            trackNumber = index + 1,
+            durationSeconds = 180,
+            coverUrl = null,
+            streamUrl = "https://example.com/$index.mp3",
+            formatLabel = "MP3",
+            bitRateKbps = 320
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add Navidrome-only removal from the Up Next queue
- Keep queue state and current index consistent when items are removed
- Add unit coverage for queue removal index handling
- Bump app version on the branch for the release flow

## Validation
- Android Studio unit test run passed for `NavidromeQueueRemovalTest`
- `git diff --check`

## Notes
- Navidrome only; ABS is unchanged
- Removal is limited to the Up Next queue UI