### PR TITLE
[codex] Navidrome playback recovery fix

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 92
-val appVersionName = "0.5.0"
+val appVersionCode = 93
+val appVersionName = "0.5.1"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
@@ -704,12 +704,13 @@ class NavidromePlayerController @Inject constructor(
             resumeFromSnapshot(playWhenReady = true)
             return
         }
-        if (activePlayer == null) {
+        if (shouldRecreatePlayerForTransportCommands(activePlayer)) {
             resumeFromSnapshot(playWhenReady = true)
             return
         }
-        if (activePlayer.isPlaying) return
-        activePlayer.play()
+        val confirmedPlayer = activePlayer ?: return
+        if (confirmedPlayer.isPlaying) return
+        confirmedPlayer.play()
         updateStateFromPlayer()
         persistPlaybackSnapshot(force = true)
         ensureProgressUpdates()
@@ -922,6 +923,7 @@ class NavidromePlayerController @Inject constructor(
                     forcedRemoteTrackIds += failedTrackId
                 }
                 if (refreshedQueue.isNullOrEmpty()) {
+                    releasePlayer(clearQueue = false)
                     clearCachedNavidromePlayback("error_refresh_failed")
                     mutableState.value = mutableState.value.copy(
                         errorMessage = error.message ?: "Playback failed for this track."
@@ -976,6 +978,10 @@ class NavidromePlayerController @Inject constructor(
             ?: -1
     }
 
+    private fun shouldRecreatePlayerForTransportCommands(activePlayer: ExoPlayer?): Boolean {
+        return activePlayer == null || activePlayer.playbackState == Player.STATE_IDLE
+    }
+
     private fun seekToQueueIndex(
         index: Int,
         positionMs: Int,
@@ -988,15 +994,16 @@ class NavidromePlayerController @Inject constructor(
                 "has_player=${player != null}"
         )
         val activePlayer = player
-        if (activePlayer == null) {
+        if (shouldRecreatePlayerForTransportCommands(activePlayer)) {
             startPlaybackAt(index = index, positionMs = safePositionMs, playWhenReady = playWhenReady)
             return
         }
-        activePlayer.seekTo(index, safePositionMs.toLong())
+        val confirmedPlayer = activePlayer ?: return
+        confirmedPlayer.seekTo(index, safePositionMs.toLong())
         if (playWhenReady) {
-            activePlayer.play()
+            confirmedPlayer.play()
         } else {
-            activePlayer.pause()
+            confirmedPlayer.pause()
         }
         mutableState.value = mutableState.value.copy(
             currentIndex = index,


### PR DESCRIPTION
## Summary
- Rebuilds the Navidrome player when transport commands hit an idle/broken ExoPlayer after a source error.
- Releases the dead player when Navidrome recovery cannot refresh the queue.
- Bumps the app to `0.5.1` / build `93`.

## Why
- Navidrome playback could stop after a fatal stream source error and then ignore play/next/previous until a different artist rebuilt playback.
- This keeps transport actions responsive after the failure instead of leaving the old player instance stuck.

## Validation
- `GRADLE_USER_HOME=/tmp/gradle ./gradlew :app:compileGithubDebugKotlin`