### PR TITLE
[codex] Navidrome radio UI and Discover fixes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 83
-val appVersionName = "0.4.1"
+val appVersionCode = 84
+val appVersionName = "0.4.2"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/core/model/NavidromeModels.kt
+++ b/app/src/main/java/com/stillshelf/app/core/model/NavidromeModels.kt
@@ -148,6 +148,7 @@ enum class NavidromeQueueDisplayMode {
 
 data class NavidromeHome(
     val recentAlbums: List<NavidromeAlbum>,
+    val discoverAlbums: List<NavidromeAlbum>,
     val artists: List<NavidromeArtist>,
     val playlists: List<NavidromePlaylist>,
     val radios: List<NavidromeRadio>

--- a/app/src/main/java/com/stillshelf/app/data/repo/NavidromeRepository.kt
+++ b/app/src/main/java/com/stillshelf/app/data/repo/NavidromeRepository.kt
@@ -850,6 +850,7 @@ class NavidromeRepository @Inject constructor(
         val sessionKey = cacheKey(auth, "persisted-home")
         if (!forceRefresh) {
             getFreshCache(homeCache, cacheKey, HOME_CACHE_MAX_AGE_MS)?.let { cached ->
+                if (cached.discoverAlbums.isEmpty()) return@let null
                 val hydrated = hydrateHomePlaylists(auth, cached, forceRefreshArtwork = false)
                 if (hydrated != cached) {
                     putCache(homeCache, cacheKey, hydrated)
@@ -862,6 +863,7 @@ class NavidromeRepository @Inject constructor(
                 return@withAuth AppResult.Success(hydrated)
             }
             getFreshPersistedHomeSnapshot(sessionKey)?.let { cached ->
+                if (cached.discoverAlbums.isEmpty()) return@let null
                 val hydrated = hydrateHomePlaylists(auth, cached, forceRefreshArtwork = false)
                 putCache(homeCache, cacheKey, hydrated)
                 if (hydrated != cached) {
@@ -885,17 +887,34 @@ class NavidromeRepository @Inject constructor(
         }
         coroutineScope {
             val recentAlbums = async { navidromeApi.getAlbumList(auth, type = "newest", size = 18) }
+            val discoverAlbums = async { navidromeApi.getAlbumList(auth, type = "alphabeticalByName", size = 200) }
             val artists = async { navidromeApi.getArtists(auth) }
             val playlists = async { navidromeApi.getPlaylists(auth) }
 
             val albumResult = recentAlbums.await()
+            val discoverAlbumResult = discoverAlbums.await()
             val artistResult = artists.await()
             val playlistResult = playlists.await()
 
-            if (albumResult.isFailure || artistResult.isFailure || playlistResult.isFailure) {
-                staleCache?.let { return@coroutineScope AppResult.Success(it) }
+            if (
+                albumResult.isFailure ||
+                discoverAlbumResult.isFailure ||
+                artistResult.isFailure ||
+                playlistResult.isFailure
+            ) {
+                staleCache?.let {
+                    val fallbackDiscoverAlbums = if (it.discoverAlbums.isNotEmpty()) {
+                        it.discoverAlbums
+                    } else {
+                        it.recentAlbums.shuffled().take(12)
+                    }
+                    return@coroutineScope AppResult.Success(
+                        it.copy(discoverAlbums = fallbackDiscoverAlbums)
+                    )
+                }
                 throw (
                     albumResult.exceptionOrNull()
+                        ?: discoverAlbumResult.exceptionOrNull()
                         ?: artistResult.exceptionOrNull()
                         ?: playlistResult.exceptionOrNull()
                         ?: IllegalStateException("Unable to load Navidrome home.")
@@ -903,6 +922,7 @@ class NavidromeRepository @Inject constructor(
             }
 
             val albums = albumResult.getOrThrow()
+            val discoverAlbumItems = discoverAlbumResult.getOrThrow()
             val artistItems = artistResult.getOrThrow()
             val playlistItems = playlistResult.getOrThrow()
             val hydratedPlaylists = hydratePlaylistArtwork(
@@ -913,6 +933,7 @@ class NavidromeRepository @Inject constructor(
 
             val home = NavidromeHome(
                 recentAlbums = albums.map { it.toModel(auth) },
+                discoverAlbums = discoverAlbumItems.map { it.toModel(auth) }.shuffled().take(12),
                 artists = artistItems.map { it.toModel(auth) },
                 playlists = hydratedPlaylists,
                 radios = emptyList()
@@ -2339,6 +2360,22 @@ class NavidromeRepository @Inject constructor(
                     )
                 }
             })
+            .put("discoverAlbums", JSONArray().apply {
+                home.discoverAlbums.forEach { album ->
+                    put(
+                        JSONObject()
+                            .put("id", album.id)
+                            .put("name", album.name)
+                            .put("artistName", album.artistName)
+                            .put("artistId", album.artistId)
+                            .put("year", album.year)
+                            .put("songCount", album.songCount)
+                            .put("durationSeconds", album.durationSeconds)
+                            .put("coverUrl", album.coverUrl)
+                            .put("genre", album.genre)
+                    )
+                }
+            })
             .put("artists", JSONArray().apply {
                 home.artists.forEach { artist ->
                     put(
@@ -2381,28 +2418,51 @@ class NavidromeRepository @Inject constructor(
 
     private fun parseHome(cached: CachedNavidromeHomePayload): NavidromeHome? {
         val root = runCatching { org.json.JSONObject(cached.payload) }.getOrNull() ?: return null
-        return NavidromeHome(
-            recentAlbums = buildList {
-                val source = root.optJSONArray("recentAlbums") ?: JSONArray()
-                for (index in 0 until source.length()) {
-                    val item = source.optJSONObject(index) ?: continue
-                    add(
-                        NavidromeAlbum(
-                            id = item.optString("id"),
-                            name = item.optString("name"),
-                            artistName = item.optString("artistName"),
-                            artistId = item.optString("artistId").ifBlank { null },
-                            year = item.optInt("year").takeIf { item.has("year") && !item.isNull("year") },
-                            songCount = item.optInt("songCount"),
-                            durationSeconds = item.optInt("durationSeconds").takeIf {
-                                item.has("durationSeconds") && !item.isNull("durationSeconds")
-                            },
-                            coverUrl = item.optString("coverUrl").ifBlank { null },
-                            genre = item.optString("genre").ifBlank { null }
-                        )
+        val recentAlbums = buildList {
+            val source = root.optJSONArray("recentAlbums") ?: JSONArray()
+            for (index in 0 until source.length()) {
+                val item = source.optJSONObject(index) ?: continue
+                add(
+                    NavidromeAlbum(
+                        id = item.optString("id"),
+                        name = item.optString("name"),
+                        artistName = item.optString("artistName"),
+                        artistId = item.optString("artistId").ifBlank { null },
+                        year = item.optInt("year").takeIf { item.has("year") && !item.isNull("year") },
+                        songCount = item.optInt("songCount"),
+                        durationSeconds = item.optInt("durationSeconds").takeIf {
+                            item.has("durationSeconds") && !item.isNull("durationSeconds")
+                        },
+                        coverUrl = item.optString("coverUrl").ifBlank { null },
+                        genre = item.optString("genre").ifBlank { null }
                     )
-                }
-            },
+                )
+            }
+        }
+        val discoverAlbums = buildList {
+            val source = root.optJSONArray("discoverAlbums") ?: JSONArray()
+            for (index in 0 until source.length()) {
+                val item = source.optJSONObject(index) ?: continue
+                add(
+                    NavidromeAlbum(
+                        id = item.optString("id"),
+                        name = item.optString("name"),
+                        artistName = item.optString("artistName"),
+                        artistId = item.optString("artistId").ifBlank { null },
+                        year = item.optInt("year").takeIf { item.has("year") && !item.isNull("year") },
+                        songCount = item.optInt("songCount"),
+                        durationSeconds = item.optInt("durationSeconds").takeIf {
+                            item.has("durationSeconds") && !item.isNull("durationSeconds")
+                        },
+                        coverUrl = item.optString("coverUrl").ifBlank { null },
+                        genre = item.optString("genre").ifBlank { null }
+                    )
+                )
+            }
+        }
+        return NavidromeHome(
+            recentAlbums = recentAlbums,
+            discoverAlbums = discoverAlbums,
             artists = buildList {
                 val source = root.optJSONArray("artists") ?: JSONArray()
                 for (index in 0 until source.length()) {

--- a/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
@@ -1264,14 +1264,10 @@ private fun NavidromeHomeScreen(
     )
     var isLibraryMenuExpanded by remember { mutableStateOf(false) }
     var isMenuExpanded by remember { mutableStateOf(false) }
-    var randomAlbumsVersion by rememberSaveable { mutableIntStateOf(0) }
     var renameTarget by remember { mutableStateOf<NavidromePlaylist?>(null) }
     var deleteTarget by remember { mutableStateOf<NavidromePlaylist?>(null) }
     var trackDetailsTarget by remember { mutableStateOf<NavidromeTrack?>(null) }
     var playlistNameInput by rememberSaveable { mutableStateOf("") }
-    val randomAlbums = remember(randomAlbumsVersion, uiState.recentAlbums) {
-        uiState.recentAlbums.shuffled().take(min(12, uiState.recentAlbums.size))
-    }
     val listItemById = remember(
         onOpenAlbums,
         onOpenArtists,
@@ -1803,7 +1799,7 @@ private fun NavidromeHomeScreen(
                                 contentPadding = homeCarouselContentPadding,
                                 horizontalArrangement = Arrangement.spacedBy(12.dp)
                             ) {
-                                items(randomAlbums, key = { it.id }) { album ->
+                                items(uiState.discoverAlbums, key = { it.id }) { album ->
                                     NavidromeHomeAlbumCard(
                                         album = album,
                                         posterWidth = homeShelfPosterWidth,
@@ -3543,6 +3539,7 @@ private fun NavidromePlaylistDetailRoute(
                                         playerViewModel.addTracksToQueue(listOf(track))
                                     },
                                     playLabel = if (playerState.currentTrack?.id == track.id) "Play Again" else "Play",
+                                    isRadio = track.id.startsWith("radio:"),
                                     onShowAlbum = track.albumId?.let { albumId ->
                                         {
                                             rowMenuExpanded = false
@@ -3818,6 +3815,7 @@ private fun NavidromeFavoriteSongsRoute(
                                     playerViewModel.addTracksToQueue(listOf(track))
                                 },
                                 playLabel = if (playerState.currentTrack?.id == track.id) "Play Again" else "Play",
+                                isRadio = track.id.startsWith("radio:"),
                                 onShowAlbum = onOpenAlbum?.let { openAlbum ->
                                     track.albumId?.let { albumId ->
                                         {
@@ -4131,6 +4129,7 @@ private fun NavidromeSongsRoute(
                                     playerViewModel.addTracksToQueue(listOf(track))
                                 },
                                 playLabel = if (playerState.currentTrack?.id == track.id) "Play Again" else "Play",
+                                isRadio = track.id.startsWith("radio:"),
                                 isDownloaded = downloadUiState.downloadedTrackIds.contains(track.id),
                                 onToggleDownload = {
                                     rowMenuExpanded = false
@@ -4762,6 +4761,7 @@ private fun NavidromeAlbumDetailRoute(
                                     playerViewModel.addTracksToQueue(listOf(track))
                                 },
                                 playLabel = if (playerState.currentTrack?.id == track.id) "Play Again" else "Play",
+                                isRadio = track.id.startsWith("radio:"),
                                 isDownloaded = downloadUiState.downloadedTrackIds.contains(track.id),
                                 onToggleDownload = {
                                     rowMenuExpanded = false
@@ -7241,6 +7241,7 @@ private fun NavidromeContinueListeningCard(
                         menuExpanded = false
                     },
                     playLabel = if (isCurrent && isPlaying) "Pause" else if (isCurrent) "Resume" else "Play Now",
+                    isRadio = track.id.startsWith("radio:"),
                     isDownloaded = isDownloaded,
                     onToggleDownload = {
                         onToggleDownload()
@@ -7743,6 +7744,7 @@ private fun NavidromeTrackActionsMenu(
     onPlayNext: () -> Unit,
     onAddToQueue: () -> Unit,
     playLabel: String,
+    isRadio: Boolean = false,
     isDownloaded: Boolean = false,
     onToggleDownload: (() -> Unit)? = null,
     onShowAlbum: (() -> Unit)?,
@@ -7765,43 +7767,45 @@ private fun NavidromeTrackActionsMenu(
             },
             onClick = onPlayTrack
         )
-        AppDropdownMenuItem(
-            text = { Text("Play Next") },
-            leadingIcon = {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Outlined.PlaylistPlay,
-                    contentDescription = null
-                )
-            },
-            onClick = {
-                onPlayNext()
-                Toast.makeText(context, "Playing next", Toast.LENGTH_SHORT).show()
-            }
-        )
-        AppDropdownMenuItem(
-            text = { Text("Add to Queue") },
-            leadingIcon = {
-                Icon(
-                    imageVector = Icons.Outlined.QueueMusic,
-                    contentDescription = null
-                )
-            },
-            onClick = {
-                onAddToQueue()
-                Toast.makeText(context, "Added to queue", Toast.LENGTH_SHORT).show()
-            }
-        )
-        if (onToggleDownload != null) {
+        if (!isRadio) {
             AppDropdownMenuItem(
-                text = { Text(if (isDownloaded) "Remove Download" else "Download") },
+                text = { Text("Play Next") },
                 leadingIcon = {
                     Icon(
-                        imageVector = Icons.Outlined.Download,
+                        imageVector = Icons.AutoMirrored.Outlined.PlaylistPlay,
                         contentDescription = null
                     )
                 },
-                onClick = onToggleDownload
+                onClick = {
+                    onPlayNext()
+                    Toast.makeText(context, "Playing next", Toast.LENGTH_SHORT).show()
+                }
             )
+            AppDropdownMenuItem(
+                text = { Text("Add to Queue") },
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Outlined.QueueMusic,
+                        contentDescription = null
+                    )
+                },
+                onClick = {
+                    onAddToQueue()
+                    Toast.makeText(context, "Added to queue", Toast.LENGTH_SHORT).show()
+                }
+            )
+            if (onToggleDownload != null) {
+                AppDropdownMenuItem(
+                    text = { Text(if (isDownloaded) "Remove Download" else "Download") },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Outlined.Download,
+                            contentDescription = null
+                        )
+                    },
+                    onClick = onToggleDownload
+                )
+            }
         }
         AppDropdownMenuItem(
             text = { Text("Show Album") },
@@ -10410,6 +10414,7 @@ private fun NavidromeExpandedPlayerSheet(
                         val coverShape = RoundedCornerShape(18.dp)
                         val fallbackIcon = if (isRadio) Icons.Outlined.GraphicEq else Icons.Outlined.Album
                         if (playerCoverModel == null) {
+                            val radioAccentColor = Color(0xFFFF334B)
                             Box(
                                 modifier = Modifier
                                     .matchParentSize()
@@ -10420,8 +10425,8 @@ private fun NavidromeExpandedPlayerSheet(
                                 Icon(
                                     imageVector = fallbackIcon,
                                     contentDescription = null,
-                                    modifier = Modifier.size(92.dp),
-                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                    modifier = Modifier.size(if (isRadio) 150.dp else 92.dp),
+                                    tint = if (isRadio) radioAccentColor else MaterialTheme.colorScheme.onSurfaceVariant
                                 )
                             }
                         } else {
@@ -10627,6 +10632,7 @@ private fun NavidromeExpandedPlayerSheet(
                                                                 itemIsCurrent -> "Resume"
                                                                 else -> "Play Now"
                                                             },
+                                                            isRadio = item.track.id.startsWith("radio:"),
                                                             isDownloaded = item.track.id in downloadedTrackIds,
                                                             onToggleDownload = onToggleDownload?.let { toggle ->
                                                                 {

--- a/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeViewModels.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeViewModels.kt
@@ -274,6 +274,7 @@ class NavidromeLoginViewModel @Inject constructor(
 
 data class NavidromeHomeUiState(
     val recentAlbums: List<NavidromeAlbum> = emptyList(),
+    val discoverAlbums: List<NavidromeAlbum> = emptyList(),
     val artists: List<NavidromeArtist> = emptyList(),
     val playlists: List<NavidromePlaylist> = emptyList(),
     val radios: List<NavidromeRadio> = emptyList(),
@@ -322,6 +323,7 @@ class NavidromeHomeViewModel @Inject constructor(
                     mutableUiState.update {
                         it.copy(
                             recentAlbums = result.value.recentAlbums,
+                            discoverAlbums = result.value.discoverAlbums,
                             artists = result.value.artists,
                             playlists = result.value.playlists,
                             radios = result.value.radios,


### PR DESCRIPTION
## Summary
- Remove song-only actions from Navidrome radio queue menus.
- Make Discover show a shuffled library sample instead of reusing the recently added list.
- Enlarge and recolor the radio fallback art glyph.
- Bump the app version to 0.4.2 (84).

## Validation
- `GRADLE_USER_HOME=/tmp/gradle ./gradlew :app:compileGithubDebugKotlin`

## Notes
- The Discover fallback now synthesizes a sample from cached recent albums when a refresh fails, so the home screen stays populated offline.