### PR TITLE
[codex] navidrome transport spacing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 88
-val appVersionName = "0.4.6"
+val appVersionCode = 89
+val appVersionName = "0.4.7"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
@@ -10141,7 +10141,7 @@ private fun NavidromeExpandedPlayerSheet(
         val targetTransportButtonSize = when {
             queueExpandedLayout || veryCompactLayout -> 80.dp
             narrowTransportLayout -> 84.dp
-            else -> 88.dp
+            else -> 84.dp
         }
         val targetTransportIconSize = when {
             queueExpandedLayout || veryCompactLayout -> 38.dp
@@ -10151,7 +10151,7 @@ private fun NavidromeExpandedPlayerSheet(
         val targetSkipButtonSize = when {
             queueExpandedLayout || veryCompactLayout -> 56.dp
             narrowTransportLayout -> 52.dp
-            else -> 64.dp
+            else -> 56.dp
         }
         val targetSkipIconSize = when {
             queueExpandedLayout || veryCompactLayout -> 32.dp
@@ -10187,7 +10187,7 @@ private fun NavidromeExpandedPlayerSheet(
         val skipIconSize by animateDpAsState(targetValue = targetSkipIconSize, animationSpec = queueTransitionSpec, label = "navidromePlayerSkipIconSize")
         val transportSectionTopGap by animateDpAsState(targetValue = targetTransportSectionTopGap, animationSpec = queueTransitionSpec, label = "navidromePlayerTransportSectionTopGap")
         val toolRowTopGap by animateDpAsState(targetValue = targetToolRowTopGap, animationSpec = queueTransitionSpec, label = "navidromePlayerToolRowTopGap")
-        val transportRowSpacing = if (narrowTransportLayout) 2.dp else 4.dp
+        val transportRowSpacing = 2.dp
         val progressSection: @Composable () -> Unit = {
             val elapsedSeconds = (sliderPosition.roundToInt().coerceAtLeast(0) / 1000)
             val totalDurationSeconds = (resolvedDurationMs.coerceAtLeast(0) / 1000)


### PR DESCRIPTION
## What changed
- Tightened the Navidrome transport row on wider screens so the outer skip buttons and the previous/next buttons sit in a more balanced group.
- Kept the smaller-screen layout unchanged.
- Bumped the app version to `0.4.7` so the test build is distinct from the last release.

## Why
- The OnePlus 12 showed uneven spacing between the new skip buttons and the existing transport buttons, while the Pixel layout already looked correct.

## Validation
- `rtk git diff --check`
