### PR TITLE
[codex] diagnostic logs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 91
-val appVersionName = "0.4.9"
+val appVersionCode = 92
+val appVersionName = "0.5.0"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/StillShelfApplication.kt
+++ b/app/src/main/java/com/stillshelf/app/StillShelfApplication.kt
@@ -5,10 +5,34 @@ import coil.ImageLoader
 import coil.ImageLoaderFactory
 import coil.disk.DiskCache
 import coil.memory.MemoryCache
+import com.stillshelf.app.core.diagnostics.DiagnosticLoggingEntryPoint
+import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.HiltAndroidApp
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 
 @HiltAndroidApp
 class StillShelfApplication : Application(), ImageLoaderFactory {
+    override fun onCreate() {
+        super.onCreate()
+        val diagnosticLogManager = EntryPointAccessors.fromApplication(
+            this,
+            DiagnosticLoggingEntryPoint::class.java
+        ).diagnosticLogManager()
+        diagnosticLogManager.initialize()
+        diagnosticLogManager.logLifecycle("AppLifecycle", "process_created")
+        ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onStart(owner: LifecycleOwner) {
+                diagnosticLogManager.logLifecycle("AppLifecycle", "foreground")
+            }
+
+            override fun onStop(owner: LifecycleOwner) {
+                diagnosticLogManager.logLifecycle("AppLifecycle", "background")
+            }
+        })
+    }
+
     override fun newImageLoader(): ImageLoader {
         return ImageLoader.Builder(this)
             .memoryCache {

--- a/app/src/main/java/com/stillshelf/app/core/datastore/SecureTokenStorage.kt
+++ b/app/src/main/java/com/stillshelf/app/core/datastore/SecureTokenStorage.kt
@@ -2,9 +2,9 @@ package com.stillshelf.app.core.datastore
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
+import com.stillshelf.app.core.diagnostics.DiagnosticLogManager
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.security.KeyStore
 import javax.inject.Inject
@@ -18,7 +18,8 @@ class SecureStorageUnavailableException : IllegalStateException(
 
 @Singleton
 class SecureTokenStorage @Inject constructor(
-    @param:ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context,
+    private val diagnosticLogManager: DiagnosticLogManager
 ) {
     @Volatile
     private var encryptedSharedPreferences: SharedPreferences? = null
@@ -40,25 +41,41 @@ class SecureTokenStorage @Inject constructor(
         val masterKeyAlias = runCatching {
             MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
         }.getOrElse { throwable ->
-            Log.e(TAG, "Unable to obtain master key alias for encrypted token prefs.", throwable)
+            diagnosticLogManager.logError(
+                tag = TAG,
+                message = "Unable to obtain master key alias for encrypted token prefs.",
+                throwable = throwable
+            )
             return null
         }
 
         return try {
             createEncryptedPreferences(masterKeyAlias)
         } catch (firstError: Throwable) {
-            Log.w(TAG, "Encrypted token prefs failed. Clearing token prefs and retrying once.", firstError)
+            diagnosticLogManager.logWarning(
+                tag = TAG,
+                message = "Encrypted token prefs failed. Clearing token prefs and retrying once.",
+                throwable = firstError
+            )
             runCatching { clearEncryptedPreferencesFile() }
             try {
                 createEncryptedPreferences(masterKeyAlias)
             } catch (secondError: Throwable) {
-                Log.w(TAG, "Encrypted token prefs still failing. Resetting master key and retrying.", secondError)
+                diagnosticLogManager.logWarning(
+                    tag = TAG,
+                    message = "Encrypted token prefs still failing. Resetting master key and retrying.",
+                    throwable = secondError
+                )
                 runCatching { deleteMasterKey(masterKeyAlias) }
                 runCatching { clearEncryptedPreferencesFile() }
                 try {
                     createEncryptedPreferences(masterKeyAlias)
                 } catch (finalError: Throwable) {
-                    Log.e(TAG, "Unable to initialize encrypted token prefs.", finalError)
+                    diagnosticLogManager.logError(
+                        tag = TAG,
+                        message = "Unable to initialize encrypted token prefs.",
+                        throwable = finalError
+                    )
                     null
                 }
             }

--- a/app/src/main/java/com/stillshelf/app/core/datastore/SessionPreferences.kt
+++ b/app/src/main/java/com/stillshelf/app/core/datastore/SessionPreferences.kt
@@ -116,6 +116,7 @@ class SessionPreferences @Inject constructor(
     private val lastLibrarySyncAtMsKey = longPreferencesKey("last_library_sync_at_ms")
     private val updateCheckOnStartupKey = booleanPreferencesKey("update_check_on_startup")
     private val updateIncludePrereleasesKey = booleanPreferencesKey("update_include_prereleases")
+    private val diagnosticLoggingEnabledKey = booleanPreferencesKey("diagnostic_logging_enabled")
     private val pendingUpdateApkPathKey = stringPreferencesKey("pending_update_apk_path")
     private val pendingUpdateVersionNameKey = stringPreferencesKey("pending_update_version_name")
     private val acknowledgedUpgradeNoticeVersionKey = stringPreferencesKey("acknowledged_upgrade_notice_version")
@@ -924,6 +925,12 @@ class SessionPreferences @Inject constructor(
     suspend fun setUpdateIncludePrereleases(enabled: Boolean) {
         dataStore.edit { prefs ->
             prefs[updateIncludePrereleasesKey] = enabled
+        }
+    }
+
+    suspend fun setDiagnosticLoggingEnabled(enabled: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[diagnosticLoggingEnabledKey] = enabled
         }
     }
 
@@ -1935,6 +1942,7 @@ class SessionPreferences @Inject constructor(
             lastLibrarySyncAtMs = this[lastLibrarySyncAtMsKey],
             updateCheckOnStartup = this[updateCheckOnStartupKey] ?: true,
             updateIncludePrereleases = this[updateIncludePrereleasesKey] ?: false,
+            diagnosticLoggingEnabled = this[diagnosticLoggingEnabledKey] ?: false,
             pendingUpdateApkPath = this[pendingUpdateApkPathKey],
             pendingUpdateVersionName = this[pendingUpdateVersionNameKey],
             recentSearchTerms = parseStringArray(this[recentSearchTermsKey]),
@@ -2006,6 +2014,7 @@ data class SessionPreferenceState(
     val lastLibrarySyncAtMs: Long? = null,
     val updateCheckOnStartup: Boolean = true,
     val updateIncludePrereleases: Boolean = false,
+    val diagnosticLoggingEnabled: Boolean = false,
     val pendingUpdateApkPath: String? = null,
     val pendingUpdateVersionName: String? = null,
     val recentSearchTerms: List<String> = emptyList(),

--- a/app/src/main/java/com/stillshelf/app/core/diagnostics/DiagnosticLogManager.kt
+++ b/app/src/main/java/com/stillshelf/app/core/diagnostics/DiagnosticLogManager.kt
@@ -1,0 +1,482 @@
+package com.stillshelf.app.core.diagnostics
+
+import android.content.Context
+import android.os.Build
+import com.stillshelf.app.BuildConfig
+import com.stillshelf.app.core.datastore.SessionPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStreamWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+data class DiagnosticLogState(
+    val enabled: Boolean = false,
+    val hasLogs: Boolean = false,
+    val sessionId: String? = null,
+    val latestLogName: String? = null,
+    val activeBackend: String? = null
+)
+
+@Singleton
+class DiagnosticLogManager @Inject constructor(
+    @ApplicationContext private val appContext: Context,
+    private val sessionPreferences: SessionPreferences
+) {
+    companion object {
+        private const val LOG_DIRECTORY_NAME = "diagnostic_logs"
+        private const val LOG_FILE_PREFIX = "stillshelf-diagnostic"
+        private const val MAX_LOG_FILE_BYTES = 1_000_000L
+        private const val MAX_LOG_FILE_COUNT = 4
+        private const val UTC_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val mutex = Mutex()
+    private val stateFlow = MutableStateFlow(DiagnosticLogState())
+    val state: StateFlow<DiagnosticLogState> = stateFlow.asStateFlow()
+    private val previousExceptionHandler = AtomicReference<Thread.UncaughtExceptionHandler?>(null)
+    @Volatile private var initialized = false
+    @Volatile private var enabled = false
+    @Volatile private var sessionId: String? = null
+    @Volatile private var currentLogFile: File? = null
+    @Volatile private var activeBackend: String? = null
+    @Volatile private var logDirectoryReady = false
+
+    init {
+        scope.launch {
+            sessionPreferences.state
+                .map { it.diagnosticLoggingEnabled }
+                .distinctUntilChanged()
+                .collect { isEnabled ->
+                    if (isEnabled) {
+                        enableLogging()
+                    } else {
+                        disableLogging()
+                    }
+                }
+        }
+        scope.launch {
+            sessionPreferences.state
+                .map { it.selectedBackend?.storageValue }
+                .distinctUntilChanged()
+                .collect { backend ->
+                    mutex.withLock {
+                        if (activeBackend == backend) return@withLock
+                        activeBackend = backend
+                        if (enabled) {
+                            currentLogFile = resumableLogFileLocked()
+                        }
+                        updateStateLocked()
+                    }
+                }
+        }
+        scope.launch {
+            cleanupHeaderOnlyLogs()
+        }
+        scope.launch {
+            refreshFileState()
+        }
+    }
+
+    fun initialize() {
+        if (initialized) return
+        synchronized(this) {
+            if (initialized) return
+            previousExceptionHandler.compareAndSet(
+                null,
+                Thread.getDefaultUncaughtExceptionHandler()
+            )
+            Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+                recordCrash(thread, throwable)
+                previousExceptionHandler.get()?.uncaughtException(thread, throwable)
+            }
+            initialized = true
+        }
+    }
+
+    fun logInfo(tag: String, message: String) {
+        logEntry("INFO", tag, message, null)
+    }
+
+    fun logDebug(tag: String, message: String) {
+        logEntry("DEBUG", tag, message, null)
+    }
+
+    fun logWarning(tag: String, message: String, throwable: Throwable? = null) {
+        logEntry("WARN", tag, message, throwable)
+    }
+
+    fun logError(tag: String, message: String, throwable: Throwable? = null) {
+        logEntry("ERROR", tag, message, throwable)
+    }
+
+    fun logPlaybackState(tag: String, state: String, detail: String? = null) {
+        val message = buildString {
+            append("playback_state=")
+            append(state)
+            detail?.takeIf { it.isNotBlank() }?.let {
+                append(" detail=")
+                append(it)
+            }
+        }
+        logEntry("INFO", tag, message, null)
+    }
+
+    fun logPlaybackError(tag: String, errorType: String, throwable: Throwable? = null) {
+        val message = buildString {
+            append("playback_error_type=")
+            append(errorType)
+        }
+        logEntry("ERROR", tag, message, throwable)
+    }
+
+    fun logNetworkError(tag: String, errorType: String, method: String, httpStatusCode: Int? = null, throwable: Throwable? = null) {
+        val message = buildString {
+            append("network_error_type=")
+            append(errorType)
+            append(" method=")
+            append(method)
+            httpStatusCode?.let {
+                append(" status=")
+                append(it)
+            }
+        }
+        logEntry("WARN", tag, message, throwable)
+    }
+
+    fun logLifecycle(tag: String, message: String) {
+        logEntry("INFO", tag, message, null)
+    }
+
+    fun logDiagnosticEvent(tag: String, message: String) {
+        logEntry("INFO", tag, message, null)
+    }
+
+    suspend fun deleteLogs() {
+        mutex.withLock {
+            enabled = false
+            logDirectory().listFiles()?.forEach { file ->
+                runCatching { file.delete() }
+            }
+            currentLogFile = null
+            stateFlow.value = DiagnosticLogState(
+            enabled = false,
+            hasLogs = false,
+            sessionId = null,
+            latestLogName = null,
+            activeBackend = null
+        )
+        }
+    }
+
+    suspend fun deleteLogFile(file: File) {
+        mutex.withLock {
+            val targetFile = file.absoluteFile
+            val activeFile = currentLogFile?.absoluteFile
+            runCatching { targetFile.delete() }
+            if (enabled && activeFile == targetFile) {
+                currentLogFile = null
+            }
+            updateStateLocked()
+        }
+    }
+
+    suspend fun latestLogFile(): File? = mutex.withLock {
+        logDirectory()
+            .listFiles()
+            ?.filter { it.isFile && it.length() > 0L }
+            ?.sortedWith(compareByDescending<File> { it.lastModified() }.thenByDescending { it.name })
+            ?.firstOrNull()
+    }
+
+    suspend fun logFiles(): List<File> = mutex.withLock {
+        logDirectory()
+            .listFiles()
+            ?.filter { it.isFile && it.length() > 0L }
+            ?.sortedWith(compareByDescending<File> { it.lastModified() }.thenByDescending { it.name })
+            .orEmpty()
+    }
+
+    private fun logEntry(level: String, tag: String, message: String, throwable: Throwable?) {
+        if (!enabled) return
+        appendLogEntry(level, tag, message, throwable)
+    }
+
+    private fun recordCrash(thread: Thread, throwable: Throwable) {
+        if (!enabled) return
+        runCatching {
+            appendLogEntry(
+                level = "FATAL",
+                tag = thread.name.ifBlank { "uncaught" },
+                message = "uncaught_exception thread=${thread.name}",
+                throwable = throwable,
+                synchronous = true
+            )
+        }
+    }
+
+    private suspend fun enableLogging() {
+        val currentBackend = sessionPreferences.state.first().selectedBackend?.storageValue
+        mutex.withLock {
+            enabled = true
+            activeBackend = currentBackend
+            sessionId = UUID.randomUUID().toString().replace("-", "").take(12)
+            cleanupHeaderOnlyLogsLocked()
+            currentLogFile = resumableLogFileLocked()
+            updateStateLocked()
+        }
+        logLifecycle("Settings", "diagnostic_logging_enabled")
+    }
+
+    private fun resumableLogFileLocked(): File? {
+        val backendSuffix = activeBackend?.trim()?.takeIf { it.isNotBlank() } ?: "pre-backend"
+        val prefix = "$LOG_FILE_PREFIX-$backendSuffix-"
+        return logDirectory()
+            .listFiles()
+            ?.filter { it.isFile && it.name.startsWith(prefix) && it.length() > 0L && it.length() < MAX_LOG_FILE_BYTES }
+            ?.maxByOrNull { it.lastModified() }
+    }
+
+    private suspend fun disableLogging() {
+        mutex.withLock {
+            enabled = false
+            currentLogFile = null
+            updateStateLocked()
+        }
+    }
+
+    private fun logDirectory(): File {
+        val directory = appContext.filesDir.resolve(LOG_DIRECTORY_NAME)
+        if (!logDirectoryReady) {
+            synchronized(this) {
+                if (!logDirectoryReady) {
+                    directory.mkdirs()
+                    logDirectoryReady = true
+                }
+            }
+        }
+        return directory
+    }
+
+    private fun appendLogEntry(
+        level: String,
+        tag: String,
+        message: String,
+        throwable: Throwable?,
+        synchronous: Boolean = false
+    ) {
+        if (!enabled) return
+        val safeTag = tag.trim().ifBlank { "StillShelf" }
+        val safeMessage = DiagnosticLogSanitizer.sanitize(message)
+        val throwableText = throwable?.let(DiagnosticLogSanitizer::sanitizeThrowable)
+        val entry = buildLogEntry(level, safeTag, safeMessage, throwableText)
+        val encoded = entry.toByteArray(Charsets.UTF_8)
+        if (synchronous) {
+            writeLogEntry(encoded, entry)
+            return
+        }
+        scope.launch {
+            mutex.withLock {
+                writeLogEntry(encoded, entry)
+            }
+        }
+    }
+
+    private fun buildLogEntry(
+        level: String,
+        tag: String,
+        message: String,
+        throwableText: String?
+    ): String {
+        val timestamp = utcFormatter().format(Date())
+        return buildString {
+            append(timestamp)
+            append(" [")
+            append(level)
+            append("] ")
+            append(tag)
+            append(": ")
+            append(message)
+            append(" | app=")
+            append(BuildConfig.VERSION_NAME)
+            append("(")
+            append(BuildConfig.VERSION_CODE)
+            append(")")
+            activeBackend?.let {
+                append(" | backend=")
+                append(it)
+            }
+            append(" | android=")
+            append(Build.VERSION.RELEASE)
+            append(" | model=")
+            append(Build.MODEL)
+            sessionId?.let {
+                append(" | session=")
+                append(it)
+            }
+            throwableText?.let {
+                append('\n')
+                append(it)
+            }
+            append('\n')
+        }
+    }
+
+    private fun writeLogEntry(encoded: ByteArray, entry: String) {
+        synchronized(this) {
+            val file = prepareWritableFileLocked(encoded.size) ?: return
+            FileOutputStream(file, true).use { stream ->
+                OutputStreamWriter(stream, Charsets.UTF_8).use { writer ->
+                    writer.write(entry)
+                    writer.flush()
+                }
+            }
+            currentLogFile = file
+            pruneOldLogsLocked()
+            updateStateLocked()
+        }
+    }
+
+    private fun prepareWritableFileLocked(nextEntrySizeBytes: Int): File? {
+        if (!enabled) return null
+        val existing = currentLogFile
+        if (existing != null && existing.exists() && existing.length() + nextEntrySizeBytes <= MAX_LOG_FILE_BYTES) {
+            return existing
+        }
+        return createFreshLogFileLocked()
+    }
+
+    private fun createFreshLogFileLocked(): File {
+        val directory = logDirectory()
+        val logFile = File(directory, buildLogFileName())
+        val header = buildFileHeader()
+        FileOutputStream(logFile, false).use { stream ->
+            OutputStreamWriter(stream, Charsets.UTF_8).use { writer ->
+                writer.write(header)
+                writer.flush()
+            }
+        }
+        currentLogFile = logFile
+        return logFile
+    }
+
+    private fun buildFileHeader(): String {
+        val timestamp = utcFormatter().format(Date())
+        return buildString {
+            append("# StillShelf diagnostic log\n")
+            append("# started_at=")
+            append(timestamp)
+            append('\n')
+            append("# app_version=")
+            append(BuildConfig.VERSION_NAME)
+            append(" (")
+            append(BuildConfig.VERSION_CODE)
+            append(")\n")
+            append("# android_version=")
+            append(Build.VERSION.RELEASE)
+            append('\n')
+            append("# device_model=")
+            append(Build.MODEL)
+            append('\n')
+            activeBackend?.let {
+                append("# backend=")
+                append(it)
+                append('\n')
+            }
+            sessionId?.let {
+                append("# session_id=")
+                append(it)
+                append('\n')
+            }
+            append('\n')
+        }
+    }
+
+    private fun buildLogFileName(): String {
+        val timestamp = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }.format(Date())
+        val safeSessionId = sessionId ?: UUID.randomUUID().toString().replace("-", "").take(12)
+        val backendSuffix = activeBackend?.trim()?.takeIf { it.isNotBlank() } ?: "pre-backend"
+        return "$LOG_FILE_PREFIX-$backendSuffix-$timestamp-$safeSessionId.log"
+    }
+
+    private fun pruneOldLogsLocked() {
+        val files = logDirectory()
+            .listFiles()
+            ?.filter { it.isFile }
+            ?.sortedByDescending { it.lastModified() }
+            .orEmpty()
+        files.drop(MAX_LOG_FILE_COUNT).forEach { file ->
+            runCatching { file.delete() }
+        }
+    }
+
+    private suspend fun cleanupHeaderOnlyLogs() {
+        mutex.withLock {
+            cleanupHeaderOnlyLogsLocked()
+            updateStateLocked()
+        }
+    }
+
+    private fun cleanupHeaderOnlyLogsLocked() {
+        val activeFile = currentLogFile?.absoluteFile
+        logDirectory().listFiles()
+            ?.filter { it.isFile }
+            ?.filter { file -> file.absoluteFile != activeFile }
+            ?.forEach { file ->
+                if (file.length() <= 0L) return@forEach
+                val hasRealLogContent = runCatching {
+                    file.useLines { lines ->
+                        lines.any { line -> line.isNotBlank() && !line.trimStart().startsWith("#") }
+                    }
+                }.getOrDefault(false)
+                if (!hasRealLogContent) {
+                    runCatching { file.delete() }
+                }
+            }
+    }
+
+    private fun updateStateLocked() {
+        val latest = currentLogFile?.takeIf { it.exists() && it.length() > 0L }
+        stateFlow.value = DiagnosticLogState(
+            enabled = enabled,
+            hasLogs = latest != null || (logDirectory().listFiles()?.any { it.isFile && it.length() > 0L } == true),
+            sessionId = sessionId,
+            latestLogName = latest?.name,
+            activeBackend = activeBackend
+        )
+    }
+
+    private suspend fun refreshFileState() {
+        mutex.withLock {
+            updateStateLocked()
+        }
+    }
+
+    private fun utcFormatter(): SimpleDateFormat {
+        return SimpleDateFormat(UTC_PATTERN, Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
+    }
+}

--- a/app/src/main/java/com/stillshelf/app/core/diagnostics/DiagnosticLogSanitizer.kt
+++ b/app/src/main/java/com/stillshelf/app/core/diagnostics/DiagnosticLogSanitizer.kt
@@ -1,0 +1,96 @@
+package com.stillshelf.app.core.diagnostics
+
+import java.security.MessageDigest
+import java.util.Locale
+
+object DiagnosticLogSanitizer {
+    private val emailRegex = Regex("(?i)(?<![\\w@.+-])[\\w.+-]+@[\\w-]+(?:\\.[\\w-]+)+")
+    private val urlRegex = Regex("(?i)\\bhttps?://[^\\s<>()\"']+")
+    private val ipAddressRegex = Regex("(?<!\\d)(?:\\d{1,3}\\.){3}\\d{1,3}(?!\\d)")
+    private val ipv6AddressRegex = Regex(
+        "(?i)(?<![\\w:])(?:\\[(?:[0-9a-f]{0,4}(?::[0-9a-f]{0,4}){2,}(?:%[\\w.~-]+)?)\\]|(?:[0-9a-f]{0,4}(?::[0-9a-f]{0,4}){2,}(?:%[\\w.~-]+)?))(?![\\w:])"
+    )
+    private val absolutePathRegex = Regex("(?<!\\w)(?:/[\\w.-]+){2,}")
+    private val windowsPathRegex = Regex("(?i)\\b[A-Z]:\\\\(?:[^\\\\\\r\\n]+\\\\)*[^\\\\\\r\\n]+")
+    private val unknownHostRegex = Regex(
+        "(?i)(Unable to resolve host(?:name)?\\s+|UnknownHostException:\\s+)(\"?)([^\"\\s:]+)(\"?)"
+    )
+    private val tokenValueRegex = Regex(
+        "(?i)\\b(?:authorization|cookie|set-cookie|api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|token|password|passwd|secret|session|bearer)\\b\\s*[:=]\\s*([^\\s,;]+)"
+    )
+    private val titleValueRegex = Regex(
+        "(?i)\\b(?:title|book[_-]?title|song[_-]?title|album[_-]?title|track[_-]?name|narrator[_-]?name|series[_-]?name|genre[_-]?name|author[_-]?name|media[_-]?name|library[_-]?name)\\b\\s*[:=]\\s*([^\\r\\n,;]+)"
+    )
+    private val userIdValueRegex = Regex(
+        "(?i)\\b(?:user[_-]?id|account[_-]?id|profile[_-]?id|username|user[_-]?name|user[_-]?login|display[_-]?name|full[_-]?name)\\b\\s*[:=]\\s*([^\\s,;]+)"
+    )
+    private val urlKeyRegex = Regex(
+        "(?i)\\b((?:server[_-]?url|base[_-]?url|endpoint|server[_-]?address|server[_-]?host|host|url))\\b\\s*[:=]\\s*([^\\s,;]+)"
+    )
+    private val headerValueRegex = Regex(
+        "(?im)^\\s*(authorization|cookie|set-cookie|x-api-key|x-auth-token|x-session-token)\\s*:\\s*([^\\r\\n]+)$"
+    )
+
+    fun sanitize(value: String): String {
+        var sanitized = value
+        sanitized = headerValueRegex.replace(sanitized) { match ->
+            val headerName = match.groupValues[1]
+            val marker = when (headerName.lowercase(Locale.US)) {
+                "authorization", "cookie", "set-cookie" -> "[REDACTED_TOKEN]"
+                else -> "[REDACTED_HEADER]"
+            }
+            "$headerName: $marker"
+        }
+        sanitized = tokenValueRegex.replace(sanitized) { match ->
+            "${match.groupValues[0].substringBefore(':').substringBefore('=').trim()}=[REDACTED_TOKEN]"
+        }
+        sanitized = urlKeyRegex.replace(sanitized) { match ->
+            val key = match.groupValues[1]
+            val redaction = if (key.equals("url", ignoreCase = true)) {
+                "[REDACTED_URL]"
+            } else {
+                "[REDACTED_SERVER]"
+            }
+            "$key=$redaction"
+        }
+        sanitized = titleValueRegex.replace(sanitized) { match ->
+            "${match.groupValues[0].substringBefore(':').substringBefore('=').trim()}=[REDACTED_TITLE]"
+        }
+        sanitized = userIdValueRegex.replace(sanitized) { match ->
+            val rawValue = match.groupValues[1]
+            val hashedValue = hashForLogging(rawValue)
+            "${match.groupValues[0].substringBefore(':').substringBefore('=').trim()}=[HASH:$hashedValue]"
+        }
+        sanitized = urlRegex.replace(sanitized, "[REDACTED_URL]")
+        sanitized = emailRegex.replace(sanitized, "[REDACTED_EMAIL]")
+        sanitized = ipAddressRegex.replace(sanitized, "[REDACTED_IP]")
+        sanitized = ipv6AddressRegex.replace(sanitized, "[REDACTED_IP]")
+        sanitized = unknownHostRegex.replace(sanitized) {
+            "${it.groupValues[1]}${it.groupValues[2]}[REDACTED_HOST]${it.groupValues[4]}"
+        }
+        sanitized = windowsPathRegex.replace(sanitized, "[REDACTED_PATH]")
+        sanitized = absolutePathRegex.replace(sanitized, "[REDACTED_PATH]")
+        return sanitized
+    }
+
+    fun sanitizeThrowable(throwable: Throwable): String {
+        val rawStackTrace = buildString {
+            append(throwable::class.java.name)
+            throwable.message?.takeIf { it.isNotBlank() }?.let { message ->
+                append(": ")
+                append(message)
+            }
+            append('\n')
+            append(throwable.stackTraceToString())
+        }
+        return sanitize(rawStackTrace)
+    }
+
+    private fun hashForLogging(value: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(value.trim().toByteArray(Charsets.UTF_8))
+        return digest.take(8).joinToString(separator = "") { byte ->
+            "%02x".format(byte)
+        }
+    }
+}

--- a/app/src/main/java/com/stillshelf/app/core/diagnostics/DiagnosticLoggingAccess.kt
+++ b/app/src/main/java/com/stillshelf/app/core/diagnostics/DiagnosticLoggingAccess.kt
@@ -1,0 +1,17 @@
+package com.stillshelf.app.core.diagnostics
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import dagger.hilt.android.EntryPointAccessors
+
+@Composable
+fun rememberDiagnosticLogManager(): DiagnosticLogManager {
+    val context = LocalContext.current.applicationContext
+    return remember(context) {
+        EntryPointAccessors.fromApplication(
+            context,
+            DiagnosticLoggingEntryPoint::class.java
+        ).diagnosticLogManager()
+    }
+}

--- a/app/src/main/java/com/stillshelf/app/core/diagnostics/DiagnosticLoggingEntryPoint.kt
+++ b/app/src/main/java/com/stillshelf/app/core/diagnostics/DiagnosticLoggingEntryPoint.kt
@@ -1,0 +1,11 @@
+package com.stillshelf.app.core.diagnostics
+
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface DiagnosticLoggingEntryPoint {
+    fun diagnosticLogManager(): DiagnosticLogManager
+}

--- a/app/src/main/java/com/stillshelf/app/core/network/NetworkModule.kt
+++ b/app/src/main/java/com/stillshelf/app/core/network/NetworkModule.kt
@@ -1,5 +1,6 @@
 package com.stillshelf.app.core.network
 
+import com.stillshelf.app.core.diagnostics.DiagnosticLogManager
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -13,12 +14,37 @@ import okhttp3.OkHttpClient
 object NetworkModule {
     @Provides
     @Singleton
-    fun provideOkHttpClient(): OkHttpClient {
+    fun provideOkHttpClient(
+        diagnosticLogManager: DiagnosticLogManager
+    ): OkHttpClient {
         return OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val request = chain.request()
+                val method = request.method
+                try {
+                    val response = chain.proceed(request)
+                    if (!response.isSuccessful) {
+                        diagnosticLogManager.logNetworkError(
+                            tag = "OkHttp",
+                            errorType = "http_${response.code}",
+                            method = method,
+                            httpStatusCode = response.code
+                        )
+                    }
+                    response
+                } catch (throwable: Throwable) {
+                    diagnosticLogManager.logNetworkError(
+                        tag = "OkHttp",
+                        errorType = throwable::class.java.simpleName.ifBlank { "network_exception" },
+                        method = method,
+                        throwable = throwable
+                    )
+                    throw throwable
+                }
+            }
             .connectTimeout(20, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)
             .build()
     }
-
 }

--- a/app/src/main/java/com/stillshelf/app/data/repo/SessionRepositoryImpl.kt
+++ b/app/src/main/java/com/stillshelf/app/data/repo/SessionRepositoryImpl.kt
@@ -36,6 +36,7 @@ import com.stillshelf.app.core.model.SeriesDetailEntry
 import com.stillshelf.app.core.datastore.SecureTokenStorage
 import com.stillshelf.app.core.datastore.PendingBookmarkCreateSnapshot
 import com.stillshelf.app.core.datastore.SessionPreferences
+import com.stillshelf.app.core.diagnostics.DiagnosticLogManager
 import com.stillshelf.app.core.model.ActiveServerConnectionStatus
 import com.stillshelf.app.core.model.Library
 import com.stillshelf.app.core.model.ServerConnectionMode
@@ -212,7 +213,8 @@ class SessionRepositoryImpl @Inject constructor(
     private val secureTokenStorage: SecureTokenStorage,
     private val audiobookshelfApi: AudiobookshelfApi,
     private val realtimeClient: AudiobookshelfRealtimeClient,
-    private val activeServerEndpointResolver: ActiveServerEndpointResolver
+    private val activeServerEndpointResolver: ActiveServerEndpointResolver,
+    private val diagnosticLogManager: DiagnosticLogManager
 ) : SessionRepository {
     companion object {
         private const val HOME_FEED_CACHE_MAX_AGE_MS: Long = 10 * 60 * 1000L
@@ -464,7 +466,7 @@ class SessionRepositoryImpl @Inject constructor(
             val isDeletingActiveServer = session.activeServerId == existing.id
             if (isDeletingActiveServer) {
                 sessionPreferences.setLastPlayedBookId(null)
-                sessionPreferences.clearCachedHomeFeed()
+                clearHomeFeedCache("delete_active_server")
                 prepareFallbackSelectionIfPossible(nextServer?.id)
             }
             secureTokenStorage.clearToken(existing.id)
@@ -568,6 +570,7 @@ class SessionRepositoryImpl @Inject constructor(
             is AppResult.Error -> return syncResult
         }
 
+        diagnosticLogManager.logLifecycle("Session", "active_server_changed")
         return activateServerWithDefaultLibrary(server.id)
     }
 
@@ -579,6 +582,7 @@ class SessionRepositoryImpl @Inject constructor(
 
         sessionPreferences.setActiveLibraryId(library.id)
         sessionPreferences.setRequiresLibrarySelection(false)
+        diagnosticLogManager.logLifecycle("Session", "active_library_changed")
         return AppResult.Success(Unit)
     }
 
@@ -593,9 +597,10 @@ class SessionRepositoryImpl @Inject constructor(
         val library = libraryDao.getByServerAndId(activeServerId, libraryId)
             ?: return AppResult.Error("Library not found.")
 
-        sessionPreferences.clearCachedHomeFeed()
+        clearHomeFeedCache("prepare_library_selection")
         sessionPreferences.setRequiresLibrarySelection(true)
         sessionPreferences.setActiveLibraryId(library.id)
+        diagnosticLogManager.logLifecycle("Session", "active_library_primed")
 
         val homeFeedResult = fetchHomeFeed(
             continueLimit = continueLimit,
@@ -621,12 +626,13 @@ class SessionRepositoryImpl @Inject constructor(
             ?: return AppResult.Error("No libraries were returned for this server.")
 
         sessionPreferences.setLastPlayedBookId(null)
-        sessionPreferences.clearCachedHomeFeed()
+        clearHomeFeedCache("initialize_active_server")
         sessionPreferences.setActiveSelectionState(
             serverId = serverId,
             libraryId = defaultLibraryId,
             requiresLibrarySelection = false
         )
+        diagnosticLogManager.logLifecycle("Session", "active_server_initialized")
         clearContentCaches()
         return AppResult.Success(Unit)
     }
@@ -676,7 +682,7 @@ class SessionRepositoryImpl @Inject constructor(
                 ?: return AppResult.Error("No active server selected.")
             val nextServer = serverDao.getAll().firstOrNull { it.id != activeServerId }
             sessionPreferences.setLastPlayedBookId(null)
-            sessionPreferences.clearCachedHomeFeed()
+            clearHomeFeedCache("sign_out")
             prepareFallbackSelectionIfPossible(nextServer?.id)
 
             runCatching { secureTokenStorage.clearToken(activeServerId) }
@@ -2629,7 +2635,7 @@ class SessionRepositoryImpl @Inject constructor(
             )
         }
         if (isFinished) {
-            runCatching { sessionPreferences.clearCachedHomeFeed() }
+            clearHomeFeedCache("mark_progress_finished")
             clearContentCaches()
         }
         putLocalProgressOverride(
@@ -2975,7 +2981,7 @@ class SessionRepositoryImpl @Inject constructor(
         if (!finished || resetProgressWhenUnfinished) {
             finishedProgressSnapshots.remove(bookId)
         }
-        runCatching { sessionPreferences.clearCachedHomeFeed() }
+        clearHomeFeedCache("mark_book_finished")
         clearContentCaches()
         val resolvedProgress = when {
             finished -> PlaybackProgress(
@@ -3315,16 +3321,24 @@ class SessionRepositoryImpl @Inject constructor(
                 cachedLibraryId = cached.libraryId
             )
         ) {
+            logCacheTrace("home_feed_cache_miss reason=selection_mismatch")
             return AppResult.Success(null)
         }
         val cacheAgeMs = (System.currentTimeMillis() - cached.savedAtMs).coerceAtLeast(0L)
         val effectiveMaxAgeMs = maxAgeMs ?: HOME_FEED_CACHE_MAX_AGE_MS
         if (cacheAgeMs > effectiveMaxAgeMs) {
+            logCacheTrace(
+                "home_feed_cache_miss reason=stale age_ms=$cacheAgeMs max_age_ms=$effectiveMaxAgeMs"
+            )
             return AppResult.Success(null)
         }
 
         val parsed = runCatching { parseCachedHomeFeed(cached.payload) }.getOrNull()
-            ?: return AppResult.Success(null)
+            ?: run {
+                logCacheTrace("home_feed_cache_miss reason=parse_failed")
+                return AppResult.Success(null)
+            }
+        logCacheTrace("home_feed_cache_hit age_ms=$cacheAgeMs")
         return AppResult.Success(parsed)
     }
 
@@ -3751,7 +3765,7 @@ class SessionRepositoryImpl @Inject constructor(
                     serverId = server.id,
                     activeLibraryId = session.activeLibraryId
                 )
-                sessionPreferences.clearCachedHomeFeed()
+                clearHomeFeedCache("server_refresh_success")
                 deletePersistedDetailCacheForServer(server.id)
                 clearContentCachesForServer(server.id)
                 clearServerDataState(server.id)
@@ -3761,7 +3775,7 @@ class SessionRepositoryImpl @Inject constructor(
             }
 
             is AppResult.Error -> {
-                sessionPreferences.clearCachedHomeFeed()
+                clearHomeFeedCache("server_refresh_failed")
                 deletePersistedDetailCacheForServer(server.id)
                 clearContentCachesForServer(server.id)
                 markServerDataStale(
@@ -3904,6 +3918,7 @@ class SessionRepositoryImpl @Inject constructor(
             collectionsCache.clear()
             playlistsCache.clear()
         }
+        logCacheTrace("content_cache_cleared scope=all")
     }
 
     private suspend fun clearContentCachesForServer(serverId: String) {
@@ -3916,6 +3931,7 @@ class SessionRepositoryImpl @Inject constructor(
             collectionsCache.keys.removeAll { it.startsWith(normalizedPrefix) }
             playlistsCache.keys.removeAll { it.startsWith(normalizedPrefix) }
         }
+        logCacheTrace("content_cache_cleared scope=server")
     }
 
     private suspend fun deletePersistedDetailCacheForServer(serverId: String) {
@@ -3926,6 +3942,16 @@ class SessionRepositoryImpl @Inject constructor(
         detailCacheDao.deleteSeriesMembershipsForServer(serverId)
         detailCacheDao.deleteSeriesSummariesForServer(serverId)
         detailCacheDao.deleteDetailSyncStateForServer(serverId)
+        logCacheTrace("detail_cache_cleared scope=server")
+    }
+
+    private suspend fun clearHomeFeedCache(reason: String) {
+        sessionPreferences.clearCachedHomeFeed()
+        logCacheTrace("home_feed_cache_cleared reason=$reason")
+    }
+
+    private fun logCacheTrace(message: String) {
+        diagnosticLogManager.logDiagnosticEvent("SessionCache", message)
     }
 
     private suspend fun runDedupedDetailRefresh(

--- a/app/src/main/java/com/stillshelf/app/playback/controller/PlaybackController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/controller/PlaybackController.kt
@@ -41,6 +41,7 @@ import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import com.stillshelf.app.core.diagnostics.DiagnosticLogManager
 import com.stillshelf.app.core.datastore.PlaybackCheckpointSnapshot
 import com.stillshelf.app.core.datastore.SessionPreferences
 import com.stillshelf.app.core.model.BookChapter
@@ -149,7 +150,8 @@ class PlaybackController @Inject constructor(
     @param:ApplicationContext private val appContext: Context,
     private val sessionRepository: SessionRepository,
     private val sessionPreferences: SessionPreferences,
-    private val bookDownloadManager: BookDownloadManager
+    private val bookDownloadManager: BookDownloadManager,
+    private val diagnosticLogManager: DiagnosticLogManager
 ) {
     companion object {
         private const val CHANNEL_ID = "stillshelf_playback_v4"
@@ -167,6 +169,7 @@ class PlaybackController @Inject constructor(
         private const val SPEAKER_OUTPUT_VOLUME_RAMP_STEPS = 5
         private const val SPEAKER_OUTPUT_VOLUME_RAMP_STEP_DELAY_MS = 90L
         private const val OUTPUT_SWITCH_REFRESH_GRACE_MS = 500L
+        private const val TAG = "PlaybackController"
         const val ACTION_PLAY_PAUSE = "com.stillshelf.app.playback.action.PLAY_PAUSE"
         const val ACTION_REWIND = "com.stillshelf.app.playback.action.REWIND"
         const val ACTION_FORWARD = "com.stillshelf.app.playback.action.FORWARD"
@@ -241,10 +244,16 @@ class PlaybackController @Inject constructor(
     private var noisyAudioReceiverRegistered: Boolean = false
     private val audioDeviceCallback = object : AudioDeviceCallback() {
         override fun onAudioDevicesAdded(addedDevices: Array<out AudioDeviceInfo>?) {
+            logPlaybackTrace(
+                "audio_route_change=device_added count=${addedDevices?.size ?: 0}"
+            )
             refreshAudioOutputDevices(reason = OutputRefreshReason.DeviceAdded)
         }
 
         override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>?) {
+            logPlaybackTrace(
+                "audio_route_change=device_removed count=${removedDevices?.size ?: 0}"
+            )
             refreshAudioOutputDevices(reason = OutputRefreshReason.DeviceRemoved)
         }
     }
@@ -356,6 +365,10 @@ class PlaybackController @Inject constructor(
 
     fun playBook(bookId: String, startPositionMs: Long? = null) {
         if (bookId.isBlank()) return
+        logPlaybackTrace(
+            "playback_command=play_book start_position_ms=${startPositionMs?.coerceAtLeast(0L)} " +
+                "has_current_book=${currentBookId != null} has_player=${mediaPlayer != null}"
+        )
         if (currentBookId != bookId) {
             attemptedAutoAdvanceTargetsMs.clear()
             clearPendingAutoAdvanceUiTarget()
@@ -584,6 +597,7 @@ class PlaybackController @Inject constructor(
     }
 
     fun playBookFromPosition(bookId: String, startPositionMs: Long) {
+        logPlaybackTrace("playback_command=play_book_from_position start_position_ms=${startPositionMs.coerceAtLeast(0L)}")
         playBook(
             bookId = bookId,
             startPositionMs = startPositionMs.coerceAtLeast(0L)
@@ -591,6 +605,7 @@ class PlaybackController @Inject constructor(
     }
 
     fun togglePlayPause() {
+        logPlaybackTrace("playback_command=toggle_play_pause is_playing=${uiState.value.isPlaying}")
         if (uiState.value.isPlaying) {
             pause()
         } else {
@@ -599,14 +614,17 @@ class PlaybackController @Inject constructor(
     }
 
     fun playCurrent() {
+        logPlaybackTrace("playback_command=play_current")
         resume()
     }
 
     fun pauseCurrent() {
+        logPlaybackTrace("playback_command=pause_current")
         pause()
     }
 
     fun stop() {
+        logPlaybackTrace("playback_command=stop had_book=${uiState.value.book != null}")
         val hadBook = uiState.value.book != null
         if (hadBook) {
             updateCachedFromUiState()
@@ -655,6 +673,9 @@ class PlaybackController @Inject constructor(
         } else {
             (current + deltaMs).coerceAtLeast(0L)
         }
+        logPlaybackTrace(
+            "playback_command=seek_by delta_ms=$deltaMs target_ms=$target duration_ms=$duration"
+        )
         seekToPosition(targetMs = target, forceSync = true)
     }
 
@@ -664,10 +685,16 @@ class PlaybackController @Inject constructor(
         if (duration <= 0L) return
         val clamped = progressFraction.coerceIn(0f, 1f)
         val targetMs = (duration.toDouble() * clamped.toDouble()).toLong()
+        logPlaybackTrace(
+            "playback_command=seek_to_progress fraction=$clamped target_ms=$targetMs duration_ms=$duration commit=$commit"
+        )
         seekToPosition(targetMs = targetMs, forceSync = commit)
     }
 
     fun seekToPositionMs(positionMs: Long, commit: Boolean) {
+        logPlaybackTrace(
+            "playback_command=seek_to_position_ms target_ms=${positionMs.coerceAtLeast(0L)} commit=$commit"
+        )
         seekToPosition(targetMs = positionMs.coerceAtLeast(0L), forceSync = commit)
     }
 
@@ -1009,6 +1036,10 @@ class PlaybackController @Inject constructor(
 
     private fun refreshAudioOutputDevices(reason: OutputRefreshReason) {
         val available = queryOutputDevices()
+        logPlaybackTrace(
+            "audio_output_refresh reason=${describeOutputRefreshReason(reason)} available_count=${available.size} " +
+                "has_explicit_selection=${preferredOutputDeviceId != null}"
+        )
         val availableIds = available.mapNotNull { it.id }.toSet()
         val bluetoothOutputId = available.firstOrNull { output ->
             val displayedId = output.id ?: return@firstOrNull false
@@ -1040,10 +1071,17 @@ class PlaybackController @Inject constructor(
             )
         }
         lastKnownOutputDeviceIds = availableIds
+        logPlaybackTrace(
+            "audio_output_refresh_applied reason=${describeOutputRefreshReason(reason)} selected_device=${preferredOutputDeviceId != null} " +
+                "available_count=${available.size}"
+        )
     }
 
     fun selectAudioOutputDevice(deviceId: Int?): Boolean {
         val available = queryOutputDevices()
+        logPlaybackTrace(
+            "audio_output_select requested=${deviceId != null} available_count=${available.size}"
+        )
         if (available.none { output -> output.id == deviceId }) {
             refreshAudioOutputDevices()
             return false
@@ -1087,6 +1125,9 @@ class PlaybackController @Inject constructor(
     private fun seekToPosition(targetMs: Long, forceSync: Boolean = true) {
         val player = mediaPlayer ?: return
         val safeTargetMs = targetMs.coerceAtLeast(0L)
+        logPlaybackTrace(
+            "playback_command=seek_to_position target_ms=$safeTargetMs force_sync=$forceSync"
+        )
         val targetTrackStartOffsetMs = resolveTrackStartOffsetForPosition(
             tracks = currentPlaybackSource?.tracks.orEmpty(),
             positionMs = safeTargetMs
@@ -1123,10 +1164,14 @@ class PlaybackController @Inject constructor(
     }
 
     private fun pause() {
+        logPlaybackTrace("playback_command=pause_request")
         pause(reason = PauseReason.User)
     }
 
     private fun resume() {
+        logPlaybackTrace(
+            "playback_command=resume_request has_player=${mediaPlayer != null} has_book=${uiState.value.book != null} is_loading=${uiState.value.isLoading}"
+        )
         val player = mediaPlayer
         if (player == null) {
             val book = uiState.value.book ?: return
@@ -1203,6 +1248,12 @@ class PlaybackController @Inject constructor(
         player.addListener(object : Player.Listener {
             override fun onPlaybackStateChanged(playbackState: Int) {
                 if (player !== mediaPlayer) return
+                logPlaybackTrace(
+                    "playback_state_changed state=${describePlaybackState(playbackState)} " +
+                        "is_playing=${runCatching { player.isPlaying }.getOrDefault(false)} " +
+                        "play_when_ready=${runCatching { player.playWhenReady }.getOrDefault(false)} " +
+                        "position_ms=${safePosition(player)} duration_ms=${safeDuration(player)}"
+                )
                 when (playbackState) {
                     Player.STATE_READY -> {
                         if (initialReadyHandled) return
@@ -1254,8 +1305,21 @@ class PlaybackController @Inject constructor(
                 }
             }
 
+            override fun onIsPlayingChanged(isPlaying: Boolean) {
+                if (player !== mediaPlayer) return
+                logPlaybackTrace(
+                    "playback_flag_changed is_playing=$isPlaying state=${describePlaybackState(player.playbackState)} " +
+                        "position_ms=${safePosition(player)}"
+                )
+            }
+
             override fun onPlayerError(error: androidx.media3.common.PlaybackException) {
                 if (player !== mediaPlayer) return
+                diagnosticLogManager.logPlaybackError(
+                    tag = TAG,
+                    errorType = error::class.java.simpleName,
+                    throwable = error
+                )
                 updateUiState {
                     it.copy(
                         isLoading = false,
@@ -1286,7 +1350,52 @@ class PlaybackController @Inject constructor(
         }
     }
 
+    private fun describePlaybackState(playbackState: Int): String {
+        return when (playbackState) {
+            Player.STATE_IDLE -> "idle"
+            Player.STATE_BUFFERING -> "buffering"
+            Player.STATE_READY -> "ready"
+            Player.STATE_ENDED -> "ended"
+            else -> "state_$playbackState"
+        }
+    }
+
+    private fun describePauseReason(reason: PauseReason): String {
+        return when (reason) {
+            PauseReason.User -> "user"
+            PauseReason.AudioFocusTransientLoss -> "audio_focus_transient_loss"
+            PauseReason.AudioFocusLoss -> "audio_focus_loss"
+            PauseReason.NoisyOutput -> "noisy_output"
+            PauseReason.Internal -> "internal"
+        }
+    }
+
+    private fun describeAudioFocusChange(focusChange: Int): String {
+        return when (focusChange) {
+            AudioManager.AUDIOFOCUS_GAIN -> "gain"
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> "loss_transient_can_duck"
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> "loss_transient"
+            AudioManager.AUDIOFOCUS_LOSS -> "loss"
+            else -> "change_$focusChange"
+        }
+    }
+
+    private fun describeOutputRefreshReason(reason: OutputRefreshReason): String {
+        return when (reason) {
+            OutputRefreshReason.General -> "general"
+            OutputRefreshReason.DeviceAdded -> "device_added"
+            OutputRefreshReason.DeviceRemoved -> "device_removed"
+        }
+    }
+
+    private fun logPlaybackTrace(message: String) {
+        diagnosticLogManager.logDiagnosticEvent(TAG, message)
+    }
+
     private fun pause(reason: PauseReason) {
+        logPlaybackTrace(
+            "playback_command=pause reason=${describePauseReason(reason)} has_player=${mediaPlayer != null} is_playing=${uiState.value.isPlaying}"
+        )
         val player = mediaPlayer
         if (player != null) {
             clearDucking(player)
@@ -1358,6 +1467,14 @@ class PlaybackController @Inject constructor(
         if (requestResult == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
             hasAudioFocus = true
         }
+        logPlaybackTrace(
+            "audio_focus_request result=${when (requestResult) {
+                AudioManager.AUDIOFOCUS_REQUEST_GRANTED -> "granted"
+                AudioManager.AUDIOFOCUS_REQUEST_DELAYED -> "delayed"
+                AudioManager.AUDIOFOCUS_REQUEST_FAILED -> "failed"
+                else -> "result_$requestResult"
+            }} has_focus=$hasAudioFocus"
+        )
         return requestResult
     }
 
@@ -1370,9 +1487,14 @@ class PlaybackController @Inject constructor(
             @Suppress("DEPRECATION")
             runCatching { audioManager.abandonAudioFocus(audioFocusChangeListener) }
         }
+        logPlaybackTrace("audio_focus_abandoned")
     }
 
     private fun handleAudioFocusChange(focusChange: Int) {
+        logPlaybackTrace(
+            "audio_focus_change=${describeAudioFocusChange(focusChange)} pending_play=$pendingPlayAfterAudioFocusGain " +
+                "is_ducked=$isDuckedForAudioFocus"
+        )
         when (focusChange) {
             AudioManager.AUDIOFOCUS_GAIN -> {
                 hasAudioFocus = true
@@ -1465,6 +1587,7 @@ class PlaybackController @Inject constructor(
         val player = mediaPlayer ?: return
         val isPlayingNow = runCatching { player.isPlaying }.getOrDefault(false)
         if (!isPlayingNow) return
+        logPlaybackTrace("audio_route_change=noisy_output_pause")
         pause(reason = PauseReason.NoisyOutput)
     }
 

--- a/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
@@ -35,6 +35,7 @@ import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.audio.AudioSink
 import androidx.media3.exoplayer.audio.DefaultAudioSink
+import com.stillshelf.app.core.diagnostics.DiagnosticLogManager
 import coil.imageLoader
 import coil.request.ImageRequest
 import com.stillshelf.app.MainActivity
@@ -240,9 +241,11 @@ class NavidromePlayerController @Inject constructor(
     @ApplicationContext private val appContext: Context,
     private val sessionPreferences: SessionPreferences,
     private val downloadManager: NavidromeDownloadManager,
-    private val navidromeRepository: NavidromeRepository
+    private val navidromeRepository: NavidromeRepository,
+    private val diagnosticLogManager: DiagnosticLogManager
 ) {
     private companion object {
+        const val TAG = "NavidromePlayerController"
         const val MAX_RECENT_TRACKS = 7
         const val PREVIOUS_RESTART_THRESHOLD_MS = 3_000
         const val PLAYING_PROGRESS_UPDATE_INTERVAL_MS = 80L
@@ -352,14 +355,30 @@ class NavidromePlayerController @Inject constructor(
         }
 
         override fun onPlaybackStateChanged(playbackState: Int) {
+            logPlaybackTrace(
+                "playback_state_changed state=${describePlaybackState(playbackState)} " +
+                    "is_playing=${runCatching { player?.isPlaying }.getOrDefault(false)} " +
+                    "play_when_ready=${runCatching { player?.playWhenReady }.getOrDefault(false)} " +
+                    "current_index=${mutableState.value.currentIndex} queue_size=${queueTracks.size} " +
+                    "position_ms=${mutableState.value.positionMs}"
+            )
             updateStateFromPlayer()
         }
 
         override fun onIsPlayingChanged(isPlaying: Boolean) {
+            logPlaybackTrace(
+                "playback_flag_changed is_playing=$isPlaying state=${describePlaybackState(player?.playbackState ?: Player.STATE_IDLE)} " +
+                    "current_index=${mutableState.value.currentIndex} position_ms=${mutableState.value.positionMs}"
+            )
             updateStateFromPlayer()
         }
 
         override fun onPlayerError(error: androidx.media3.common.PlaybackException) {
+            diagnosticLogManager.logPlaybackError(
+                tag = TAG,
+                errorType = error::class.java.simpleName,
+                throwable = error
+            )
             mutableState.value = mutableState.value.copy(
                 isLoading = false,
                 isPlaying = false,
@@ -371,10 +390,16 @@ class NavidromePlayerController @Inject constructor(
 
     private val audioDeviceCallback = object : AudioDeviceCallback() {
         override fun onAudioDevicesAdded(addedDevices: Array<out AudioDeviceInfo>?) {
+            logPlaybackTrace(
+                "audio_route_change=device_added count=${addedDevices?.size ?: 0}"
+            )
             refreshAudioOutputDevices(reason = OutputRefreshReason.DeviceAdded)
         }
 
         override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>?) {
+            logPlaybackTrace(
+                "audio_route_change=device_removed count=${removedDevices?.size ?: 0}"
+            )
             refreshAudioOutputDevices(reason = OutputRefreshReason.DeviceRemoved)
         }
     }
@@ -441,6 +466,28 @@ class NavidromePlayerController @Inject constructor(
             }
     }
 
+    private fun describePlaybackState(playbackState: Int): String {
+        return when (playbackState) {
+            Player.STATE_IDLE -> "idle"
+            Player.STATE_BUFFERING -> "buffering"
+            Player.STATE_READY -> "ready"
+            Player.STATE_ENDED -> "ended"
+            else -> "state_$playbackState"
+        }
+    }
+
+    private fun describeOutputRefreshReason(reason: OutputRefreshReason): String {
+        return when (reason) {
+            OutputRefreshReason.General -> "general"
+            OutputRefreshReason.DeviceAdded -> "device_added"
+            OutputRefreshReason.DeviceRemoved -> "device_removed"
+        }
+    }
+
+    private fun logPlaybackTrace(message: String) {
+        diagnosticLogManager.logDiagnosticEvent(TAG, message)
+    }
+
     private fun getOrCreatePlayer(): ExoPlayer {
         val existing = player
         if (existing != null) return existing
@@ -457,6 +504,9 @@ class NavidromePlayerController @Inject constructor(
 
     fun selectAudioOutputDevice(deviceId: Int?): Boolean {
         val available = queryOutputDevices()
+        logPlaybackTrace(
+            "audio_output_select requested=${deviceId != null} available_count=${available.size}"
+        )
         if (deviceId != null && available.none { output -> output.id == deviceId }) {
             refreshAudioOutputs()
             return false
@@ -501,6 +551,10 @@ class NavidromePlayerController @Inject constructor(
         queueDisplayMode: NavidromeQueueDisplayMode = NavidromeQueueDisplayMode.FULL
     ) {
         if (tracks.isEmpty()) return
+        logPlaybackTrace(
+            "playback_command=play_tracks queue_size=${tracks.size} start_index=${startIndex.coerceIn(0, tracks.lastIndex)} " +
+                "queue_mode=${queueDisplayMode.name.lowercase()}"
+        )
         invalidatePendingPlaybackRestore()
         val index = startIndex.coerceIn(0, tracks.lastIndex)
         playbackRecoveryTrackId = null
@@ -540,6 +594,9 @@ class NavidromePlayerController @Inject constructor(
     fun playTracksNext(tracks: List<NavidromeTrack>) {
         val normalizedTracks = tracks.filter { it.id.isNotBlank() }
         if (normalizedTracks.isEmpty()) return
+        logPlaybackTrace(
+            "playback_command=play_tracks_next queue_size=${normalizedTracks.size}"
+        )
         if (queueTracks.isEmpty()) {
             playTracks(normalizedTracks, startIndex = 0)
             return
@@ -626,6 +683,7 @@ class NavidromePlayerController @Inject constructor(
     }
 
     fun togglePlayPause() {
+        logPlaybackTrace("playback_command=toggle_play_pause is_playing=${mutableState.value.isPlaying}")
         if (mutableState.value.isPlaying) {
             pause()
         } else {
@@ -634,6 +692,10 @@ class NavidromePlayerController @Inject constructor(
     }
 
     fun play() {
+        logPlaybackTrace(
+            "playback_command=play queue_size=${queueTracks.size} current_index=${mutableState.value.currentIndex} " +
+                "has_player=${player != null} is_playing=${mutableState.value.isPlaying}"
+        )
         if (queueTracks.isEmpty()) return
         val currentTrack = queueTracks.getOrNull(mutableState.value.currentIndex)
         val activePlayer = player
@@ -654,6 +716,10 @@ class NavidromePlayerController @Inject constructor(
     }
 
     fun pause() {
+        logPlaybackTrace(
+            "playback_command=pause queue_size=${queueTracks.size} current_index=${mutableState.value.currentIndex} " +
+                "has_player=${player != null} is_playing=${mutableState.value.isPlaying}"
+        )
         if (queueTracks.isEmpty()) return
         val currentTrack = queueTracks.getOrNull(mutableState.value.currentIndex)
         val activePlayer = player ?: return
@@ -671,12 +737,19 @@ class NavidromePlayerController @Inject constructor(
 
     fun playNext() {
         val currentIndex = resolveCurrentQueueIndex()
+        logPlaybackTrace(
+            "playback_command=next current_index=$currentIndex queue_size=${queueTracks.size}"
+        )
         val nextIndex = (currentIndex + 1).takeIf { it in queueTracks.indices } ?: return
         seekToQueueIndex(index = nextIndex, positionMs = 0, playWhenReady = true)
     }
 
     fun playPrevious() {
         val currentIndex = resolveCurrentQueueIndex()
+        logPlaybackTrace(
+            "playback_command=previous current_index=$currentIndex queue_size=${queueTracks.size} " +
+                "position_ms=${mutableState.value.positionMs}"
+        )
         if (currentIndex !in queueTracks.indices) return
         val currentTrack = queueTracks[currentIndex]
         if (!currentTrack.isRadioTrack() && mutableState.value.positionMs > PREVIOUS_RESTART_THRESHOLD_MS) {
@@ -723,6 +796,9 @@ class NavidromePlayerController @Inject constructor(
     fun currentRepeatMode(): Int = repeatMode
 
     fun stop() {
+        logPlaybackTrace(
+            "playback_command=stop queue_size=${queueTracks.size} current_index=${mutableState.value.currentIndex}"
+        )
         invalidatePendingPlaybackRestore()
         queueTracks = emptyList()
         lastRecordedTrackId = null
@@ -734,14 +810,19 @@ class NavidromePlayerController @Inject constructor(
         releasePlayer(clearQueue = true)
         stopProgressUpdates()
         clearPlaybackSurface()
-        scope.launch(Dispatchers.IO) {
-            sessionPreferences.clearCachedNavidromePlayback()
-        }
+        clearCachedNavidromePlayback("stop")
         mutableState.value = NavidromePlayerState(
             recentTracks = recentTracks,
             outputDevices = mutableState.value.outputDevices,
             selectedOutputDeviceId = mutableState.value.selectedOutputDeviceId
         )
+    }
+
+    private fun clearCachedNavidromePlayback(reason: String) {
+        logPlaybackTrace("playback_cache_cleared reason=$reason")
+        scope.launch(Dispatchers.IO) {
+            sessionPreferences.clearCachedNavidromePlayback()
+        }
     }
 
     fun handleExternalPlaybackAction(action: String) {
@@ -755,6 +836,9 @@ class NavidromePlayerController @Inject constructor(
     fun seekTo(positionMs: Int) {
         val durationMs = resolvePlayerDurationMs()
         val clampedPosition = positionMs.coerceIn(0, durationMs.coerceAtLeast(0))
+        logPlaybackTrace(
+            "playback_command=seek target_ms=$clampedPosition duration_ms=$durationMs"
+        )
         player?.seekTo(clampedPosition.toLong())
         mutableState.value = mutableState.value.copy(
             positionMs = clampedPosition,
@@ -772,6 +856,10 @@ class NavidromePlayerController @Inject constructor(
         if (queueTracks.isEmpty()) return
         val safeIndex = index.coerceIn(0, queueTracks.lastIndex)
         val safePositionMs = positionMs.coerceAtLeast(0)
+        logPlaybackTrace(
+            "playback_command=start_playback index=$safeIndex position_ms=$safePositionMs play_when_ready=$playWhenReady " +
+                "queue_size=${queueTracks.size} reset_recovery=$resetRecoveryState"
+        )
         if (resetRecoveryState) {
             playbackRecoveryTrackId = null
         }
@@ -834,9 +922,7 @@ class NavidromePlayerController @Inject constructor(
                     forcedRemoteTrackIds += failedTrackId
                 }
                 if (refreshedQueue.isNullOrEmpty()) {
-                    scope.launch(Dispatchers.IO) {
-                        sessionPreferences.clearCachedNavidromePlayback()
-                    }
+                    clearCachedNavidromePlayback("error_refresh_failed")
                     mutableState.value = mutableState.value.copy(
                         errorMessage = error.message ?: "Playback failed for this track."
                     )
@@ -876,6 +962,9 @@ class NavidromePlayerController @Inject constructor(
         } else {
             state.positionMs.coerceAtLeast(0)
         }
+        logPlaybackTrace(
+            "playback_command=resume_from_snapshot index=$index position_ms=$positionMs play_when_ready=$playWhenReady"
+        )
         startPlaybackAt(index = index, positionMs = positionMs, playWhenReady = playWhenReady)
     }
 
@@ -894,6 +983,10 @@ class NavidromePlayerController @Inject constructor(
     ) {
         if (index !in queueTracks.indices) return
         val safePositionMs = positionMs.coerceAtLeast(0)
+        logPlaybackTrace(
+            "playback_command=seek_queue_index index=$index position_ms=$safePositionMs play_when_ready=$playWhenReady " +
+                "has_player=${player != null}"
+        )
         val activePlayer = player
         if (activePlayer == null) {
             startPlaybackAt(index = index, positionMs = safePositionMs, playWhenReady = playWhenReady)
@@ -938,9 +1031,7 @@ class NavidromePlayerController @Inject constructor(
             lastPersistedSnapshotTrackId = null
             lastPersistedSnapshotPositionMs = 0
             lastPersistedSnapshotElapsedMs = 0L
-            scope.launch(Dispatchers.IO) {
-                sessionPreferences.clearCachedNavidromePlayback()
-            }
+            clearCachedNavidromePlayback("queue_empty")
             return
         }
         val state = mutableState.value
@@ -990,6 +1081,10 @@ class NavidromePlayerController @Inject constructor(
         lastPersistedSnapshotTrackId = currentTrackId
         lastPersistedSnapshotPositionMs = currentPositionMs
         lastPersistedSnapshotElapsedMs = nowElapsedMs
+        logPlaybackTrace(
+            "playback_snapshot_saved index=$currentIndex position_ms=$currentPositionMs queue_size=${queueTracks.size} " +
+                "force=$force is_playing=${state.isPlaying}"
+        )
         scope.launch(Dispatchers.IO) {
             val sessionKey = navidromeRepository.currentPlaybackSessionKey()
             sessionPreferences.setCachedNavidromePlayback(
@@ -1004,17 +1099,20 @@ class NavidromePlayerController @Inject constructor(
         scope.launch(Dispatchers.IO) {
             val cachedSnapshot = sessionPreferences.getCachedNavidromePlayback()
                 ?: return@launch
+            logPlaybackTrace(
+                "playback_snapshot_restore_found has_session_key=${cachedSnapshot.sessionKey != null} payload_bytes=${cachedSnapshot.payload.length}"
+            )
             val restoreGeneration = restorePlaybackGeneration
             val currentSessionKey = navidromeRepository.currentPlaybackSessionKey()
             if (cachedSnapshot.sessionKey.isNullOrBlank()) {
-                sessionPreferences.clearCachedNavidromePlayback()
+                clearCachedNavidromePlayback("restore_missing_session_key")
                 return@launch
             }
             if (
                 currentSessionKey != null &&
                 cachedSnapshot.sessionKey != currentSessionKey
             ) {
-                sessionPreferences.clearCachedNavidromePlayback()
+                clearCachedNavidromePlayback("restore_session_mismatch")
                 return@launch
             }
             val snapshot = cachedSnapshot.payload
@@ -1024,7 +1122,7 @@ class NavidromePlayerController @Inject constructor(
                 is com.stillshelf.app.core.util.AppResult.Success -> result.value
                 is com.stillshelf.app.core.util.AppResult.Error -> {
                     if (snapshot.queue.any { it.streamUrl.isBlank() && !it.isRadioTrack() }) {
-                        sessionPreferences.clearCachedNavidromePlayback()
+                        clearCachedNavidromePlayback("restore_refresh_missing_stream_url")
                         return@launch
                     }
                     snapshot.queue
@@ -1035,9 +1133,12 @@ class NavidromePlayerController @Inject constructor(
                 is com.stillshelf.app.core.util.AppResult.Error -> snapshot.recentTracks
             }
             if (refreshedQueue.isEmpty()) {
-                sessionPreferences.clearCachedNavidromePlayback()
+                clearCachedNavidromePlayback("restore_refresh_empty")
                 return@launch
             }
+            logPlaybackTrace(
+                "playback_snapshot_restore_ready queue_size=${refreshedQueue.size} recent_size=${refreshedRecent.size}"
+            )
             scope.launch(Dispatchers.Main.immediate) {
                 if (
                     restoreGeneration != restorePlaybackGeneration ||
@@ -1055,6 +1156,10 @@ class NavidromePlayerController @Inject constructor(
                 lastPersistedSnapshotTrackId = currentTrack?.id
                 lastPersistedSnapshotPositionMs = if (currentTrack.isRadioTrack()) 0 else snapshot.positionMs
                 lastPersistedSnapshotElapsedMs = SystemClock.elapsedRealtime()
+                logPlaybackTrace(
+                    "playback_snapshot_restored index=$restoredIndex position_ms=${if (currentTrack.isRadioTrack()) 0 else snapshot.positionMs} " +
+                        "queue_size=${refreshedQueue.size}"
+                )
                 mutableState.value = mutableState.value.copy(
                     queue = refreshedQueue,
                     queueDisplayMode = snapshot.queueDisplayMode,
@@ -1576,6 +1681,10 @@ class NavidromePlayerController @Inject constructor(
 
     private fun refreshAudioOutputDevices(reason: OutputRefreshReason) {
         val available = queryOutputDevices()
+        logPlaybackTrace(
+            "audio_output_refresh reason=${describeOutputRefreshReason(reason)} available_count=${available.size} " +
+                "has_explicit_selection=$hasExplicitOutputSelection"
+        )
         val availableIds = available.mapNotNull { it.id }.toSet()
         val bluetoothOutputId = available.firstOrNull { output ->
             val displayedId = output.id ?: return@firstOrNull false
@@ -1623,6 +1732,10 @@ class NavidromePlayerController @Inject constructor(
             selectedOutputDeviceId = displayedSelectionId
         )
         lastKnownOutputDeviceIds = availableIds
+        logPlaybackTrace(
+            "audio_output_refresh_applied reason=${describeOutputRefreshReason(reason)} selected_output=${preferredOutputDeviceId != null} " +
+                "available_count=${available.size}"
+        )
     }
 
     private fun queryOutputDevices(): List<NavidromeOutputDevice> {

--- a/app/src/main/java/com/stillshelf/app/ui/components/MiniPlayerBar.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/components/MiniPlayerBar.kt
@@ -152,6 +152,7 @@ fun MiniPlayerBar(
 
             IconButton(
                 onClick = onPlayPause,
+                enabled = !state.isLoading,
                 modifier = Modifier
                     .width(actionButtonWidth)
                     .height(actionButtonHeight)
@@ -163,11 +164,19 @@ fun MiniPlayerBar(
                         .background(MaterialTheme.colorScheme.onSurface),
                     contentAlignment = Alignment.Center
                 ) {
-                    Icon(
-                        imageVector = if (state.isPlaying) Icons.Outlined.Pause else Icons.Filled.PlayArrow,
-                        contentDescription = if (state.isPlaying) "Pause" else "Play",
-                        tint = MaterialTheme.colorScheme.surface
-                    )
+                    if (state.isLoading) {
+                        PlaybackLoadingIndicator(
+                            modifier = Modifier.size(18.dp),
+                            baseTint = MaterialTheme.colorScheme.surface.copy(alpha = 0.26f),
+                            sweepTint = MaterialTheme.colorScheme.surface
+                        )
+                    } else {
+                        Icon(
+                            imageVector = if (state.isPlaying) Icons.Outlined.Pause else Icons.Filled.PlayArrow,
+                            contentDescription = if (state.isPlaying) "Pause" else "Play",
+                            tint = MaterialTheme.colorScheme.surface
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/stillshelf/app/ui/navigation/MainNavGraph.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/navigation/MainNavGraph.kt
@@ -48,6 +48,7 @@ import androidx.navigation.navArgument
 import com.stillshelf.app.ui.components.MiniPlayerViewModel
 import com.stillshelf.app.ui.components.RootScaffold
 import com.stillshelf.app.ui.screens.AboutScreen
+import com.stillshelf.app.ui.screens.AdvancedScreen
 import com.stillshelf.app.ui.screens.AuthorsBrowseScreen
 import com.stillshelf.app.ui.screens.AuthorDetailScreen
 import com.stillshelf.app.ui.screens.BookDetailScreen
@@ -193,6 +194,7 @@ private fun MainShell(
         currentRoute != MainTab.Settings.route &&
         currentRoute != MainRoute.SETTINGS &&
         currentRoute != MainRoute.ABOUT &&
+        currentRoute != MainRoute.ADVANCED &&
         currentRoute != MainRoute.SERVERS &&
         currentRoute != MainRoute.LIBRARY_PICKER &&
         currentRoute?.startsWith("auth/") != true
@@ -223,7 +225,8 @@ private fun MainShell(
                 paddingValues = paddingValues,
                 navController = tabsNavController,
                 onHomeClick = screenHomeClick,
-                onOpenSelectedBook = ::handleBookSelection
+                onOpenSelectedBook = ::handleBookSelection,
+                onPlayContinueListening = playerViewModel::openPlayer
             )
         }
 
@@ -274,7 +277,8 @@ private fun MainTabsNavHost(
     paddingValues: PaddingValues,
     navController: androidx.navigation.NavHostController,
     onHomeClick: (() -> Unit)?,
-    onOpenSelectedBook: (String?, Double?) -> Unit
+    onOpenSelectedBook: (String?, Double?) -> Unit,
+    onPlayContinueListening: (String) -> Unit
 ) {
     NavHost(
         navController = navController,
@@ -327,6 +331,7 @@ private fun MainTabsNavHost(
                         launchSingleTop = true
                     }
                 },
+                onPlayContinueListening = onPlayContinueListening,
                 onOpenPlayer = { bookId ->
                     onOpenSelectedBook(bookId, null)
                 }
@@ -385,6 +390,11 @@ private fun MainTabsNavHost(
             SettingsScreen(
                 onBackClick = { navController.popBackStack() },
                 onHomeClick = onHomeClick,
+                onOpenAdvanced = {
+                    navController.navigate(MainRoute.ADVANCED) {
+                        launchSingleTop = true
+                    }
+                },
                 onOpenAbout = {
                     navController.navigate(MainRoute.ABOUT) {
                         launchSingleTop = true
@@ -401,6 +411,11 @@ private fun MainTabsNavHost(
             SettingsScreen(
                 onBackClick = { navController.popBackStack() },
                 onHomeClick = onHomeClick,
+                onOpenAdvanced = {
+                    navController.navigate(MainRoute.ADVANCED) {
+                        launchSingleTop = true
+                    }
+                },
                 onOpenAbout = {
                     navController.navigate(MainRoute.ABOUT) {
                         launchSingleTop = true
@@ -415,6 +430,12 @@ private fun MainTabsNavHost(
         }
         composable(MainRoute.ABOUT) {
             AboutScreen(
+                onBackClick = { navController.popBackStack() },
+                onHomeClick = onHomeClick
+            )
+        }
+        composable(MainRoute.ADVANCED) {
+            AdvancedScreen(
                 onBackClick = { navController.popBackStack() },
                 onHomeClick = onHomeClick
             )

--- a/app/src/main/java/com/stillshelf/app/ui/navigation/NavRoutes.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/navigation/NavRoutes.kt
@@ -30,6 +30,7 @@ object MainRoute {
     const val CUSTOMIZE = "main/customize"
     const val SETTINGS = "main/settings"
     const val ABOUT = "main/settings/about"
+    const val ADVANCED = "main/settings/advanced"
     const val PLAYER = "main/player"
     const val PLAYER_BOOK_ID_ARG = "bookId"
     const val PLAYER_START_SECONDS_ARG = "startSeconds"
@@ -127,6 +128,82 @@ enum class MainTab(val route: String, val label: String) {
         fun fromRoute(route: String?): MainTab {
             return entries.firstOrNull { it.route == route } ?: Home
         }
+    }
+}
+
+internal fun resolveSafeScreenArea(route: String?): String {
+    val rawRoute = route?.trim().orEmpty()
+    if (rawRoute.isBlank()) return "unknown"
+
+    return when {
+        rawRoute == GraphRoute.BACKEND_SELECTOR -> "backend_selector"
+        rawRoute == GraphRoute.AUTH -> "auth_graph"
+        rawRoute == GraphRoute.MAIN -> "main_graph"
+        rawRoute == GraphRoute.NAVIDROME_AUTH -> "navidrome_auth"
+        rawRoute == GraphRoute.NAVIDROME -> "navidrome_graph"
+
+        rawRoute == MainRoute.SHELL -> "main_shell"
+        rawRoute == MainRoute.CUSTOMIZE -> "customize"
+        rawRoute == MainRoute.SETTINGS -> "settings"
+        rawRoute == MainRoute.ABOUT -> "about"
+        rawRoute == MainRoute.ADVANCED -> "advanced"
+        rawRoute == MainRoute.PLAYER || rawRoute.startsWith("main/player") -> "player"
+        rawRoute == MainRoute.SERVERS -> "servers"
+        rawRoute == MainRoute.LIBRARY_PICKER -> "library_picker"
+
+        rawRoute == MainTab.Home.route -> "home"
+        rawRoute == MainTab.Browse.route -> "browse"
+        rawRoute == MainTab.Search.route -> "search"
+        rawRoute == MainTab.Downloads.route -> "downloads"
+        rawRoute == MainTab.Settings.route -> "settings_tab"
+
+        rawRoute == BrowseRoute.BOOKS -> "browse_books"
+        rawRoute == BrowseRoute.AUTHORS -> "browse_authors"
+        rawRoute == BrowseRoute.NARRATORS -> "browse_narrators"
+        rawRoute == BrowseRoute.SERIES -> "browse_series"
+        rawRoute == BrowseRoute.COLLECTIONS -> "browse_collections"
+        rawRoute == BrowseRoute.GENRES -> "browse_genres"
+        rawRoute == BrowseRoute.BOOKMARKS -> "browse_bookmarks"
+        rawRoute == BrowseRoute.PLAYLISTS -> "browse_playlists"
+        rawRoute == BrowseRoute.DOWNLOADED -> "browse_downloaded"
+
+        rawRoute == AuthRoute.SERVERS -> "auth_servers"
+        rawRoute == AuthRoute.ADD_SERVER -> "auth_add_server"
+        rawRoute == AuthRoute.LIBRARY_PICKER -> "auth_library_picker"
+        rawRoute.startsWith("auth/login") -> "auth_login"
+
+        rawRoute == NavidromeRoute.LOGIN -> "navidrome_login"
+        rawRoute == NavidromeRoute.HOME -> "navidrome_home"
+        rawRoute == NavidromeRoute.LIBRARY -> "navidrome_library"
+        rawRoute == NavidromeRoute.ARTISTS -> "navidrome_artists"
+        rawRoute == NavidromeRoute.ALBUMS -> "navidrome_albums"
+        rawRoute == NavidromeRoute.NEWEST_ALBUMS -> "navidrome_newest_albums"
+        rawRoute == NavidromeRoute.RADIOS -> "navidrome_radios"
+        rawRoute == NavidromeRoute.SONGS -> "navidrome_songs"
+        rawRoute == NavidromeRoute.DOWNLOADED -> "navidrome_downloaded"
+        rawRoute == NavidromeRoute.FAVORITES -> "navidrome_favorites"
+        rawRoute == NavidromeRoute.PLAYLISTS -> "navidrome_playlists"
+        rawRoute == NavidromeRoute.SEARCH -> "navidrome_search"
+        rawRoute == NavidromeRoute.SETTINGS -> "navidrome_settings"
+        rawRoute == NavidromeRoute.EQUALIZER -> "navidrome_equalizer"
+        rawRoute == NavidromeRoute.LYRICS_SOURCES -> "navidrome_lyrics_sources"
+        rawRoute == NavidromeRoute.SERVERS -> "navidrome_servers"
+        rawRoute == NavidromeRoute.CUSTOMIZE -> "navidrome_customize"
+        rawRoute.startsWith("navidrome/playlist/") -> "navidrome_playlist_detail"
+        rawRoute.startsWith("navidrome/artist/") -> "navidrome_artist_detail"
+        rawRoute.startsWith("navidrome/album/") -> "navidrome_album_detail"
+
+        rawRoute.startsWith("main/browse/") -> "browse_area"
+        rawRoute.startsWith("main/book/") -> "book_detail"
+        rawRoute.startsWith("main/author/") -> "author_detail"
+        rawRoute.startsWith("main/narrator/") -> "narrator_detail"
+        rawRoute.startsWith("main/series/") || rawRoute.startsWith("main/subseries/") -> "series_detail"
+        rawRoute.startsWith("main/genre/") -> "genre_detail"
+        rawRoute.startsWith("main/collection/") -> "collection_detail"
+        rawRoute.startsWith("main/playlist/") -> "playlist_detail"
+        rawRoute.startsWith("main/") -> "main_area"
+
+        else -> "unknown"
     }
 }
 

--- a/app/src/main/java/com/stillshelf/app/ui/navigation/RootNavGraph.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/navigation/RootNavGraph.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.composable
 import com.stillshelf.app.core.model.BackendProvider
 import com.stillshelf.app.ui.screens.BackendSelectionScreen
@@ -67,6 +68,8 @@ fun RootNavGraph(
 
     key(startGraph) {
         val navController = rememberNavController()
+        val currentBackStackEntry by navController.currentBackStackEntryAsState()
+        val currentRoute = currentBackStackEntry?.destination?.route
         NavHost(
             navController = navController,
             startDestination = startGraph,

--- a/app/src/main/java/com/stillshelf/app/ui/navigation/RootViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/navigation/RootViewModel.kt
@@ -2,6 +2,7 @@ package com.stillshelf.app.ui.navigation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.stillshelf.app.core.diagnostics.DiagnosticLogManager
 import com.stillshelf.app.core.datastore.SecureTokenStorage
 import com.stillshelf.app.core.datastore.SessionPreferences
 import com.stillshelf.app.core.model.BackendProvider
@@ -28,7 +29,8 @@ class RootViewModel @Inject constructor(
     private val sessionPreferences: SessionPreferences,
     private val secureTokenStorage: SecureTokenStorage,
     private val playbackController: Lazy<PlaybackController>,
-    private val navidromePlayerController: Lazy<NavidromePlayerController>
+    private val navidromePlayerController: Lazy<NavidromePlayerController>,
+    private val diagnosticLogManager: DiagnosticLogManager
 ) : ViewModel() {
 
     private val selectedBackendFlow = sessionPreferences.state
@@ -93,6 +95,7 @@ class RootViewModel @Inject constructor(
 
     fun selectBackend(provider: BackendProvider) {
         viewModelScope.launch {
+            diagnosticLogManager.logLifecycle("Session", "backend_selected=${provider.storageValue}")
             if (provider != BackendProvider.NAVIDROME) {
                 navidromePlayerController.get().stop()
             }
@@ -105,6 +108,7 @@ class RootViewModel @Inject constructor(
 
     fun clearSelectedBackend() {
         viewModelScope.launch {
+            diagnosticLogManager.logLifecycle("Session", "backend_selection_cleared")
             playbackController.get().stop()
             navidromePlayerController.get().stop()
             sessionPreferences.setSelectedBackend(null)

--- a/app/src/main/java/com/stillshelf/app/ui/screens/DiagnosticLogsSettings.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/DiagnosticLogsSettings.kt
@@ -1,0 +1,455 @@
+package com.stillshelf.app.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.Button
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ChevronRight
+import androidx.compose.material3.Surface
+import java.io.File
+
+@Composable
+fun DiagnosticLogsSettingsCard(
+    enabled: Boolean,
+    hasLogs: Boolean,
+    actionsExpanded: Boolean,
+    onEnabledChange: (Boolean) -> Unit,
+    onActionsExpandedChange: (Boolean) -> Unit,
+    onShowLogsClick: () -> Unit,
+    onExportClick: () -> Unit,
+    onShareClick: () -> Unit,
+    onOpenIssuesClick: () -> Unit,
+    onDeleteClick: () -> Unit,
+    onSeeWhatCollectedClick: () -> Unit,
+    containerColor: Color,
+    border: androidx.compose.foundation.BorderStroke?
+) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = containerColor),
+        shape = RoundedCornerShape(18.dp),
+        border = border
+    ) {
+        Column {
+            DiagnosticLogToggleRow(
+                enabled = enabled,
+                onEnabledChange = onEnabledChange
+            )
+            if (enabled || hasLogs) {
+                HorizontalDivider()
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                ) {
+                    DiagnosticLogsActionsHeaderRow(
+                        enabled = enabled,
+                        hasLogs = hasLogs,
+                        expanded = actionsExpanded,
+                        onShowLogsClick = onShowLogsClick,
+                        onClick = { onActionsExpandedChange(!actionsExpanded) }
+                    )
+                    AnimatedVisibility(visible = actionsExpanded) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 14.dp, vertical = 12.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        )
+                        {
+                            OutlinedButton(
+                                onClick = onSeeWhatCollectedClick,
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Text("See what is being collected")
+                            }
+                            if (hasLogs) {
+                                Text(
+                                    text = "When you have logs, you can choose a file to export or share, delete old logs, or open GitHub Issues.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                Button(
+                                    onClick = onExportClick,
+                                    modifier = Modifier.fillMaxWidth()
+                                ) {
+                                    Text("Export diagnostic log")
+                                }
+                                OutlinedButton(
+                                    onClick = onShareClick,
+                                    modifier = Modifier.fillMaxWidth()
+                                ) {
+                                    Text("Share diagnostic log")
+                                }
+                                OutlinedButton(
+                                    onClick = onOpenIssuesClick,
+                                    modifier = Modifier.fillMaxWidth()
+                                ) {
+                                    Text("Open GitHub Issues")
+                                }
+                                Button(
+                                    onClick = onDeleteClick,
+                                    modifier = Modifier.fillMaxWidth(),
+                                    colors = ButtonDefaults.buttonColors(
+                                        containerColor = MaterialTheme.colorScheme.error,
+                                        contentColor = MaterialTheme.colorScheme.onError
+                                    )
+                                ) {
+                                    Text("Delete diagnostic logs")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DiagnosticLogToggleRow(
+    enabled: Boolean,
+    onEnabledChange: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 14.dp, vertical = 10.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = "Enable diagnostic logs",
+                style = MaterialTheme.typography.titleMedium
+            )
+            Text(
+                text = "Stores local diagnostic logs to help troubleshoot crashes and playback issues.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Switch(
+            checked = enabled,
+            onCheckedChange = onEnabledChange
+        )
+    }
+}
+
+@Composable
+private fun DiagnosticLogsActionsHeaderRow(
+    enabled: Boolean,
+    hasLogs: Boolean,
+    expanded: Boolean,
+    onShowLogsClick: () -> Unit,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+                .clickable(enabled = enabled || hasLogs) { onClick() }
+                .padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = if (enabled) "Diagnostic log actions" else "Saved logs available",
+                style = MaterialTheme.typography.titleSmall
+            )
+            Text(
+                text = if (enabled) {
+                    "Tap to hide or show log actions."
+                } else {
+                    "Tap to export or share old logs."
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        if (hasLogs) {
+            TextButton(onClick = onShowLogsClick) {
+                Text("Show logs")
+            }
+        }
+        if (!enabled && hasLogs) {
+            Surface(
+                shape = RoundedCornerShape(999.dp),
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.14f)
+            ) {
+                Text(
+                    text = "Saved",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+                )
+            }
+        }
+        Icon(
+            imageVector = Icons.Outlined.ChevronRight,
+            contentDescription = null,
+            modifier = Modifier
+                .padding(start = 8.dp)
+                .graphicsLayer {
+                    rotationZ = if (expanded) 90f else 0f
+                }
+        )
+    }
+}
+
+@Composable
+fun DiagnosticLogsBrowserDialog(
+    logFiles: List<File>,
+    onOpenLogClick: (File) -> Unit,
+    onExportLogClick: (File) -> Unit,
+    onShareLogClick: (File) -> Unit,
+    onDeleteLogClick: (File) -> Unit,
+    onDismissRequest: () -> Unit
+) {
+    val scrollState = rememberScrollState()
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text("Saved logs") },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(scrollState),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(
+                    text = "These logs are stored in the app's private storage. Tap Open to view one in a popup window, or choose Export/Share on the file you want.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                if (logFiles.isEmpty()) {
+                    Text(
+                        text = "No log files are available.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                } else {
+                    logFiles.forEach { file ->
+                        Card(
+                            colors = CardDefaults.cardColors(
+                                containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+                            ),
+                            shape = RoundedCornerShape(14.dp)
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(12.dp),
+                                verticalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                Text(
+                                    text = file.name,
+                                    style = MaterialTheme.typography.titleSmall
+                                )
+                                Text(
+                                    text = "Saved locally. ${formatLogFileSize(file.length())}",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                Button(
+                                    onClick = { onOpenLogClick(file) },
+                                    modifier = Modifier.fillMaxWidth()
+                                ) {
+                                    Text("Open")
+                                }
+                                OutlinedButton(
+                                    onClick = { onExportLogClick(file) },
+                                    modifier = Modifier.fillMaxWidth()
+                                ) {
+                                    Text("Export")
+                                }
+                                OutlinedButton(
+                                    onClick = { onShareLogClick(file) },
+                                    modifier = Modifier.fillMaxWidth()
+                                ) {
+                                    Text("Share")
+                                }
+                                Button(
+                                    onClick = { onDeleteLogClick(file) },
+                                    modifier = Modifier.fillMaxWidth(),
+                                    colors = ButtonDefaults.buttonColors(
+                                        containerColor = MaterialTheme.colorScheme.error,
+                                        contentColor = MaterialTheme.colorScheme.onError
+                                    )
+                                ) {
+                                    Text("Delete")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text("Close")
+            }
+        }
+    )
+}
+
+@Composable
+fun DiagnosticLogViewerDialog(
+    title: String,
+    content: String,
+    onDismissRequest: () -> Unit
+) {
+    val scrollState = rememberScrollState()
+    LaunchedEffect(content) {
+        withFrameNanos { }
+        scrollState.scrollTo(scrollState.maxValue)
+    }
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text(title) },
+        text = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 420.dp)
+                    .verticalScroll(scrollState)
+            ) {
+                SelectionContainer {
+                    Text(
+                        text = content.ifBlank { "The log file is empty." },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text("Close")
+            }
+        }
+    )
+}
+
+@Composable
+fun DiagnosticLogsCollectedInfoDialog(
+    onDismissRequest: () -> Unit
+) {
+    val scrollState = rememberScrollState()
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text("What is collected") },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(scrollState),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(
+                    text = "Stores local diagnostic logs on this device to help troubleshoot crashes, playback issues, and network or cache problems. Logs are never uploaded automatically.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                SectionText(
+                    title = "What’s included in logs:",
+                    items = listOf(
+                        "Timestamps for each log entry",
+                        "App version",
+                        "Android version",
+                        "Device model",
+                        "Backend in use (Audiobookshelf or Navidrome)",
+                        "Random session ID",
+                        "Lifecycle and app events such as backend changes, app foreground/background changes, update checks, sync actions, and cache clear events",
+                        "Error messages and crash stack traces",
+                        "Playback command traces (play, pause, seek, next/previous)",
+                        "Playback state transitions (e.g. buffering, ready, idle, ended)",
+                        "Audio focus changes and output-route changes",
+                        "Home feed cache hits and misses",
+                        "Content and detail cache clear events",
+                        "Playback snapshot save, restore, and clear events",
+                        "Network error types (without URLs, headers, or tokens)"
+                    )
+                )
+                SectionText(
+                    title = "What is NOT collected:",
+                    items = listOf(
+                        "Usernames or passwords",
+                        "Auth tokens or API keys",
+                        "Server URLs or IP addresses",
+                        "Email addresses",
+                        "Media names (books, songs, authors, albums)",
+                        "File paths or library names",
+                        "Request/response bodies, headers, or cookies"
+                    )
+                )
+                Text(
+                    text = "Sensitive data is not collected. In the unlikely event that any is captured (e.g. due to a bug), it is automatically redacted or hashed before being written.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text("Close")
+            }
+        }
+    )
+}
+
+@Composable
+private fun SectionText(
+    title: String,
+    items: List<String>
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleSmall
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            items.forEach { item ->
+                Text(
+                    text = "• $item",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+private fun formatLogFileSize(sizeBytes: Long): String {
+    if (sizeBytes <= 0L) return "Unknown size"
+    return when {
+        sizeBytes < 1024L -> "$sizeBytes B"
+        sizeBytes < 1024L * 1024L -> String.format(java.util.Locale.US, "%.1f KB", sizeBytes / 1024.0)
+        else -> String.format(java.util.Locale.US, "%.1f MB", sizeBytes / (1024.0 * 1024.0))
+    }
+}

--- a/app/src/main/java/com/stillshelf/app/ui/screens/MainScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/MainScreens.kt
@@ -3,9 +3,13 @@ package com.stillshelf.app.ui.screens
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
+import android.content.Intent
 import android.graphics.Bitmap
+import android.net.Uri
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
@@ -199,6 +203,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.core.graphics.drawable.toBitmap
+import androidx.core.content.FileProvider
 import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
 import coil.compose.SubcomposeAsyncImage
@@ -241,6 +246,7 @@ import com.stillshelf.app.ui.navigation.MainTab
 import com.stillshelf.app.ui.theme.AppThemeMode
 import com.stillshelf.app.ui.theme.LocalMaterialDesignEnabled
 import java.io.File
+import java.io.RandomAccessFile
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -416,6 +422,7 @@ fun HomeScreen(
     onOpenBook: (String) -> Unit = {},
     onOpenSeries: (String) -> Unit = {},
     onOpenAuthor: (String) -> Unit = {},
+    onPlayContinueListening: (String) -> Unit = {},
     onOpenPlayer: (String?) -> Unit = {},
     onHomeClick: (() -> Unit)? = null,
     viewModel: HomeViewModel = hiltViewModel(),
@@ -1007,7 +1014,7 @@ fun HomeScreen(
                                                 posterHeight = continueListeningPosterHeight,
                                                 isDownloaded = uiState.downloadedBookIds.containsDownloadedBook(item.book),
                                                 downloadProgressPercent = uiState.downloadProgressByBookId.downloadProgressForBook(item.book),
-                                                onClick = { onOpenPlayer(item.book.id) },
+                                                onClick = { onPlayContinueListening(item.book.id) },
                                                 onGoToBook = { onOpenBook(item.book.id) },
                                                 onAddToCollection = { addToListBookId = item.book.id },
                                                 onMarkFinished = {
@@ -4759,6 +4766,7 @@ fun DownloadsScreen(
 @Composable
 fun SettingsScreen(
     onManageServers: () -> Unit = {},
+    onOpenAdvanced: () -> Unit = {},
     onOpenAbout: () -> Unit = {},
     onBackClick: (() -> Unit)? = null,
     onHomeClick: (() -> Unit)? = null,
@@ -4968,6 +4976,11 @@ fun SettingsScreen(
             }
         }
 
+        Text(
+            text = "SERVERS MANAGEMENT",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
         Card(
             colors = CardDefaults.cardColors(containerColor = sectionCardColor),
             shape = RoundedCornerShape(18.dp),
@@ -4995,6 +5008,23 @@ fun SettingsScreen(
                     infoMessage = null
                     signOutDialogVisible = true
                 }
+            )
+        }
+        Text(
+            text = "ADVANCED",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Card(
+            colors = CardDefaults.cardColors(containerColor = sectionCardColor),
+            shape = RoundedCornerShape(18.dp),
+            border = sectionCardBorder
+        ) {
+            SettingsRow(
+                title = "Advanced",
+                value = "Diagnostic logs",
+                trailingContentWidth = 144.dp,
+                onClick = onOpenAdvanced
             )
         }
         Card(
@@ -5129,6 +5159,286 @@ fun SettingsScreen(
                     }
                 }
             )
+        }
+    }
+}
+
+@Composable
+fun AdvancedScreen(
+    onBackClick: (() -> Unit)? = null,
+    onHomeClick: (() -> Unit)? = null,
+    viewModel: SettingsViewModel = hiltViewModel()
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var deleteLogsDialogVisible by remember { mutableStateOf(false) }
+    var diagnosticInfoDialogVisible by remember { mutableStateOf(false) }
+    var diagnosticLogsBrowserVisible by remember { mutableStateOf(false) }
+    var diagnosticLogViewerVisible by remember { mutableStateOf(false) }
+    var diagnosticLogViewerTitle by remember { mutableStateOf("") }
+    var diagnosticLogViewerContent by remember { mutableStateOf("") }
+    var diagnosticActionsExpanded by rememberSaveable { mutableStateOf(false) }
+    var pendingExportLogFile by remember { mutableStateOf<File?>(null) }
+    var diagnosticLogsBrowserFiles by remember { mutableStateOf<List<File>>(emptyList()) }
+    val sectionCardColor = if (uiState.materialDesignEnabled) {
+        MaterialTheme.colorScheme.surfaceContainerHigh
+    } else {
+        MaterialTheme.colorScheme.surface
+    }
+    val sectionCardBorder = if (uiState.materialDesignEnabled) {
+        BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.42f))
+    } else {
+        null
+    }
+
+    fun shareDiagnosticLogFile(file: File) {
+        val shareUri = runCatching {
+            FileProvider.getUriForFile(
+                context,
+                "${context.packageName}.fileprovider",
+                file
+            )
+        }.getOrNull()
+        if (shareUri == null) {
+            Toast.makeText(context, "Unable to share diagnostic log.", Toast.LENGTH_SHORT).show()
+            return
+        }
+        val shareIntent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_STREAM, shareUri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        runCatching {
+            context.startActivity(Intent.createChooser(shareIntent, "Share diagnostic log"))
+        }.onFailure {
+            Toast.makeText(context, "Unable to share diagnostic log.", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    fun openDiagnosticLogsBrowser(logFiles: List<File>) {
+        if (logFiles.isEmpty()) {
+            Toast.makeText(context, "No diagnostic log available.", Toast.LENGTH_SHORT).show()
+            return
+        }
+        diagnosticLogsBrowserFiles = logFiles
+        diagnosticLogsBrowserVisible = true
+    }
+
+    fun deleteDiagnosticLogFile(file: File) {
+        scope.launch {
+            viewModel.deleteDiagnosticLog(file)
+            diagnosticLogsBrowserFiles = viewModel.diagnosticLogFiles()
+            if (diagnosticLogsBrowserFiles.isEmpty()) {
+                diagnosticLogsBrowserVisible = false
+            }
+            Toast.makeText(context, "Diagnostic log deleted.", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    fun openDiagnosticLogFile(file: File) {
+        scope.launch {
+            val content = runCatching {
+                withContext(Dispatchers.IO) {
+                    readDiagnosticLogPreview(file)
+                }
+            }.getOrElse {
+                Toast.makeText(context, "Unable to open diagnostic log.", Toast.LENGTH_SHORT).show()
+                return@launch
+            }
+            diagnosticLogsBrowserVisible = false
+            diagnosticLogViewerTitle = file.name
+            diagnosticLogViewerContent = content
+            diagnosticLogViewerVisible = true
+        }
+    }
+
+    LaunchedEffect(diagnosticLogsBrowserVisible) {
+        if (!diagnosticLogsBrowserVisible) return@LaunchedEffect
+        while (true) {
+            diagnosticLogsBrowserFiles = viewModel.diagnosticLogFiles()
+            delay(2_000)
+        }
+    }
+
+    val exportLogLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument("text/plain")
+    ) { destinationUri ->
+        val sourceFile = pendingExportLogFile ?: return@rememberLauncherForActivityResult
+        pendingExportLogFile = null
+        if (destinationUri == null) return@rememberLauncherForActivityResult
+        runCatching {
+            context.contentResolver.openOutputStream(destinationUri)?.use { output ->
+                sourceFile.inputStream().use { input ->
+                    input.copyTo(output)
+                }
+            } ?: error("Unable to open the destination file.")
+            Toast.makeText(context, "Diagnostic log exported.", Toast.LENGTH_SHORT).show()
+        }.onFailure {
+            Toast.makeText(context, "Unable to export diagnostic log.", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    fun launchDiagnosticLogExport(file: File) {
+        pendingExportLogFile = file
+        exportLogLauncher.launch(file.name)
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .navigationBarsPadding()
+            .padding(horizontal = AppScreenHorizontalPadding, vertical = 18.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp)
+    ) {
+        BackTitle(
+            title = "Advanced",
+            onBackClick = onBackClick,
+            onHomeClick = onHomeClick
+        )
+
+        Text(
+            text = "DIAGNOSTICS",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        DiagnosticLogsSettingsCard(
+            enabled = uiState.diagnosticLoggingEnabled,
+            hasLogs = uiState.hasDiagnosticLogs,
+            actionsExpanded = diagnosticActionsExpanded,
+            onEnabledChange = { enabled ->
+                viewModel.setDiagnosticLoggingEnabled(enabled)
+                diagnosticActionsExpanded = enabled
+            },
+            onActionsExpandedChange = { expanded ->
+                diagnosticActionsExpanded = expanded
+            },
+            onShowLogsClick = {
+                scope.launch {
+                    openDiagnosticLogsBrowser(viewModel.diagnosticLogFiles())
+                }
+            },
+            onExportClick = {
+                scope.launch {
+                    val logFiles = viewModel.diagnosticLogFiles()
+                    when (logFiles.size) {
+                        0 -> Toast.makeText(context, "No diagnostic log available.", Toast.LENGTH_SHORT).show()
+                        1 -> {
+                            val logFile = logFiles.first()
+                            launchDiagnosticLogExport(logFile)
+                        }
+                        else -> openDiagnosticLogsBrowser(logFiles)
+                    }
+                }
+            },
+            onShareClick = {
+                scope.launch {
+                    val logFiles = viewModel.diagnosticLogFiles()
+                    when (logFiles.size) {
+                        0 -> Toast.makeText(context, "No diagnostic log available.", Toast.LENGTH_SHORT).show()
+                        1 -> {
+                            val logFile = logFiles.first()
+                            shareDiagnosticLogFile(logFile)
+                        }
+                        else -> openDiagnosticLogsBrowser(logFiles)
+                    }
+                }
+            },
+            onOpenIssuesClick = {
+                runCatching {
+                    context.startActivity(
+                        Intent(
+                            Intent.ACTION_VIEW,
+                            Uri.parse("https://github.com/kalzEOS/stillshelf/issues/new")
+                        )
+                    )
+                }.onFailure {
+                    Toast.makeText(context, "Unable to open GitHub Issues.", Toast.LENGTH_SHORT).show()
+                }
+            },
+            onDeleteClick = {
+                deleteLogsDialogVisible = true
+            },
+            onSeeWhatCollectedClick = {
+                diagnosticInfoDialogVisible = true
+            },
+            containerColor = sectionCardColor,
+            border = sectionCardBorder
+        )
+
+        if (deleteLogsDialogVisible) {
+            AlertDialog(
+                onDismissRequest = { deleteLogsDialogVisible = false },
+                title = { Text("Delete diagnostic logs?") },
+                text = {
+                    Text(
+                        text = "This removes all saved local diagnostic log files from this device and turns diagnostic logging off."
+                    )
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            deleteLogsDialogVisible = false
+                            viewModel.deleteDiagnosticLogs()
+                            Toast.makeText(context, "Diagnostic logs deleted.", Toast.LENGTH_SHORT).show()
+                        }
+                    ) {
+                        Text("Delete")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { deleteLogsDialogVisible = false }) {
+                        Text("Cancel")
+                    }
+                }
+            )
+        }
+
+        if (diagnosticInfoDialogVisible) {
+            DiagnosticLogsCollectedInfoDialog(
+                onDismissRequest = { diagnosticInfoDialogVisible = false }
+            )
+        }
+
+        if (diagnosticLogsBrowserVisible) {
+            DiagnosticLogsBrowserDialog(
+                logFiles = diagnosticLogsBrowserFiles,
+                onOpenLogClick = ::openDiagnosticLogFile,
+                onExportLogClick = ::launchDiagnosticLogExport,
+                onShareLogClick = ::shareDiagnosticLogFile,
+                onDeleteLogClick = ::deleteDiagnosticLogFile,
+                onDismissRequest = { diagnosticLogsBrowserVisible = false }
+            )
+        }
+
+        if (diagnosticLogViewerVisible) {
+            DiagnosticLogViewerDialog(
+                title = diagnosticLogViewerTitle,
+                content = diagnosticLogViewerContent,
+                onDismissRequest = { diagnosticLogViewerVisible = false }
+            )
+        }
+    }
+}
+
+private fun readDiagnosticLogPreview(file: File): String {
+    val fileLength = file.length()
+    if (fileLength <= 0L) return "The log file is empty."
+    val previewBytes = 64 * 1024
+    if (fileLength <= previewBytes) {
+        return file.readText()
+    }
+    return RandomAccessFile(file, "r").use { raf ->
+        val start = (fileLength - previewBytes).coerceAtLeast(0L)
+        raf.seek(start)
+        val bytes = ByteArray((fileLength - start).toInt())
+        raf.readFully(bytes)
+        buildString {
+            append("Showing the last ")
+            append(previewBytes / 1024)
+            append(" KB of this log. Older content was trimmed.\n\n")
+            append(String(bytes, Charsets.UTF_8))
         }
     }
 }
@@ -5920,7 +6230,6 @@ fun ServersManagementScreen(
                 modifier = Modifier.weight(1f)
             )
         }
-
         Card(
             shape = RoundedCornerShape(24.dp),
             colors = CardDefaults.cardColors(containerColor = sectionCardColor),

--- a/app/src/main/java/com/stillshelf/app/ui/screens/SettingsViewModel.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.stillshelf.app.core.model.BackendProvider
 import com.stillshelf.app.BuildConfig
+import com.stillshelf.app.core.diagnostics.DiagnosticLogManager
 import com.stillshelf.app.core.datastore.SessionPreferences
 import com.stillshelf.app.core.model.EndpointReachabilityStatus
 import com.stillshelf.app.core.model.ServerConnectionRoute
@@ -16,6 +17,7 @@ import com.stillshelf.app.update.AppUpdateManager
 import com.stillshelf.app.update.AppUpdateRelease
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.net.URI
+import java.io.File
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -81,6 +83,8 @@ data class SettingsUiState(
     val appUpdatesEnabled: Boolean = BuildConfig.IN_APP_UPDATES_ENABLED,
     val updateCheckOnStartupEnabled: Boolean = true,
     val includePrereleaseUpdates: Boolean = false,
+    val diagnosticLoggingEnabled: Boolean = false,
+    val hasDiagnosticLogs: Boolean = false,
     val automaticServerSwitchingEnabled: Boolean = false,
     val lanServerUrl: String = "",
     val wanServerUrl: String = "",
@@ -99,14 +103,15 @@ class SettingsViewModel @Inject constructor(
     private val sessionRepository: SessionRepository,
     private val sessionPreferences: SessionPreferences,
     private val activeEndpointHealthMonitor: ActiveEndpointHealthMonitor,
-    private val appUpdateManager: AppUpdateManager
+    private val appUpdateManager: AppUpdateManager,
+    private val diagnosticLogManager: DiagnosticLogManager
 ) : ViewModel() {
     private val mutableUiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = mutableUiState.asStateFlow()
 
     init {
         viewModelScope.launch {
-            combine(
+            val baseStateFlow = combine(
                 sessionRepository.observeSessionState(),
                 sessionRepository.observeServers(),
                 sessionPreferences.state,
@@ -147,6 +152,8 @@ class SettingsViewModel @Inject constructor(
                         lastLibrarySyncAtMs = pref.lastLibrarySyncAtMs,
                         updateCheckOnStartupEnabled = pref.updateCheckOnStartup,
                         includePrereleaseUpdates = pref.updateIncludePrereleases,
+                        diagnosticLoggingEnabled = pref.diagnosticLoggingEnabled,
+                        hasDiagnosticLogs = false,
                         automaticServerSwitchingEnabled = switchingConfig.enabled,
                         lanServerUrl = switchingConfig.lanBaseUrl.orEmpty(),
                         wanServerUrl = switchingConfig.wanBaseUrl.orEmpty(),
@@ -180,6 +187,8 @@ class SettingsViewModel @Inject constructor(
                         lastLibrarySyncAtMs = pref.lastLibrarySyncAtMs,
                         updateCheckOnStartupEnabled = pref.updateCheckOnStartup,
                         includePrereleaseUpdates = pref.updateIncludePrereleases,
+                        diagnosticLoggingEnabled = pref.diagnosticLoggingEnabled,
+                        hasDiagnosticLogs = false,
                         automaticServerSwitchingEnabled = switchingConfig.enabled,
                         lanServerUrl = switchingConfig.lanBaseUrl.orEmpty(),
                         wanServerUrl = switchingConfig.wanBaseUrl.orEmpty(),
@@ -197,6 +206,10 @@ class SettingsViewModel @Inject constructor(
                         connectionLatencyMs = endpointHealth?.latencyMs
                     )
                 }
+            }
+
+            combine(baseStateFlow, diagnosticLogManager.state) { state, diagnosticState ->
+                state.copy(hasDiagnosticLogs = diagnosticState.hasLogs)
             }.collect { state ->
                 mutableUiState.update { previous ->
                     state.copy(
@@ -214,6 +227,10 @@ class SettingsViewModel @Inject constructor(
     fun onCheckForUpdatesClick() {
         if (!BuildConfig.IN_APP_UPDATES_ENABLED || uiState.value.isCheckingForUpdates) return
         viewModelScope.launch {
+            diagnosticLogManager.logLifecycle(
+                "Settings",
+                "update_check_started include_prereleases=${uiState.value.includePrereleaseUpdates}"
+            )
             mutableUiState.update {
                 it.copy(
                     isCheckingForUpdates = true,
@@ -229,6 +246,10 @@ class SettingsViewModel @Inject constructor(
             ) {
                 is AppResult.Success -> {
                     val update = result.value
+                    diagnosticLogManager.logLifecycle(
+                        "Settings",
+                        if (update == null) "update_check_completed no_update" else "update_check_completed update_found"
+                    )
                     mutableUiState.update {
                         it.copy(
                             isCheckingForUpdates = false,
@@ -239,6 +260,11 @@ class SettingsViewModel @Inject constructor(
                 }
 
                 is AppResult.Error -> {
+                    diagnosticLogManager.logWarning(
+                        tag = "Settings",
+                        message = "update_check_failed",
+                        throwable = result.cause
+                    )
                     mutableUiState.update {
                         it.copy(
                             isCheckingForUpdates = false,
@@ -279,6 +305,7 @@ class SettingsViewModel @Inject constructor(
     fun onSyncLibrariesClick() {
         if (uiState.value.isSyncingLibraries) return
         viewModelScope.launch {
+            diagnosticLogManager.logLifecycle("Settings", "library_sync_started")
             mutableUiState.update {
                 it.copy(
                     isSyncingLibraries = true,
@@ -290,6 +317,7 @@ class SettingsViewModel @Inject constructor(
                 is AppResult.Success -> {
                     val syncedAtMs = System.currentTimeMillis()
                     sessionPreferences.setLastLibrarySyncAtMs(syncedAtMs)
+                    diagnosticLogManager.logLifecycle("Settings", "library_sync_completed")
                     mutableUiState.update {
                         it.copy(
                             isSyncingLibraries = false,
@@ -301,6 +329,11 @@ class SettingsViewModel @Inject constructor(
                 }
 
                 is AppResult.Error -> {
+                    diagnosticLogManager.logWarning(
+                        tag = "Settings",
+                        message = "library_sync_failed",
+                        throwable = result.cause
+                    )
                     mutableUiState.update {
                         it.copy(
                             isSyncingLibraries = false,
@@ -317,6 +350,7 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             when (val result = sessionRepository.signOutActiveSession()) {
                 is AppResult.Success -> {
+                    diagnosticLogManager.logLifecycle("Settings", "signed_out")
                     mutableUiState.update {
                         it.copy(
                             errorMessage = null,
@@ -326,6 +360,11 @@ class SettingsViewModel @Inject constructor(
                 }
 
                 is AppResult.Error -> {
+                    diagnosticLogManager.logWarning(
+                        tag = "Settings",
+                        message = "sign_out_failed",
+                        throwable = result.cause
+                    )
                     mutableUiState.update { it.copy(errorMessage = result.message) }
                 }
             }
@@ -357,6 +396,27 @@ class SettingsViewModel @Inject constructor(
         if (!BuildConfig.IN_APP_UPDATES_ENABLED) return
         viewModelScope.launch {
             sessionPreferences.setUpdateIncludePrereleases(enabled)
+        }
+    }
+
+    fun setDiagnosticLoggingEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            sessionPreferences.setDiagnosticLoggingEnabled(enabled)
+        }
+    }
+
+    suspend fun latestDiagnosticLogFile() = diagnosticLogManager.latestLogFile()
+
+    suspend fun diagnosticLogFiles(): List<File> = diagnosticLogManager.logFiles()
+
+    suspend fun deleteDiagnosticLog(file: File) {
+        diagnosticLogManager.deleteLogFile(file)
+    }
+
+    fun deleteDiagnosticLogs() {
+        viewModelScope.launch {
+            sessionPreferences.setDiagnosticLoggingEnabled(false)
+            diagnosticLogManager.deleteLogs()
         }
     }
 

--- a/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
@@ -9910,17 +9910,6 @@ private fun NavidromeExpandedPlayerSheet(
     } else {
         Color.Transparent
     }
-    var showLoadingIndicator by remember { mutableStateOf(false) }
-    LaunchedEffect(state.isLoading) {
-        if (!state.isLoading) {
-            showLoadingIndicator = false
-            return@LaunchedEffect
-        }
-        delay(200)
-        if (state.isLoading) {
-            showLoadingIndicator = true
-        }
-    }
     val toolButtonContainerColor = if (immersiveEnabled) {
         Color.White.copy(alpha = 0.12f)
     } else {
@@ -9998,6 +9987,17 @@ private fun NavidromeExpandedPlayerSheet(
                 0f
             }
         )
+    }
+    var showLoadingIndicator by remember { mutableStateOf(false) }
+    LaunchedEffect(state.isLoading) {
+        if (!state.isLoading) {
+            showLoadingIndicator = false
+            return@LaunchedEffect
+        }
+        delay(200)
+        if (state.isLoading) {
+            showLoadingIndicator = true
+        }
     }
     BoxWithConstraints(
         modifier = Modifier
@@ -10205,7 +10205,7 @@ private fun NavidromeExpandedPlayerSheet(
                             .clickable(enabled = !state.isLoading, onClick = onPlayPause),
                         contentAlignment = Alignment.Center
                     ) {
-                        if (showLoadingIndicator) {
+                        if (state.isLoading && showLoadingIndicator) {
                             PlaybackLoadingIndicator(
                                 modifier = Modifier.size(transportIconSize),
                                 baseTint = if (transportButtonColor.luminance() > 0.5f) {

--- a/app/src/main/java/com/stillshelf/app/update/AppUpdateManager.kt
+++ b/app/src/main/java/com/stillshelf/app/update/AppUpdateManager.kt
@@ -4,6 +4,7 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import androidx.core.content.FileProvider
+import com.stillshelf.app.core.diagnostics.DiagnosticLogManager
 import com.stillshelf.app.core.datastore.SessionPreferences
 import com.stillshelf.app.core.util.AppResult
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -29,7 +30,8 @@ data class AppUpdateRelease(
 class AppUpdateManager @Inject constructor(
     @param:ApplicationContext private val appContext: Context,
     private val okHttpClient: OkHttpClient,
-    private val sessionPreferences: SessionPreferences
+    private val sessionPreferences: SessionPreferences,
+    private val diagnosticLogManager: DiagnosticLogManager
 ) {
     companion object {
         private const val RELEASES_API_URL = "https://api.github.com/repos/kalzEOS/stillshelf/releases"
@@ -47,6 +49,12 @@ class AppUpdateManager @Inject constructor(
                     .build()
                 okHttpClient.newCall(request).execute().use { response ->
                     if (!response.isSuccessful) {
+                        diagnosticLogManager.logNetworkError(
+                            tag = "AppUpdateManager",
+                            errorType = "http_${response.code}",
+                            method = "GET",
+                            httpStatusCode = response.code
+                        )
                         throw IllegalStateException("Unable to check updates (${response.code}).")
                     }
                     val responseBody = response.body?.string().orEmpty()
@@ -67,7 +75,14 @@ class AppUpdateManager @Inject constructor(
                 }
             }.fold(
                 onSuccess = { AppResult.Success(it) },
-                onFailure = { AppResult.Error(it.message ?: "Unable to check updates.", it) }
+                onFailure = { throwable ->
+                    diagnosticLogManager.logError(
+                        tag = "AppUpdateManager",
+                        message = "Unable to check updates.",
+                        throwable = throwable
+                    )
+                    AppResult.Error(throwable.message ?: "Unable to check updates.", throwable)
+                }
             )
         }
     }
@@ -95,6 +110,12 @@ class AppUpdateManager @Inject constructor(
                     .build()
                 okHttpClient.newCall(request).execute().use { response ->
                     if (!response.isSuccessful) {
+                        diagnosticLogManager.logNetworkError(
+                            tag = "AppUpdateManager",
+                            errorType = "http_${response.code}",
+                            method = "GET",
+                            httpStatusCode = response.code
+                        )
                         throw IllegalStateException("Download failed (${response.code}).")
                     }
                     val body = response.body ?: throw IllegalStateException("Download returned empty data.")
@@ -117,6 +138,11 @@ class AppUpdateManager @Inject constructor(
             }.fold(
                 onSuccess = { AppResult.Success(Unit) },
                 onFailure = { throwable ->
+                    diagnosticLogManager.logError(
+                        tag = "AppUpdateManager",
+                        message = "Unable to update app.",
+                        throwable = throwable
+                    )
                     AppResult.Error(throwable.message ?: "Unable to update app.", throwable)
                 }
             )

--- a/app/src/main/res/xml/update_file_paths.xml
+++ b/app/src/main/res/xml/update_file_paths.xml
@@ -3,4 +3,7 @@
     <cache-path
         name="update_cache"
         path="updates/" />
+    <files-path
+        name="diagnostic_logs"
+        path="diagnostic_logs/" />
 </paths>

--- a/app/src/test/java/com/stillshelf/app/core/diagnostics/DiagnosticLogSanitizerTest.kt
+++ b/app/src/test/java/com/stillshelf/app/core/diagnostics/DiagnosticLogSanitizerTest.kt
@@ -1,0 +1,62 @@
+package com.stillshelf.app.core.diagnostics
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DiagnosticLogSanitizerTest {
+    @Test
+    fun sanitizesSensitiveValuesInLogText() {
+        val raw = """
+            url=https://example.com/api/v1/books
+            server_url=http://10.0.0.5:8080
+            Authorization: Bearer abc123
+            Cookie: session=xyz789
+            email=user@example.com
+            ip=192.168.0.8
+            ipv6=2001:db8::1
+            resolver=Unable to resolve host invidious.lan: No address associated with hostname
+            resolver2=Unable to resolve host nas: No address associated with hostname
+            UnknownHostException: example.org
+            path=/data/user/0/com.stillshelf.app/files/cache.log
+            user_id=user-123
+            media title=The Hobbit
+        """.trimIndent()
+
+        val sanitized = DiagnosticLogSanitizer.sanitize(raw)
+
+        assertFalse(sanitized.contains("https://example.com"))
+        assertFalse(sanitized.contains("10.0.0.5"))
+        assertFalse(sanitized.contains("abc123"))
+        assertFalse(sanitized.contains("xyz789"))
+        assertFalse(sanitized.contains("user@example.com"))
+        assertFalse(sanitized.contains("192.168.0.8"))
+        assertFalse(sanitized.contains("2001:db8::1"))
+        assertFalse(sanitized.contains("invidious.lan"))
+        assertFalse(sanitized.contains("nas"))
+        assertFalse(sanitized.contains("example.org"))
+        assertFalse(sanitized.contains("/data/user/0/com.stillshelf.app/files/cache.log"))
+        assertFalse(sanitized.contains("user-123"))
+        assertFalse(sanitized.contains("The Hobbit"))
+        assertTrue(sanitized.contains("[REDACTED_URL]"))
+        assertTrue(sanitized.contains("[REDACTED_SERVER]"))
+        assertTrue(sanitized.contains("[REDACTED_TOKEN]"))
+        assertTrue(sanitized.contains("[REDACTED_EMAIL]"))
+        assertTrue(sanitized.contains("[REDACTED_IP]"))
+        assertTrue(sanitized.contains("[REDACTED_PATH]"))
+        assertTrue(sanitized.contains("[REDACTED_HOST]"))
+        assertTrue(sanitized.contains("[HASH:"))
+        assertTrue(sanitized.contains("[REDACTED_TITLE]"))
+    }
+
+    @Test
+    fun sanitizesThrowableMessagesAndStackTraces() {
+        val throwable = IllegalStateException("Request failed for https://example.com/api?token=abc123")
+
+        val sanitized = DiagnosticLogSanitizer.sanitizeThrowable(throwable)
+
+        assertFalse(sanitized.contains("https://example.com"))
+        assertFalse(sanitized.contains("abc123"))
+        assertTrue(sanitized.contains("[REDACTED_URL]"))
+    }
+}


### PR DESCRIPTION
## What changed
- Added a privacy-first diagnostic logging system with local-only storage, rotation, export/share, deletion, and an in-app log viewer.
- Added sanitizer/redactor coverage for tokens, URLs, emails, IPs, hostnames, IPv6, paths, titles, and user IDs.
- Added playback, lifecycle, cache, network, update, and backend/session diagnostic traces.
- Moved diagnostics into an Advanced settings page and updated the disclosure copy to match what is actually collected.

## Why
- To help troubleshoot crashes and playback stalls, especially on Navidrome, without uploading logs automatically or leaking sensitive data.

## Validation
- `rtk ./gradlew :app:compileGithubDebugKotlin`
- `rtk ./gradlew :app:testGithubDebugUnitTest --tests com.stillshelf.app.core.diagnostics.DiagnosticLogSanitizerTest`
- `rtk ./gradlew :app:testGithubDebugUnitTest` (full suite still has an existing unrelated `BooksBrowseViewModelTest` failure that is not part of this branch)