### PR TITLE
StillShelf v0.5.2: Navidrome playback cache lifecycle

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 93
-val appVersionName = "0.5.1"
+val appVersionCode = 94
+val appVersionName = "0.5.2"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/downloads/navidrome/NavidromeDownloadManager.kt
+++ b/app/src/main/java/com/stillshelf/app/downloads/navidrome/NavidromeDownloadManager.kt
@@ -61,7 +61,7 @@ class NavidromeDownloadManager @Inject constructor(
     val activeItems: Flow<List<NavidromeDownloadItem>> = combine(mutableItems, mutableActiveSelection) { items, selection ->
         items.filter { item ->
             item.serverId == selection.serverId && item.libraryId == selection.libraryId
-        }
+        }.filterNot { it.isPlaybackCache }
     }
 
     init {
@@ -91,7 +91,7 @@ class NavidromeDownloadManager @Inject constructor(
                 it.libraryId == selection.libraryId &&
                 it.trackId == track.id
         }
-        if (existing != null && existing.status != NavidromeDownloadStatus.Failed) {
+        if (existing != null && !existing.isPlaybackCache && existing.status != NavidromeDownloadStatus.Failed) {
             removeItem(existing)
             return@withLock AppResult.Success(
                 NavidromeDownloadToggleResult(
@@ -103,7 +103,8 @@ class NavidromeDownloadManager @Inject constructor(
         val newItem = enqueueTrack(
             selection = selection,
             track = track,
-            albumSongCount = albumSongCount
+            albumSongCount = albumSongCount,
+            isPlaybackCache = false
         ) ?: return@withLock AppResult.Error("Unable to queue this download.")
         replaceItems { items ->
             items.filterNot {
@@ -129,7 +130,11 @@ class NavidromeDownloadManager @Inject constructor(
             ?: return@withLock AppResult.Error("Select a Navidrome server first.")
         val normalizedTracks = tracks
             .distinctBy { it.id }
-            .filter { it.id.isNotBlank() && it.streamUrl.isNotBlank() }
+            .filter {
+                it.id.isNotBlank() &&
+                    it.streamUrl.isNotBlank() &&
+                    !it.id.startsWith("radio:")
+            }
         if (normalizedTracks.isEmpty()) {
             return@withLock AppResult.Error("Nothing to download.")
         }
@@ -138,7 +143,7 @@ class NavidromeDownloadManager @Inject constructor(
             .associateBy { it.trackId }
         val allAlreadyPresent = normalizedTracks.all { track ->
             val existing = existingByTrackId[track.id]
-            existing != null && existing.status != NavidromeDownloadStatus.Failed
+            existing != null && !existing.isPlaybackCache && existing.status != NavidromeDownloadStatus.Failed
         }
         if (allAlreadyPresent) {
             normalizedTracks.forEach { track ->
@@ -154,13 +159,14 @@ class NavidromeDownloadManager @Inject constructor(
 
         val newItems = normalizedTracks.mapNotNull { track ->
             val existing = existingByTrackId[track.id]
-            if (existing != null && existing.status != NavidromeDownloadStatus.Failed) {
+            if (existing != null && !existing.isPlaybackCache && existing.status != NavidromeDownloadStatus.Failed) {
                 null
             } else {
                 enqueueTrack(
                     selection = selection,
                     track = track,
-                    albumSongCount = track.albumId?.let(albumSongCountByAlbumId::get)
+                    albumSongCount = track.albumId?.let(albumSongCountByAlbumId::get),
+                    isPlaybackCache = false
                 )
             }
         }
@@ -242,6 +248,58 @@ class NavidromeDownloadManager @Inject constructor(
         )
     }
 
+    suspend fun prefetchPlaybackQueue(tracks: List<NavidromeTrack>): AppResult<Int> = mutex.withLock {
+        val selection = resolveActiveSelection()
+            ?: return@withLock AppResult.Error("Select a Navidrome server first.")
+        val normalizedTracks = tracks
+            .distinctBy { it.id }
+            .filter {
+                it.id.isNotBlank() &&
+                    it.streamUrl.isNotBlank() &&
+                    !it.id.startsWith("radio:")
+            }
+        if (normalizedTracks.isEmpty()) {
+            return@withLock AppResult.Success(0)
+        }
+
+        val existingByTrackId = mutableItems.value
+            .filter { it.serverId == selection.serverId && it.libraryId == selection.libraryId }
+            .associateBy { it.trackId }
+
+        val newItems = normalizedTracks.mapNotNull { track ->
+            val existing = existingByTrackId[track.id]
+            val needsDownload = existing == null ||
+                existing.status == NavidromeDownloadStatus.Failed ||
+                (existing.status == NavidromeDownloadStatus.Completed && localPlaybackUri(track) == null)
+            if (!needsDownload) {
+                null
+            } else {
+                enqueueTrack(
+                    selection = selection,
+                    track = track,
+                    // Warmup downloads are queue-scoped cache entries, so do not stamp album completion metadata.
+                    albumSongCount = null,
+                    isPlaybackCache = true
+                )
+            }
+        }
+
+        if (newItems.isEmpty()) {
+            return@withLock AppResult.Success(0)
+        }
+
+        replaceItems { items ->
+            val newTrackIds = newItems.map { it.trackId }.toSet()
+            items.filterNot {
+                it.serverId == selection.serverId &&
+                    it.libraryId == selection.libraryId &&
+                    it.trackId in newTrackIds
+            } + newItems
+        }
+
+        AppResult.Success(newItems.size)
+    }
+
     fun localPlaybackUri(track: NavidromeTrack): String? {
         val selection = mutableActiveSelection.value
         if (selection.serverId.isBlank()) return null
@@ -254,6 +312,21 @@ class NavidromeDownloadManager @Inject constructor(
         } ?: return null
         return item.localPath.toPlayableLocalUri()
     }
+
+    suspend fun prunePlaybackCache(keepTrackIds: Set<String>): Int = mutex.withLock {
+        val selection = resolveActiveSelection() ?: return@withLock 0
+        val removable = mutableItems.value.filter {
+            it.serverId == selection.serverId &&
+                it.libraryId == selection.libraryId &&
+                it.isPlaybackCache &&
+                it.trackId !in keepTrackIds
+        }
+        if (removable.isEmpty()) return@withLock 0
+        removeItems(removable)
+        removable.size
+    }
+
+    suspend fun clearPlaybackCache(): Int = prunePlaybackCache(emptySet())
 
     private suspend fun resolveActiveSelection(): NavidromeActiveSelection? {
         val state = sessionPreferences.state.first()
@@ -269,14 +342,16 @@ class NavidromeDownloadManager @Inject constructor(
     private fun enqueueTrack(
         selection: NavidromeActiveSelection,
         track: NavidromeTrack,
-        albumSongCount: Int?
+        albumSongCount: Int?,
+        isPlaybackCache: Boolean
     ): NavidromeDownloadItem? {
         val split = splitAuthenticatedUrl(track.streamUrl)
         val targetFile = buildTrackTargetFile(
             serverId = selection.serverId,
             libraryId = selection.libraryId,
             trackId = track.id,
-            formatLabel = track.formatLabel
+            formatLabel = track.formatLabel,
+            isPlaybackCache = isPlaybackCache
         )
         targetFile.parentFile?.mkdirs()
         if (targetFile.exists()) {
@@ -314,7 +389,8 @@ class NavidromeDownloadManager @Inject constructor(
             progressPercent = 0,
             downloadId = downloadId,
             localPath = targetFile.absolutePath,
-            errorMessage = null
+            errorMessage = null,
+            isPlaybackCache = isPlaybackCache
         )
     }
 
@@ -405,15 +481,21 @@ class NavidromeDownloadManager @Inject constructor(
     }
 
     private fun removeItem(item: NavidromeDownloadItem) {
-        item.downloadId?.let { downloadManager.remove(it) }
-        item.localPath?.let { path ->
-            runCatching { File(path).delete() }
+        removeItems(listOf(item))
+    }
+
+    private fun removeItems(itemsToRemove: List<NavidromeDownloadItem>) {
+        if (itemsToRemove.isEmpty()) return
+        itemsToRemove.forEach { item ->
+            item.downloadId?.let { downloadManager.remove(it) }
+            item.localPath?.let { path ->
+                runCatching { File(path).delete() }
+            }
         }
+        val removalKeys = itemsToRemove.map { Triple(it.serverId, it.libraryId, it.trackId) }.toSet()
         replaceItems { items ->
             items.filterNot {
-                it.serverId == item.serverId &&
-                    it.libraryId == item.libraryId &&
-                    it.trackId == item.trackId
+                Triple(it.serverId, it.libraryId, it.trackId) in removalKeys
             }
         }
     }
@@ -422,10 +504,15 @@ class NavidromeDownloadManager @Inject constructor(
         serverId: String,
         libraryId: String,
         trackId: String,
-        formatLabel: String?
+        formatLabel: String?,
+        isPlaybackCache: Boolean
     ): File {
-        val baseDir = appContext.getExternalFilesDir(Environment.DIRECTORY_MUSIC)
-            ?: File(appContext.filesDir, "music")
+        val baseDir = if (isPlaybackCache) {
+            File(appContext.cacheDir, "navidrome")
+        } else {
+            appContext.getExternalFilesDir(Environment.DIRECTORY_MUSIC)
+                ?: File(appContext.filesDir, "music")
+        }
         val extension = formatLabel
             ?.lowercase()
             ?.filter { it.isLetterOrDigit() }

--- a/app/src/main/java/com/stillshelf/app/downloads/navidrome/NavidromeDownloadStorage.kt
+++ b/app/src/main/java/com/stillshelf/app/downloads/navidrome/NavidromeDownloadStorage.kt
@@ -32,6 +32,7 @@ data class NavidromeDownloadItem(
     val downloadId: Long? = null,
     val localPath: String? = null,
     val errorMessage: String? = null,
+    val isPlaybackCache: Boolean = false,
     val updatedAtMs: Long = System.currentTimeMillis()
 )
 
@@ -79,6 +80,7 @@ class NavidromeDownloadStorage @Inject constructor(
                             downloadId = node.optLong("downloadId").takeIf { it > 0L },
                             localPath = node.optString("localPath").ifBlank { null },
                             errorMessage = node.optString("errorMessage").ifBlank { null },
+                            isPlaybackCache = node.optBoolean("isPlaybackCache", false),
                             updatedAtMs = node.optLong("updatedAtMs", System.currentTimeMillis())
                         )
                     )
@@ -109,6 +111,7 @@ class NavidromeDownloadStorage @Inject constructor(
                         .put("downloadId", item.downloadId)
                         .put("localPath", item.localPath)
                         .put("errorMessage", item.errorMessage)
+                        .put("isPlaybackCache", item.isPlaybackCache)
                         .put("updatedAtMs", item.updatedAtMs)
                 )
             }

--- a/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
@@ -10,6 +10,7 @@ import android.graphics.Bitmap
 import android.media.AudioDeviceCallback
 import android.media.AudioDeviceInfo
 import android.media.AudioManager
+import android.net.Uri
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -31,10 +32,14 @@ import androidx.media3.common.Player
 import androidx.media3.common.Player.REPEAT_MODE_ALL
 import androidx.media3.common.Player.REPEAT_MODE_OFF
 import androidx.media3.common.Player.REPEAT_MODE_ONE
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.audio.AudioSink
 import androidx.media3.exoplayer.audio.DefaultAudioSink
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import com.stillshelf.app.core.diagnostics.DiagnosticLogManager
 import coil.imageLoader
 import coil.request.ImageRequest
@@ -63,6 +68,66 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.json.JSONArray
 import org.json.JSONObject
+
+internal const val NAVIDROME_PLAYBACK_MEDIA_SCHEME = "stillshelf-navidrome"
+internal const val NAVIDROME_PLAYBACK_MEDIA_AUTHORITY = "playback"
+internal const val NAVIDROME_PLAYBACK_TRACK_ID_QUERY_PARAMETER = "trackId"
+internal const val NAVIDROME_PLAYBACK_STREAM_URL_QUERY_PARAMETER = "streamUrl"
+internal const val NAVIDROME_PLAYBACK_WARMUP_TRACK_LIMIT = 20
+
+internal fun normalizeNavidromePlaybackWarmupTracks(tracks: List<NavidromeTrack>): List<NavidromeTrack> {
+    return tracks
+        .distinctBy { it.id }
+        .filter {
+            it.id.isNotBlank() &&
+                it.streamUrl.isNotBlank() &&
+                !it.id.startsWith("radio:")
+        }
+}
+
+internal fun buildNavidromePlaybackWarmupSignature(tracks: List<NavidromeTrack>): String {
+    return tracks.joinToString(separator = "|") { it.id }
+}
+
+internal fun selectNavidromePlaybackWarmupTracks(
+    tracks: List<NavidromeTrack>,
+    currentIndex: Int,
+    trackLimit: Int = NAVIDROME_PLAYBACK_WARMUP_TRACK_LIMIT
+): List<NavidromeTrack> {
+    if (tracks.isEmpty() || trackLimit <= 0) return emptyList()
+    val startIndex = currentIndex.coerceIn(0, tracks.lastIndex)
+    return tracks.drop(startIndex).take(trackLimit)
+}
+
+internal fun buildNavidromePlaybackMediaUri(trackId: String, streamUrl: String): Uri {
+    return Uri.parse(
+        buildString {
+            append(NAVIDROME_PLAYBACK_MEDIA_SCHEME)
+            append("://")
+            append(NAVIDROME_PLAYBACK_MEDIA_AUTHORITY)
+            append("?")
+            append(NAVIDROME_PLAYBACK_TRACK_ID_QUERY_PARAMETER)
+            append("=")
+            append(Uri.encode(trackId))
+            append("&")
+            append(NAVIDROME_PLAYBACK_STREAM_URL_QUERY_PARAMETER)
+            append("=")
+            append(Uri.encode(streamUrl))
+        }
+    )
+}
+
+internal fun chooseNavidromePlaybackUri(
+    streamUrl: String,
+    localPlaybackUri: String?,
+    forceRemote: Boolean
+): String {
+    return if (!forceRemote && !localPlaybackUri.isNullOrBlank()) {
+        localPlaybackUri
+    } else {
+        streamUrl
+    }
+}
 
 internal fun shouldScheduleNavidromePausedPlayerRelease(
     currentTrack: NavidromeTrack?,
@@ -311,7 +376,8 @@ class NavidromePlayerController @Inject constructor(
     private var progressJob: Job? = null
     private var pausedReleaseJob: Job? = null
     private var outputRecoveryJob: Job? = null
-    private var queueTracks: List<NavidromeTrack> = emptyList()
+    private var playbackCacheWarmupJob: Job? = null
+    @Volatile private var queueTracks: List<NavidromeTrack> = emptyList()
     private var queueDisplayMode: NavidromeQueueDisplayMode = NavidromeQueueDisplayMode.FULL
     private var recentTracks: List<NavidromeTrack> = emptyList()
     private var lastRecordedTrackId: String? = null
@@ -323,12 +389,13 @@ class NavidromePlayerController @Inject constructor(
     private var outputRouteKeyByDisplayedId: Map<Int, String> = emptyMap()
     private var lastKnownOutputDeviceIds: Set<Int> = emptySet()
     private var suppressRefreshRoutingUntilElapsedMs: Long = 0L
-    private val forcedRemoteTrackIds = mutableSetOf<String>()
+    @Volatile private var forcedRemoteTrackIds: Set<String> = emptySet()
     private var playbackRecoveryTrackId: String? = null
     private var restorePlaybackGeneration: Long = 0L
     private var lastPersistedSnapshotTrackId: String? = null
     private var lastPersistedSnapshotPositionMs: Int = 0
     private var lastPersistedSnapshotElapsedMs: Long = 0L
+    @Volatile private var playbackCacheWarmupSignature: String? = null
     private val audioManager: AudioManager =
         appContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     private val mediaSession = MediaSessionCompat(appContext, "StillShelfNavidromePlayback")
@@ -457,13 +524,57 @@ class NavidromePlayerController @Inject constructor(
                     .build()
             }
         }
+        val mediaSourceFactory = DefaultMediaSourceFactory(createNavidromePlaybackDataSourceFactory())
         return ExoPlayer.Builder(appContext, renderersFactory)
+            .setMediaSourceFactory(mediaSourceFactory)
             .setHandleAudioBecomingNoisy(true)
             .build()
             .apply {
                 setAudioAttributes(playbackAudioAttributes, true)
                 addListener(playerListener)
             }
+    }
+
+    private fun createNavidromePlaybackDataSourceFactory(): ResolvingDataSource.Factory {
+        return ResolvingDataSource.Factory(
+            DefaultDataSource.Factory(appContext),
+            ResolvingDataSource.Resolver { dataSpec ->
+                resolveNavidromePlaybackDataSpec(dataSpec)
+            }
+        )
+    }
+
+    private fun resolveNavidromePlaybackDataSpec(dataSpec: DataSpec): DataSpec {
+        val uri = dataSpec.uri
+        if (uri.scheme != NAVIDROME_PLAYBACK_MEDIA_SCHEME) {
+            return dataSpec
+        }
+        val trackId = uri.getQueryParameter(NAVIDROME_PLAYBACK_TRACK_ID_QUERY_PARAMETER).orEmpty()
+        val embeddedStreamUrl = uri.getQueryParameter(NAVIDROME_PLAYBACK_STREAM_URL_QUERY_PARAMETER).orEmpty()
+        val track = queueTracks.firstOrNull { it.id == trackId }
+        val forcedRemoteSnapshot = forcedRemoteTrackIds
+        val resolvedUri = if (track != null) {
+            val forceRemote = track.id in forcedRemoteSnapshot
+            Uri.parse(
+                chooseNavidromePlaybackUri(
+                    streamUrl = track.streamUrl,
+                    localPlaybackUri = if (forceRemote) null else downloadManager.localPlaybackUri(track),
+                    forceRemote = forceRemote
+                )
+            )
+        } else if (embeddedStreamUrl.isNotBlank()) {
+            Uri.parse(embeddedStreamUrl)
+        } else {
+            uri
+        }
+        return dataSpec.buildUpon().setUri(resolvedUri).build()
+    }
+
+    private fun buildNavidromePlaybackMediaItem(track: NavidromeTrack): MediaItem {
+        return MediaItem.Builder()
+            .setMediaId(track.id)
+            .setUri(buildNavidromePlaybackMediaUri(track.id, track.streamUrl))
+            .build()
     }
 
     private fun describePlaybackState(playbackState: Int): String {
@@ -574,12 +685,7 @@ class NavidromePlayerController @Inject constructor(
         )
         val activePlayer = getOrCreatePlayer()
         activePlayer.setMediaItems(
-            tracks.map { track ->
-                MediaItem.Builder()
-                    .setMediaId(track.id)
-                    .setUri(resolvePlaybackUri(track))
-                    .build()
-            },
+            tracks.map(::buildNavidromePlaybackMediaItem),
             index,
             0L
         )
@@ -589,6 +695,7 @@ class NavidromePlayerController @Inject constructor(
         updateStateFromPlayer()
         persistPlaybackSnapshot(force = true)
         ensureProgressUpdates()
+        schedulePlaybackCacheWarmup(tracks)
     }
 
     fun playTracksNext(tracks: List<NavidromeTrack>) {
@@ -612,13 +719,11 @@ class NavidromePlayerController @Inject constructor(
         }
         queueDisplayMode = NavidromeQueueDisplayMode.FULL
         player?.addMediaItems(insertIndex, normalizedTracks.map { track ->
-            MediaItem.Builder()
-                .setMediaId(track.id)
-                .setUri(resolvePlaybackUri(track))
-                .build()
+            buildNavidromePlaybackMediaItem(track)
         })
         updateStateFromPlayer()
         persistPlaybackSnapshot(force = true)
+        schedulePlaybackCacheWarmup(queueTracks)
     }
 
     fun appendTracksToQueue(tracks: List<NavidromeTrack>) {
@@ -631,13 +736,11 @@ class NavidromePlayerController @Inject constructor(
         queueTracks = queueTracks + normalizedTracks
         queueDisplayMode = NavidromeQueueDisplayMode.FULL
         player?.addMediaItems(normalizedTracks.map { track ->
-            MediaItem.Builder()
-                .setMediaId(track.id)
-                .setUri(resolvePlaybackUri(track))
-                .build()
+            buildNavidromePlaybackMediaItem(track)
         })
         updateStateFromPlayer()
         persistPlaybackSnapshot(force = true)
+        schedulePlaybackCacheWarmup(queueTracks)
     }
 
     fun removeTrackFromQueue(index: Int): Boolean {
@@ -679,6 +782,7 @@ class NavidromePlayerController @Inject constructor(
 
         persistPlaybackSnapshot(force = true)
         ensureProgressUpdates()
+        schedulePlaybackCacheWarmup(queueTracks)
         return true
     }
 
@@ -806,8 +910,12 @@ class NavidromePlayerController @Inject constructor(
         lastPersistedSnapshotTrackId = null
         lastPersistedSnapshotPositionMs = 0
         lastPersistedSnapshotElapsedMs = 0L
-        forcedRemoteTrackIds.clear()
+        forcedRemoteTrackIds = emptySet()
         playbackRecoveryTrackId = null
+        cancelPlaybackCacheWarmup(clearSignature = true)
+        scope.launch(Dispatchers.IO) {
+            downloadManager.clearPlaybackCache()
+        }
         releasePlayer(clearQueue = true)
         stopProgressUpdates()
         clearPlaybackSurface()
@@ -867,12 +975,7 @@ class NavidromePlayerController @Inject constructor(
         releasePlayer(clearQueue = false)
         val activePlayer = getOrCreatePlayer()
         activePlayer.setMediaItems(
-            queueTracks.map { track ->
-                MediaItem.Builder()
-                    .setMediaId(track.id)
-                    .setUri(resolvePlaybackUri(track))
-                    .build()
-            },
+            queueTracks.map(::buildNavidromePlaybackMediaItem),
             safeIndex,
             safePositionMs.toLong()
         )
@@ -896,6 +999,7 @@ class NavidromePlayerController @Inject constructor(
         persistPlaybackSnapshot(force = true)
         updateStateFromPlayer()
         ensureProgressUpdates()
+        schedulePlaybackCacheWarmup(queueTracks)
     }
 
     private fun recoverPlaybackAfterError(error: androidx.media3.common.PlaybackException) {
@@ -920,7 +1024,7 @@ class NavidromePlayerController @Inject constructor(
                     return@launch
                 }
                 if (bypassBrokenLocalCopy) {
-                    forcedRemoteTrackIds += failedTrackId
+                    forcedRemoteTrackIds = forcedRemoteTrackIds + failedTrackId
                 }
                 if (refreshedQueue.isNullOrEmpty()) {
                     releasePlayer(clearQueue = false)
@@ -947,12 +1051,86 @@ class NavidromePlayerController @Inject constructor(
     }
 
     private fun resolvePlaybackUri(track: NavidromeTrack): String {
-        val localUri = if (track.id in forcedRemoteTrackIds) {
-            null
-        } else {
-            downloadManager.localPlaybackUri(track)
+        val forcedRemoteSnapshot = forcedRemoteTrackIds
+        val forceRemote = track.id in forcedRemoteSnapshot
+        return chooseNavidromePlaybackUri(
+            streamUrl = track.streamUrl,
+            localPlaybackUri = if (forceRemote) null else downloadManager.localPlaybackUri(track),
+            forceRemote = forceRemote
+        )
+    }
+
+    private fun cancelPlaybackCacheWarmup(clearSignature: Boolean) {
+        playbackCacheWarmupJob?.cancel()
+        playbackCacheWarmupJob = null
+        if (clearSignature) {
+            playbackCacheWarmupSignature = null
         }
-        return localUri ?: track.streamUrl
+    }
+
+    private fun schedulePlaybackCacheWarmup(tracks: List<NavidromeTrack>) {
+        val queueIndex = mutableState.value.currentIndex
+        val warmupTracks = selectNavidromePlaybackWarmupTracks(
+            tracks = normalizeNavidromePlaybackWarmupTracks(tracks),
+            currentIndex = queueIndex
+        )
+        if (warmupTracks.isEmpty()) {
+            cancelPlaybackCacheWarmup(clearSignature = true)
+            scope.launch(Dispatchers.IO) {
+                downloadManager.clearPlaybackCache()
+            }
+            return
+        }
+        val signature = buildNavidromePlaybackWarmupSignature(warmupTracks)
+        if (signature == playbackCacheWarmupSignature) {
+            return
+        }
+        playbackCacheWarmupSignature = signature
+        playbackCacheWarmupJob?.cancel()
+        playbackCacheWarmupJob = scope.launch(Dispatchers.IO) {
+            logPlaybackTrace(
+                "playback_cache_warmup_started queue_size=${warmupTracks.size}"
+            )
+            val refreshedQueue = when (val result = navidromeRepository.refreshPlayableTracks(warmupTracks)) {
+                is com.stillshelf.app.core.util.AppResult.Success -> result.value
+                is com.stillshelf.app.core.util.AppResult.Error -> {
+                    logPlaybackTrace(
+                        "playback_cache_warmup_refresh_failed message=${result.message}"
+                    )
+                    warmupTracks
+                }
+            }
+            if (!isActive) return@launch
+            val prefetchResult = downloadManager.prefetchPlaybackQueue(refreshedQueue)
+            if (!isActive) return@launch
+            scope.launch(Dispatchers.Main.immediate) {
+                if (playbackCacheWarmupSignature != signature) {
+                    return@launch
+                }
+                if (queueTracks.map { it.id } == warmupTracks.map { it.id }) {
+                    queueTracks = refreshedQueue
+                    recentTracks = recentTracks.map { recent ->
+                        refreshedQueue.firstOrNull { it.id == recent.id } ?: recent
+                    }
+                    updateStateFromPlayer()
+                }
+                when (prefetchResult) {
+                    is com.stillshelf.app.core.util.AppResult.Success -> {
+                        logPlaybackTrace(
+                            "playback_cache_warmup_prefetch_queued count=${prefetchResult.value}"
+                        )
+                        scope.launch(Dispatchers.IO) {
+                            downloadManager.prunePlaybackCache(warmupTracks.map { it.id }.toSet())
+                        }
+                    }
+                    is com.stillshelf.app.core.util.AppResult.Error -> {
+                        logPlaybackTrace(
+                            "playback_cache_warmup_prefetch_failed message=${prefetchResult.message}"
+                        )
+                    }
+                }
+            }
+        }
     }
 
     private fun resumeFromSnapshot(playWhenReady: Boolean) {
@@ -1028,6 +1206,7 @@ class NavidromePlayerController @Inject constructor(
             player = null
         }
         if (clearQueue) {
+            cancelPlaybackCacheWarmup(clearSignature = true)
             queueTracks = emptyList()
             queueDisplayMode = NavidromeQueueDisplayMode.FULL
         }
@@ -1181,6 +1360,7 @@ class NavidromePlayerController @Inject constructor(
                     selectedOutputDeviceId = mutableState.value.selectedOutputDeviceId,
                     errorMessage = null
                 )
+                schedulePlaybackCacheWarmup(refreshedQueue)
             }
         }
     }

--- a/app/src/test/java/com/stillshelf/app/playback/navidrome/NavidromePlaybackCacheWarmupTest.kt
+++ b/app/src/test/java/com/stillshelf/app/playback/navidrome/NavidromePlaybackCacheWarmupTest.kt
@@ -1,0 +1,88 @@
+package com.stillshelf.app.playback.navidrome
+
+import com.stillshelf.app.core.model.NavidromeTrack
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class NavidromePlaybackCacheWarmupTest {
+    @Test
+    fun normalizeNavidromePlaybackWarmupTracks_filtersInvalidAndRadioTracks() {
+        val tracks = listOf(
+            track(id = "track-1", streamUrl = "https://example.com/1.mp3"),
+            track(id = "track-1", streamUrl = "https://example.com/1-duplicate.mp3"),
+            track(id = "track-2", streamUrl = ""),
+            track(id = "radio:stream", streamUrl = "https://example.com/live.mp3"),
+            track(id = "track-3", streamUrl = "https://example.com/3.mp3")
+        )
+
+        val normalized = normalizeNavidromePlaybackWarmupTracks(tracks)
+
+        assertEquals(listOf("track-1", "track-3"), normalized.map { it.id })
+    }
+
+    @Test
+    fun buildNavidromePlaybackWarmupSignature_isOrderSensitive() {
+        val forward = buildNavidromePlaybackWarmupSignature(
+            listOf(track("track-1"), track("track-2"))
+        )
+        val reversed = buildNavidromePlaybackWarmupSignature(
+            listOf(track("track-2"), track("track-1"))
+        )
+
+        assertEquals("track-1|track-2", forward)
+        assertFalse(forward == reversed)
+    }
+
+    @Test
+    fun selectNavidromePlaybackWarmupTracks_capsToUpcomingWindow() {
+        val tracks = (0 until 30).map { track("track-$it") }
+
+        val selected = selectNavidromePlaybackWarmupTracks(
+            tracks = tracks,
+            currentIndex = 10,
+            trackLimit = 5
+        )
+
+        assertEquals(listOf("track-10", "track-11", "track-12", "track-13", "track-14"), selected.map { it.id })
+    }
+
+    @Test
+    fun chooseNavidromePlaybackUri_prefersLocalCacheWhenAllowed() {
+        val resolved = chooseNavidromePlaybackUri(
+            streamUrl = "https://example.com/stream.mp3",
+            localPlaybackUri = "file:///data/user/0/app/cache/track.mp3",
+            forceRemote = false
+        )
+
+        assertEquals("file:///data/user/0/app/cache/track.mp3", resolved)
+    }
+
+    @Test
+    fun chooseNavidromePlaybackUri_respectsForcedRemotePlayback() {
+        val resolved = chooseNavidromePlaybackUri(
+            streamUrl = "https://example.com/stream.mp3",
+            localPlaybackUri = "file:///data/user/0/app/cache/track.mp3",
+            forceRemote = true
+        )
+
+        assertEquals("https://example.com/stream.mp3", resolved)
+    }
+
+    private fun track(id: String, streamUrl: String = "https://example.com/$id.mp3"): NavidromeTrack {
+        return NavidromeTrack(
+            id = id,
+            title = "Title $id",
+            artistName = "Artist",
+            albumName = "Album",
+            albumId = "album-1",
+            artistId = "artist-1",
+            trackNumber = 1,
+            durationSeconds = 180,
+            coverUrl = null,
+            streamUrl = streamUrl,
+            formatLabel = "MP3",
+            bitRateKbps = 320
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Cap Navidrome playback warmup to the next queue window instead of prefetching the entire queue.
- Treat forced-remote playback resolution atomically on each read.
- Separate playback cache entries from user downloads so the Downloaded tab stays clean.
- Clear/prune playback cache automatically so it stays temporary.
- Bump the app version to 0.5.2.

## Verification
- `JAVA_HOME=/home/kalzi/.local/share/JetBrains/Toolbox/apps/android-studio/jbr GRADLE_USER_HOME=/tmp/gradle ./gradlew --no-daemon :app:testGithubDebugUnitTest --tests com.stillshelf.app.playback.navidrome.NavidromePlaybackCacheWarmupTest --tests com.stillshelf.app.ui.screens.navidrome.NavidromeDownloadAggregationTest --tests com.stillshelf.app.downloads.navidrome.NavidromeDownloadReconciliationTest`
- Previous focused compile/test runs for the Navidrome cache branch also passed before the version bump.