### PR TITLE
StillShelf v0.4.9

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 90
-val appVersionName = "0.4.8"
+val appVersionCode = 91
+val appVersionName = "0.4.9"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/data/repo/NavidromeRepository.kt
+++ b/app/src/main/java/com/stillshelf/app/data/repo/NavidromeRepository.kt
@@ -697,6 +697,7 @@ class NavidromeRepository @Inject constructor(
             is AppResult.Error -> return@withAuth result
         }
 
+        invalidateArtistAndAlbumDetailCaches()
         AppResult.Success(libraries)
     }
 
@@ -2205,6 +2206,13 @@ class NavidromeRepository @Inject constructor(
             lyricsCache.clear()
         }
         sessionPreferences.clearCachedNavidromeLyrics()
+    }
+
+    internal suspend fun invalidateArtistAndAlbumDetailCaches() {
+        cacheMutex.withLock {
+            artistDetailCache.clear()
+            albumDetailCache.clear()
+        }
     }
 
     private suspend fun cacheResolvedLyrics(cacheKey: String, lyrics: NavidromeLyrics) {

--- a/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
@@ -4511,6 +4511,7 @@ private fun SearchRecentRow(
 }
 
 @Composable
+@OptIn(androidx.compose.material.ExperimentalMaterialApi::class)
 private fun NavidromeArtistDetailRoute(
     onBack: () -> Unit,
     onHome: (() -> Unit)?,
@@ -4527,6 +4528,14 @@ private fun NavidromeArtistDetailRoute(
     val bottomOverlayPadding = LocalNavidromeBottomOverlayPadding.current
     val context = LocalContext.current
     var menuExpanded by rememberSaveable { mutableStateOf(false) }
+    var manualRefreshInProgress by rememberSaveable { mutableStateOf(false) }
+    val refreshState = rememberPullRefreshState(
+        refreshing = uiState.isLoading && manualRefreshInProgress,
+        onRefresh = {
+            manualRefreshInProgress = true
+            viewModel.refresh()
+        }
+    )
     LaunchedEffect(downloadUiState.actionMessage) {
         val message = downloadUiState.actionMessage ?: return@LaunchedEffect
         Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
@@ -4536,6 +4545,15 @@ private fun NavidromeArtistDetailRoute(
         val message = downloadUiState.errorMessage ?: return@LaunchedEffect
         Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         downloadsViewModel.clearMessages()
+    }
+    LaunchedEffect(uiState.errorMessage) {
+        val message = uiState.errorMessage ?: return@LaunchedEffect
+        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+    }
+    LaunchedEffect(uiState.isLoading) {
+        if (!uiState.isLoading) {
+            manualRefreshInProgress = false
+        }
     }
     Column(modifier = Modifier.fillMaxSize()) {
         DetailHeader(
@@ -4609,79 +4627,97 @@ private fun NavidromeArtistDetailRoute(
                 }
             }
         )
-        if (uiState.isLoading) {
-            LoadingCard()
-        } else if (uiState.detail != null) {
-            val detail = uiState.detail!!
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(
-                    start = 20.dp,
-                    end = 20.dp,
-                    top = 12.dp,
-                    bottom = bottomOverlayPadding + 25.dp
-                ),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                item {
-                    CenteredDetailHero(
-                        title = detail.artist.name,
-                        subtitle = "${detail.artist.albumCount} albums",
-                        imageUrl = detail.artist.imageUrl ?: detail.artist.coverUrl,
-                        circular = true,
-                        showDownloadedIndicator = downloadUiState.fullyDownloadedAlbumCountByArtistId[detail.artist.id]
-                            ?.let { it >= detail.artist.albumCount && detail.artist.albumCount > 0 }
-                            ?: false,
-                        downloadProgressPercent = downloadUiState.artistProgressById[detail.artist.id]
-                    )
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .pullRefresh(refreshState)
+        ) {
+            when {
+                uiState.isLoading && uiState.detail == null -> {
+                    LoadingCard()
                 }
-                item { SectionTitle("Albums") }
-                if (displayStyle == NavidromeAlbumsDisplayStyle.GRID) {
-                    item {
-                        Column(
-                            verticalArrangement = Arrangement.spacedBy(20.dp)
-                        ) {
-                            detail.albums.chunked(2).forEach { albumRow ->
-                                Row(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+
+                uiState.detail != null -> {
+                    val detail = uiState.detail!!
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(
+                            start = 20.dp,
+                            end = 20.dp,
+                            top = 12.dp,
+                            bottom = bottomOverlayPadding + 25.dp
+                        ),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        item {
+                            CenteredDetailHero(
+                                title = detail.artist.name,
+                                subtitle = "${detail.artist.albumCount} albums",
+                                imageUrl = detail.artist.imageUrl ?: detail.artist.coverUrl,
+                                circular = true,
+                                showDownloadedIndicator = downloadUiState.fullyDownloadedAlbumCountByArtistId[detail.artist.id]
+                                    ?.let { it >= detail.artist.albumCount && detail.artist.albumCount > 0 }
+                                    ?: false,
+                                downloadProgressPercent = downloadUiState.artistProgressById[detail.artist.id]
+                            )
+                        }
+                        item { SectionTitle("Albums") }
+                        if (displayStyle == NavidromeAlbumsDisplayStyle.GRID) {
+                            item {
+                                Column(
+                                    verticalArrangement = Arrangement.spacedBy(20.dp)
                                 ) {
-                                    albumRow.forEach { album ->
-                                        Box(modifier = Modifier.weight(1f)) {
-                                            AlbumGridCard(
-                                                album = album,
-                                                isCurrent = playerState.currentTrack?.albumId == album.id,
-                                                isDownloaded = downloadUiState.downloadedTrackCountByAlbumId[album.id]
-                                                    ?.let { it >= album.songCount && album.songCount > 0 }
-                                                    ?: false,
-                                                downloadProgressPercent = downloadUiState.albumProgressById[album.id],
-                                                onClick = { onOpenAlbum(album.id) }
-                                            )
+                                    detail.albums.chunked(2).forEach { albumRow ->
+                                        Row(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            horizontalArrangement = Arrangement.spacedBy(16.dp)
+                                        ) {
+                                            albumRow.forEach { album ->
+                                                Box(modifier = Modifier.weight(1f)) {
+                                                    AlbumGridCard(
+                                                        album = album,
+                                                        isCurrent = playerState.currentTrack?.albumId == album.id,
+                                                        isDownloaded = downloadUiState.downloadedTrackCountByAlbumId[album.id]
+                                                            ?.let { it >= album.songCount && album.songCount > 0 }
+                                                            ?: false,
+                                                        downloadProgressPercent = downloadUiState.albumProgressById[album.id],
+                                                        onClick = { onOpenAlbum(album.id) }
+                                                    )
+                                                }
+                                            }
+                                            if (albumRow.size == 1) {
+                                                Spacer(modifier = Modifier.weight(1f))
+                                            }
                                         }
-                                    }
-                                    if (albumRow.size == 1) {
-                                        Spacer(modifier = Modifier.weight(1f))
                                     }
                                 }
                             }
+                        } else {
+                            items(detail.albums) { album ->
+                                AlbumRow(
+                                    album = album,
+                                    isCurrent = playerState.currentTrack?.albumId == album.id,
+                                    isDownloaded = downloadUiState.downloadedTrackCountByAlbumId[album.id]
+                                        ?.let { it >= album.songCount && album.songCount > 0 }
+                                        ?: false,
+                                    downloadProgressPercent = downloadUiState.albumProgressById[album.id],
+                                    onClick = { onOpenAlbum(album.id) }
+                                )
+                            }
                         }
                     }
-                } else {
-                    items(detail.albums) { album ->
-                        AlbumRow(
-                            album = album,
-                            isCurrent = playerState.currentTrack?.albumId == album.id,
-                            isDownloaded = downloadUiState.downloadedTrackCountByAlbumId[album.id]
-                                ?.let { it >= album.songCount && album.songCount > 0 }
-                                ?: false,
-                            downloadProgressPercent = downloadUiState.albumProgressById[album.id],
-                            onClick = { onOpenAlbum(album.id) }
-                        )
-                    }
+                }
+
+                else -> {
+                    ErrorCard(uiState.errorMessage ?: "Unable to load artist.")
                 }
             }
-        } else {
-            ErrorCard(uiState.errorMessage ?: "Unable to load artist.")
+
+            PullRefreshIndicator(
+                refreshing = uiState.isLoading && manualRefreshInProgress,
+                state = refreshState,
+                modifier = Modifier.align(Alignment.TopCenter)
+            )
         }
     }
 }

--- a/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeViewModels.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeViewModels.kt
@@ -60,6 +60,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.roundToInt
+import java.util.concurrent.atomic.AtomicLong
 
 data class NavidromeLoginUiState(
     val serverName: String = "",
@@ -2792,32 +2793,58 @@ data class NavidromeArtistDetailUiState(
 @HiltViewModel
 class NavidromeArtistDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val navidromeRepository: NavidromeRepository
+    private val navidromeRepository: NavidromeRepository,
+    private val sessionPreferences: SessionPreferences
 ) : ViewModel() {
     private val artistId: String =
         savedStateHandle.get<String>(NavidromeRoute.ARTIST_ID_ARG).orEmpty()
     private val mutableUiState = MutableStateFlow(NavidromeArtistDetailUiState())
     val uiState: StateFlow<NavidromeArtistDetailUiState> = mutableUiState.asStateFlow()
+    private var hasObservedLibrarySyncAtMs = false
+    private var lastObservedLibrarySyncAtMs: Long? = null
+    private val refreshGeneration = AtomicLong(0L)
 
     init {
+        observeLibrarySyncs()
         refresh(forceRefresh = false)
     }
 
     fun refresh(forceRefresh: Boolean = true) {
+        val requestGeneration = refreshGeneration.incrementAndGet()
         viewModelScope.launch {
+            mutableUiState.update { it.copy(isLoading = true, errorMessage = null) }
             when (val result = navidromeRepository.fetchArtistDetail(artistId, forceRefresh = forceRefresh)) {
                 is AppResult.Success -> {
+                    if (refreshGeneration.get() != requestGeneration) return@launch
                     mutableUiState.update {
                         it.copy(detail = result.value, isLoading = false, errorMessage = null)
                     }
                 }
 
                 is AppResult.Error -> {
+                    if (refreshGeneration.get() != requestGeneration) return@launch
                     mutableUiState.update {
                         it.copy(isLoading = false, errorMessage = result.message)
                     }
                 }
             }
+        }
+    }
+
+    private fun observeLibrarySyncs() {
+        viewModelScope.launch {
+            sessionPreferences.state
+                .map { state -> state.lastLibrarySyncAtMs }
+                .distinctUntilChanged()
+                .collect { syncedAtMs ->
+                    val shouldRefresh = hasObservedLibrarySyncAtMs &&
+                        lastObservedLibrarySyncAtMs != syncedAtMs
+                    hasObservedLibrarySyncAtMs = true
+                    lastObservedLibrarySyncAtMs = syncedAtMs
+                    if (shouldRefresh) {
+                        refresh(forceRefresh = true)
+                    }
+                }
         }
     }
 }

--- a/app/src/test/java/com/stillshelf/app/data/repo/NavidromeRepositoryCacheInvalidationTest.kt
+++ b/app/src/test/java/com/stillshelf/app/data/repo/NavidromeRepositoryCacheInvalidationTest.kt
@@ -1,0 +1,75 @@
+package com.stillshelf.app.data.repo
+
+import com.stillshelf.app.core.datastore.SessionPreferenceState
+import com.stillshelf.app.core.datastore.SessionPreferences
+import com.stillshelf.app.core.network.NetworkConnectionState
+import com.stillshelf.app.core.network.NetworkConnectionType
+import com.stillshelf.app.core.network.NetworkMonitor
+import com.stillshelf.app.data.api.NavidromeApi
+import com.stillshelf.app.core.datastore.SecureTokenStorage
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.lang.reflect.Field
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class NavidromeRepositoryCacheInvalidationTest {
+    @Test
+    fun invalidateArtistAndAlbumDetailCaches_clearsBothDetailCaches() = runTest {
+        val repository = buildRepository()
+
+        cacheMap(repository, "artistDetailCache")["artist-1"] = Any()
+        cacheMap(repository, "albumDetailCache")["album-1"] = Any()
+
+        repository.invalidateArtistAndAlbumDetailCaches()
+
+        assertTrue(cacheMap(repository, "artistDetailCache").isEmpty())
+        assertTrue(cacheMap(repository, "albumDetailCache").isEmpty())
+    }
+
+    private fun buildRepository(): NavidromeRepository {
+        val api = mockk<NavidromeApi>(relaxed = true)
+        val sessionPreferences = mockk<SessionPreferences>(relaxed = true) {
+            every { state } returns flowOf(
+                SessionPreferenceState(
+                    activeServerId = null,
+                    activeLibraryId = null
+                )
+            )
+            coEvery { isNavidromeLegacySessionMigrated() } returns true
+        }
+        val secureTokenStorage = mockk<SecureTokenStorage>(relaxed = true)
+        val networkMonitor = mockk<NetworkMonitor>(relaxed = true) {
+            every { observeConnectionState() } returns flowOf(
+                NetworkConnectionState(
+                    type = NetworkConnectionType.Offline,
+                    identity = "offline"
+                )
+            )
+        }
+
+        return NavidromeRepository(
+            navidromeApi = api,
+            sessionPreferences = sessionPreferences,
+            secureTokenStorage = secureTokenStorage,
+            networkMonitor = networkMonitor,
+            okHttpClient = OkHttpClient()
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun cacheMap(repository: NavidromeRepository, fieldName: String): MutableMap<String, Any?> {
+        val field: Field = NavidromeRepository::class.java.getDeclaredField(fieldName)
+        field.isAccessible = true
+        return field.get(repository) as MutableMap<String, Any?>
+    }
+}

--- a/app/src/test/java/com/stillshelf/app/ui/screens/navidrome/NavidromeArtistDetailViewModelTest.kt
+++ b/app/src/test/java/com/stillshelf/app/ui/screens/navidrome/NavidromeArtistDetailViewModelTest.kt
@@ -1,0 +1,172 @@
+package com.stillshelf.app.ui.screens.navidrome
+
+import androidx.lifecycle.SavedStateHandle
+import com.stillshelf.app.core.datastore.SessionPreferenceState
+import com.stillshelf.app.core.datastore.SessionPreferences
+import com.stillshelf.app.core.model.NavidromeAlbum
+import com.stillshelf.app.core.model.NavidromeArtist
+import com.stillshelf.app.core.model.NavidromeArtistDetail
+import com.stillshelf.app.core.util.AppResult
+import com.stillshelf.app.data.repo.NavidromeRepository
+import com.stillshelf.app.ui.navigation.NavidromeRoute
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class NavidromeArtistDetailViewModelTest {
+    private val dispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun syncTimestampChange_triggersForcedArtistRefresh() = runTest(dispatcher) {
+        val syncState = MutableStateFlow(
+            SessionPreferenceState(
+                activeServerId = null,
+                activeLibraryId = null,
+                lastLibrarySyncAtMs = null
+            )
+        )
+        val repository = mockk<NavidromeRepository>()
+        val sessionPreferences = mockk<SessionPreferences>() {
+            every { state } returns syncState
+        }
+
+        val initialDetail = artistDetail(
+            artistName = "Initial Artist",
+            albumName = "Old Album"
+        )
+        val refreshedDetail = artistDetail(
+            artistName = "Initial Artist",
+            albumName = "New Album"
+        )
+
+        coEvery { repository.fetchArtistDetail("artist-1", false) } returns AppResult.Success(initialDetail)
+        coEvery { repository.fetchArtistDetail("artist-1", true) } returns AppResult.Success(refreshedDetail)
+
+        val viewModel = NavidromeArtistDetailViewModel(
+            savedStateHandle = SavedStateHandle(mapOf(NavidromeRoute.ARTIST_ID_ARG to "artist-1")),
+            navidromeRepository = repository,
+            sessionPreferences = sessionPreferences
+        )
+
+        advanceUntilIdle()
+        assertEquals("Old Album", viewModel.uiState.value.detail?.albums?.firstOrNull()?.name)
+
+        syncState.value = syncState.value.copy(lastLibrarySyncAtMs = 123L)
+        advanceUntilIdle()
+
+        assertEquals("New Album", viewModel.uiState.value.detail?.albums?.firstOrNull()?.name)
+        coVerify(exactly = 1) { repository.fetchArtistDetail("artist-1", false) }
+        coVerify(exactly = 1) { repository.fetchArtistDetail("artist-1", true) }
+    }
+
+    @Test
+    fun newerSyncRefresh_winsOverSlowerInitialLoad() = runTest(dispatcher) {
+        val syncState = MutableStateFlow(
+            SessionPreferenceState(
+                activeServerId = null,
+                activeLibraryId = null,
+                lastLibrarySyncAtMs = null
+            )
+        )
+        val repository = mockk<NavidromeRepository>()
+        val sessionPreferences = mockk<SessionPreferences>() {
+            every { state } returns syncState
+        }
+        val initialFetchStarted = CompletableDeferred<Unit>()
+        val releaseInitialFetch = CompletableDeferred<Unit>()
+
+        val initialDetail = artistDetail(
+            artistName = "Initial Artist",
+            albumName = "Old Album"
+        )
+        val refreshedDetail = artistDetail(
+            artistName = "Initial Artist",
+            albumName = "New Album"
+        )
+
+        coEvery { repository.fetchArtistDetail("artist-1", false) } coAnswers {
+            initialFetchStarted.complete(Unit)
+            releaseInitialFetch.await()
+            AppResult.Success(initialDetail)
+        }
+        coEvery { repository.fetchArtistDetail("artist-1", true) } returns AppResult.Success(refreshedDetail)
+
+        val viewModel = NavidromeArtistDetailViewModel(
+            savedStateHandle = SavedStateHandle(mapOf(NavidromeRoute.ARTIST_ID_ARG to "artist-1")),
+            navidromeRepository = repository,
+            sessionPreferences = sessionPreferences
+        )
+
+        testScheduler.runCurrent()
+        initialFetchStarted.await()
+        syncState.value = syncState.value.copy(lastLibrarySyncAtMs = 123L)
+        advanceUntilIdle()
+        assertEquals("New Album", viewModel.uiState.value.detail?.albums?.firstOrNull()?.name)
+
+        releaseInitialFetch.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals("New Album", viewModel.uiState.value.detail?.albums?.firstOrNull()?.name)
+        coVerify(exactly = 1) { repository.fetchArtistDetail("artist-1", false) }
+        coVerify(exactly = 1) { repository.fetchArtistDetail("artist-1", true) }
+    }
+
+    private fun artistDetail(
+        artistName: String,
+        albumName: String
+    ): NavidromeArtistDetail {
+        return NavidromeArtistDetail(
+            artist = NavidromeArtist(
+                id = "artist-1",
+                name = artistName,
+                albumCount = 1,
+                coverUrl = null,
+                imageUrl = null
+            ),
+            albums = listOf(
+                NavidromeAlbum(
+                    id = "album-1",
+                    name = albumName,
+                    artistName = artistName,
+                    artistId = "artist-1",
+                    year = null,
+                    songCount = 1,
+                    durationSeconds = null,
+                    coverUrl = null,
+                    genre = null
+                )
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add pull-to-refresh to Navidrome artist details.
- Auto-refresh open artist detail pages after a library sync completes.
- Prevent stale in-flight artist refreshes from overwriting newer results.
- Clear cached artist and album detail entries after a resync.

## Verification
- `./gradlew :app:testGithubDebugUnitTest`

## Notes
- This release addresses stale artist album lists after resyncing on some devices.