### PR TITLE
StillShelf v0.5.3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 94
-val appVersionName = "0.5.2"
+val appVersionCode = 95
+val appVersionName = "0.5.3"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/core/datastore/SessionPreferences.kt
+++ b/app/src/main/java/com/stillshelf/app/core/datastore/SessionPreferences.kt
@@ -14,6 +14,7 @@ import com.stillshelf.app.core.model.NAVIDROME_EQUALIZER_MIN_DB
 import com.stillshelf.app.core.model.NavidromeServer
 import com.stillshelf.app.core.model.NavidromeEqualizerProfile
 import com.stillshelf.app.core.model.NavidromeLyricsSource
+import com.stillshelf.app.core.model.NavidromeCacheSizeOption
 import com.stillshelf.app.core.model.NavidromeTrack
 import com.stillshelf.app.core.model.flatNavidromeEqualizerBandLevels
 import com.stillshelf.app.core.model.ServerConnectionMode
@@ -125,6 +126,7 @@ class SessionPreferences @Inject constructor(
     private val pendingBookmarkCreatesKey = stringPreferencesKey("pending_bookmark_creates")
     private val recentSearchTermsKey = stringPreferencesKey("recent_search_terms")
     private val navidromeRecentSearchTermsKey = stringPreferencesKey("navidrome_recent_search_terms")
+    private val navidromeCacheSizeLimitKey = stringPreferencesKey("navidrome_cache_size_limit")
 
     val state: Flow<SessionPreferenceState> = dataStore.data
         .map { prefs -> prefs.toSessionPreferenceState() }
@@ -1292,6 +1294,12 @@ class SessionPreferences @Inject constructor(
         }
     }
 
+    suspend fun setNavidromeCacheSizeLimit(option: String) {
+        dataStore.edit { prefs ->
+            prefs[navidromeCacheSizeLimitKey] = option
+        }
+    }
+
     private fun parseCsv(csv: String?): Set<String> {
         if (csv.isNullOrBlank()) return emptySet()
         return csv.split(",")
@@ -1946,7 +1954,8 @@ class SessionPreferences @Inject constructor(
             pendingUpdateApkPath = this[pendingUpdateApkPathKey],
             pendingUpdateVersionName = this[pendingUpdateVersionNameKey],
             recentSearchTerms = parseStringArray(this[recentSearchTermsKey]),
-            navidromeRecentSearchTerms = parseStringArray(this[navidromeRecentSearchTermsKey])
+            navidromeRecentSearchTerms = parseStringArray(this[navidromeRecentSearchTermsKey]),
+            navidromeCacheSizeLimit = this[navidromeCacheSizeLimitKey] ?: NavidromeCacheSizeOption.default
         )
     }
 }
@@ -2018,7 +2027,8 @@ data class SessionPreferenceState(
     val pendingUpdateApkPath: String? = null,
     val pendingUpdateVersionName: String? = null,
     val recentSearchTerms: List<String> = emptyList(),
-    val navidromeRecentSearchTerms: List<String> = emptyList()
+    val navidromeRecentSearchTerms: List<String> = emptyList(),
+    val navidromeCacheSizeLimit: String = NavidromeCacheSizeOption.default
 )
 
 data class CachedHomeFeedPayload(

--- a/app/src/main/java/com/stillshelf/app/core/model/NavidromeModels.kt
+++ b/app/src/main/java/com/stillshelf/app/core/model/NavidromeModels.kt
@@ -5,6 +5,48 @@ import kotlin.math.roundToInt
 
 val navidromeEqualizerBandFrequenciesHz = listOf(32, 64, 125, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000)
 const val NAVIDROME_EQUALIZER_MIN_DB = -6f
+
+object NavidromeCacheSizeOption {
+    const val NO_CACHING = "off"
+    const val NO_LIMIT = "nolimit"
+    @Deprecated("Use NO_CACHING")
+    const val OFF = NO_CACHING
+    const val MB_256 = "256mb"
+    const val MB_512 = "512mb"
+    const val GB_1 = "1gb"
+    const val GB_2 = "2gb"
+    const val GB_5 = "5gb"
+    const val GB_10 = "10gb"
+
+    val all = listOf(NO_CACHING, MB_256, MB_512, GB_1, GB_2, GB_5, GB_10, NO_LIMIT)
+    val default = MB_512
+
+    fun toBytes(option: String): Long? = when (option) {
+        NO_CACHING -> null
+        NO_LIMIT -> Long.MAX_VALUE
+        MB_256 -> 256L * 1024 * 1024
+        MB_512 -> 512L * 1024 * 1024
+        GB_1 -> 1024L * 1024 * 1024
+        GB_2 -> 2L * 1024 * 1024 * 1024
+        GB_5 -> 5L * 1024 * 1024 * 1024
+        GB_10 -> 10L * 1024 * 1024 * 1024
+        else -> 512L * 1024 * 1024
+    }
+
+    fun label(option: String): String = when (option) {
+        NO_CACHING -> "No caching"
+        NO_LIMIT -> "No limit"
+        MB_256 -> "256 MB"
+        MB_512 -> "512 MB"
+        GB_1 -> "1 GB"
+        GB_2 -> "2 GB"
+        GB_5 -> "5 GB"
+        GB_10 -> "10 GB"
+        else -> "512 MB"
+    }
+}
+
+
 const val NAVIDROME_EQUALIZER_MAX_DB = 6f
 const val NAVIDROME_EQUALIZER_STEP_DB = 1f
 

--- a/app/src/main/java/com/stillshelf/app/data/api/NavidromeApi.kt
+++ b/app/src/main/java/com/stillshelf/app/data/api/NavidromeApi.kt
@@ -261,7 +261,8 @@ class NavidromeApi @Inject constructor(
     suspend fun getAlbumList(
         auth: NavidromeAuth,
         type: String,
-        size: Int = 24
+        size: Int = 24,
+        offset: Int = 0
     ): Result<List<NavidromeAlbumDto>> = withContext(Dispatchers.IO) {
         runCatching {
             val root = execute(
@@ -271,7 +272,8 @@ class NavidromeApi @Inject constructor(
                     query = queryWithMusicFolder(
                         auth,
                         "type" to type,
-                        "size" to size.coerceIn(1, 100).toString()
+                        "size" to size.coerceIn(1, 100).toString(),
+                        "offset" to offset.coerceAtLeast(0).toString()
                     )
                 )
             )

--- a/app/src/main/java/com/stillshelf/app/data/repo/NavidromeRepository.kt
+++ b/app/src/main/java/com/stillshelf/app/data/repo/NavidromeRepository.kt
@@ -970,12 +970,26 @@ class NavidromeRepository @Inject constructor(
             NavidromeAlbumSortOption.ALBUM_ARTIST,
             NavidromeAlbumSortOption.RELEASE_YEAR -> "alphabeticalByName"
         }
-        val result = navidromeApi.getAlbumList(auth, type = apiType, size = 200)
-        if (result.isFailure) {
-            staleCache?.let { return@withAuth AppResult.Success(it) }
-            throw result.exceptionOrNull() ?: IllegalStateException("Unable to load albums.")
+        val pageSize = 100
+        val fetchedAlbums = mutableListOf<com.stillshelf.app.data.api.NavidromeAlbumDto>()
+        val seenAlbumIds = linkedSetOf<String>()
+        var offset = 0
+        while (true) {
+            val result = navidromeApi.getAlbumList(auth, type = apiType, size = pageSize, offset = offset)
+            if (result.isFailure) {
+                staleCache?.let { return@withAuth AppResult.Success(it) }
+                throw result.exceptionOrNull() ?: IllegalStateException("Unable to load albums.")
+            }
+            val page = result.getOrThrow()
+            page.forEach { album ->
+                if (seenAlbumIds.add(album.id)) {
+                    fetchedAlbums += album
+                }
+            }
+            if (page.size < pageSize) break
+            offset += pageSize
         }
-        val albums = result.getOrThrow()
+        val albums = fetchedAlbums
             .map { it.toModel(auth) }
 
         val sorted = when (sort) {

--- a/app/src/main/java/com/stillshelf/app/downloads/navidrome/NavidromeDownloadManager.kt
+++ b/app/src/main/java/com/stillshelf/app/downloads/navidrome/NavidromeDownloadManager.kt
@@ -6,6 +6,7 @@ import android.database.Cursor
 import android.net.Uri
 import android.os.Environment
 import com.stillshelf.app.core.datastore.SessionPreferences
+import com.stillshelf.app.core.model.NavidromeCacheSizeOption
 import com.stillshelf.app.core.model.NavidromeTrack
 import com.stillshelf.app.core.network.authorizationHeaderValue
 import com.stillshelf.app.core.network.splitAuthenticatedUrl
@@ -62,6 +63,14 @@ class NavidromeDownloadManager @Inject constructor(
         items.filter { item ->
             item.serverId == selection.serverId && item.libraryId == selection.libraryId
         }.filterNot { it.isPlaybackCache }
+    }
+    val activeCacheItems: Flow<List<NavidromeDownloadItem>> = combine(mutableItems, mutableActiveSelection) { items, selection ->
+        items.filter { item ->
+            item.serverId == selection.serverId &&
+                item.libraryId == selection.libraryId &&
+                item.isPlaybackCache &&
+                item.status != NavidromeDownloadStatus.Failed
+        }
     }
 
     init {
@@ -249,6 +258,10 @@ class NavidromeDownloadManager @Inject constructor(
     }
 
     suspend fun prefetchPlaybackQueue(tracks: List<NavidromeTrack>): AppResult<Int> = mutex.withLock {
+        val cacheLimitOption = sessionPreferences.state.first().navidromeCacheSizeLimit
+        if (NavidromeCacheSizeOption.toBytes(cacheLimitOption) == null) {
+            return@withLock AppResult.Success(0)
+        }
         val selection = resolveActiveSelection()
             ?: return@withLock AppResult.Error("Select a Navidrome server first.")
         val normalizedTracks = tracks
@@ -268,6 +281,8 @@ class NavidromeDownloadManager @Inject constructor(
 
         val newItems = normalizedTracks.mapNotNull { track ->
             val existing = existingByTrackId[track.id]
+            // A permanent download is authoritative — warmup must never overwrite it.
+            if (existing != null && !existing.isPlaybackCache) return@mapNotNull null
             val needsDownload = existing == null ||
                 existing.status == NavidromeDownloadStatus.Failed ||
                 (existing.status == NavidromeDownloadStatus.Completed && localPlaybackUri(track) == null)
@@ -293,7 +308,8 @@ class NavidromeDownloadManager @Inject constructor(
             items.filterNot {
                 it.serverId == selection.serverId &&
                     it.libraryId == selection.libraryId &&
-                    it.trackId in newTrackIds
+                    it.trackId in newTrackIds &&
+                    it.isPlaybackCache
             } + newItems
         }
 
@@ -327,6 +343,67 @@ class NavidromeDownloadManager @Inject constructor(
     }
 
     suspend fun clearPlaybackCache(): Int = prunePlaybackCache(emptySet())
+
+    fun currentPlaybackCacheSizeBytes(): Long {
+        val selection = mutableActiveSelection.value
+        return mutableItems.value
+            .filter {
+                it.serverId == selection.serverId &&
+                    it.libraryId == selection.libraryId &&
+                    it.isPlaybackCache &&
+                    it.status != NavidromeDownloadStatus.Failed
+            }
+            .sumOf { it.effectivePlaybackCacheSizeBytes() }
+    }
+
+    suspend fun evictPlaybackCacheToLimit(limitBytes: Long) = mutex.withLock {
+        val selection = resolveActiveSelection() ?: return@withLock
+        val cacheItems = mutableItems.value
+            .filter {
+                it.serverId == selection.serverId &&
+                    it.libraryId == selection.libraryId &&
+                    it.isPlaybackCache &&
+                    it.status != NavidromeDownloadStatus.Failed
+            }
+            .map { it to it.effectivePlaybackCacheSizeBytes() }
+            .filter { (_, size) -> size > 0L }
+            .sortedBy { (item, _) -> item.lastAccessedAtMs }
+        var totalBytes = cacheItems.sumOf { (_, size) -> size }
+        val toRemove = mutableListOf<NavidromeDownloadItem>()
+        for ((item, size) in cacheItems) {
+            if (totalBytes <= limitBytes) break
+            toRemove += item
+            totalBytes -= size
+        }
+        if (toRemove.isNotEmpty()) {
+            removeItems(toRemove)
+        }
+    }
+
+    fun touchCacheItem(trackId: String) {
+        scope.launch {
+            mutex.withLock {
+                val selection = mutableActiveSelection.value
+                val items = mutableItems.value
+                val now = System.currentTimeMillis()
+                val updated = items.map { item ->
+                    if (item.isPlaybackCache &&
+                        item.serverId == selection.serverId &&
+                        item.libraryId == selection.libraryId &&
+                        item.trackId == trackId
+                    ) {
+                        item.copy(lastAccessedAtMs = now)
+                    } else {
+                        item
+                    }
+                }
+                if (updated != items) {
+                    mutableItems.value = updated
+                    downloadStorage.persistItems(updated)
+                }
+            }
+        }
+    }
 
     private suspend fun resolveActiveSelection(): NavidromeActiveSelection? {
         val state = sessionPreferences.state.first()
@@ -437,6 +514,7 @@ class NavidromeDownloadManager @Inject constructor(
                             status = NavidromeDownloadStatus.Completed,
                             progressPercent = 100,
                             localPath = localPath ?: matchedItem.localPath,
+                            fileSizeBytes = totalBytes.takeIf { it > 0L } ?: matchedItem.fileSizeBytes,
                             errorMessage = null,
                             updatedAtMs = System.currentTimeMillis()
                         )
@@ -492,10 +570,11 @@ class NavidromeDownloadManager @Inject constructor(
                 runCatching { File(path).delete() }
             }
         }
-        val removalKeys = itemsToRemove.map { Triple(it.serverId, it.libraryId, it.trackId) }.toSet()
+        data class RemovalKey(val serverId: String, val libraryId: String, val trackId: String, val isPlaybackCache: Boolean)
+        val removalKeys = itemsToRemove.map { RemovalKey(it.serverId, it.libraryId, it.trackId, it.isPlaybackCache) }.toSet()
         replaceItems { items ->
             items.filterNot {
-                Triple(it.serverId, it.libraryId, it.trackId) in removalKeys
+                RemovalKey(it.serverId, it.libraryId, it.trackId, it.isPlaybackCache) in removalKeys
             }
         }
     }
@@ -508,7 +587,11 @@ class NavidromeDownloadManager @Inject constructor(
         isPlaybackCache: Boolean
     ): File {
         val baseDir = if (isPlaybackCache) {
-            File(appContext.cacheDir, "navidrome")
+            // DownloadManager runs as a system service and cannot write to internal cacheDir.
+            // externalCacheDir is app-private external storage that DownloadManager can reach.
+            appContext.externalCacheDir?.let { File(it, "navidrome") }
+                ?: appContext.getExternalFilesDir(null)?.let { File(it, "navidrome_cache") }
+                ?: File(appContext.filesDir, "navidrome_cache")
         } else {
             appContext.getExternalFilesDir(Environment.DIRECTORY_MUSIC)
                 ?: File(appContext.filesDir, "music")
@@ -534,6 +617,14 @@ class NavidromeDownloadManager @Inject constructor(
         val normalized = path?.trim().orEmpty()
         return normalized.isNotBlank() && File(normalized).exists()
     }
+}
+
+private fun NavidromeDownloadItem.effectivePlaybackCacheSizeBytes(): Long {
+    return fileSizeBytes
+        ?: localPath
+            ?.takeIf { it.isNotBlank() }
+            ?.let { path -> runCatching { File(path).length() }.getOrNull() }
+        ?: 0L
 }
 
 private fun Cursor.getLongOrNull(columnName: String): Long? {

--- a/app/src/main/java/com/stillshelf/app/downloads/navidrome/NavidromeDownloadStorage.kt
+++ b/app/src/main/java/com/stillshelf/app/downloads/navidrome/NavidromeDownloadStorage.kt
@@ -31,9 +31,11 @@ data class NavidromeDownloadItem(
     val progressPercent: Int,
     val downloadId: Long? = null,
     val localPath: String? = null,
+    val fileSizeBytes: Long? = null,
     val errorMessage: String? = null,
     val isPlaybackCache: Boolean = false,
-    val updatedAtMs: Long = System.currentTimeMillis()
+    val updatedAtMs: Long = System.currentTimeMillis(),
+    val lastAccessedAtMs: Long = updatedAtMs
 )
 
 @Singleton
@@ -79,9 +81,11 @@ class NavidromeDownloadStorage @Inject constructor(
                             progressPercent = node.optInt("progressPercent", 0).coerceIn(0, 100),
                             downloadId = node.optLong("downloadId").takeIf { it > 0L },
                             localPath = node.optString("localPath").ifBlank { null },
+                            fileSizeBytes = node.optLong("fileSizeBytes").takeIf { it > 0L },
                             errorMessage = node.optString("errorMessage").ifBlank { null },
                             isPlaybackCache = node.optBoolean("isPlaybackCache", false),
-                            updatedAtMs = node.optLong("updatedAtMs", System.currentTimeMillis())
+                            updatedAtMs = node.optLong("updatedAtMs", System.currentTimeMillis()),
+                            lastAccessedAtMs = node.optLong("lastAccessedAtMs", node.optLong("updatedAtMs", System.currentTimeMillis()))
                         )
                     )
                 }
@@ -110,9 +114,11 @@ class NavidromeDownloadStorage @Inject constructor(
                         .put("progressPercent", item.progressPercent)
                         .put("downloadId", item.downloadId)
                         .put("localPath", item.localPath)
+                        .put("fileSizeBytes", item.fileSizeBytes)
                         .put("errorMessage", item.errorMessage)
                         .put("isPlaybackCache", item.isPlaybackCache)
                         .put("updatedAtMs", item.updatedAtMs)
+                        .put("lastAccessedAtMs", item.lastAccessedAtMs)
                 )
             }
         }.toString()

--- a/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
@@ -48,6 +48,7 @@ import com.stillshelf.app.core.datastore.SessionPreferences
 import com.stillshelf.app.core.model.NavidromeOutputDevice
 import com.stillshelf.app.core.model.NavidromePlayerState
 import com.stillshelf.app.core.model.NavidromeQueueDisplayMode
+import com.stillshelf.app.core.model.NavidromeCacheSizeOption
 import com.stillshelf.app.core.model.NavidromeTrack
 import com.stillshelf.app.data.repo.NavidromeRepository
 import com.stillshelf.app.downloads.navidrome.NavidromeDownloadManager
@@ -64,6 +65,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.json.JSONArray
@@ -913,9 +915,6 @@ class NavidromePlayerController @Inject constructor(
         forcedRemoteTrackIds = emptySet()
         playbackRecoveryTrackId = null
         cancelPlaybackCacheWarmup(clearSignature = true)
-        scope.launch(Dispatchers.IO) {
-            downloadManager.clearPlaybackCache()
-        }
         releasePlayer(clearQueue = true)
         stopProgressUpdates()
         clearPlaybackSurface()
@@ -1060,6 +1059,13 @@ class NavidromePlayerController @Inject constructor(
         )
     }
 
+    fun invalidatePlaybackCacheWarmup() {
+        scope.launch(Dispatchers.Main.immediate) {
+            cancelPlaybackCacheWarmup(clearSignature = true)
+            schedulePlaybackCacheWarmup(queueTracks)
+        }
+    }
+
     private fun cancelPlaybackCacheWarmup(clearSignature: Boolean) {
         playbackCacheWarmupJob?.cancel()
         playbackCacheWarmupJob = null
@@ -1076,9 +1082,6 @@ class NavidromePlayerController @Inject constructor(
         )
         if (warmupTracks.isEmpty()) {
             cancelPlaybackCacheWarmup(clearSignature = true)
-            scope.launch(Dispatchers.IO) {
-                downloadManager.clearPlaybackCache()
-            }
             return
         }
         val signature = buildNavidromePlaybackWarmupSignature(warmupTracks)
@@ -1099,6 +1102,13 @@ class NavidromePlayerController @Inject constructor(
                     )
                     warmupTracks
                 }
+            }
+            if (!isActive) return@launch
+            val cacheLimitBytes = sessionPreferences.state.first()
+                .navidromeCacheSizeLimit
+                .let { NavidromeCacheSizeOption.toBytes(it) }
+            if (cacheLimitBytes != null) {
+                downloadManager.evictPlaybackCacheToLimit(cacheLimitBytes)
             }
             if (!isActive) return@launch
             val prefetchResult = downloadManager.prefetchPlaybackQueue(refreshedQueue)
@@ -1480,6 +1490,7 @@ class NavidromePlayerController @Inject constructor(
                 )
             }
             lastRecordedTrackId = currentTrack.id
+            scope.launch(Dispatchers.IO) { downloadManager.touchCacheItem(currentTrack.id) }
         } else if (currentTrack == null) {
             lastRecordedTrackId = null
         }

--- a/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
@@ -103,6 +103,7 @@ import androidx.compose.material.icons.outlined.Favorite
 import androidx.compose.material.icons.outlined.GridView
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.ArrowCircleDown
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
 import androidx.compose.material.icons.outlined.KeyboardArrowUp
 import androidx.compose.material.icons.outlined.MoreHoriz
@@ -258,6 +259,7 @@ import com.stillshelf.app.core.model.NavidromeQueueDisplayMode
 import com.stillshelf.app.core.model.NavidromeRadio
 import com.stillshelf.app.core.model.NavidromeServerScanProgress
 import com.stillshelf.app.core.model.NavidromeServerScanStatus
+import com.stillshelf.app.core.model.NavidromeCacheSizeOption
 import com.stillshelf.app.core.model.NavidromeTrack
 import com.stillshelf.app.core.network.authorizationHeaderValue
 import com.stillshelf.app.core.network.splitAuthenticatedUrl
@@ -742,6 +744,7 @@ fun NavidromeAppRoute(
                     ?.id
                     ?.let(downloadUiState.trackProgressById::get),
                 downloadedTrackIds = downloadUiState.downloadedTrackIds,
+                cachedTrackIds = downloadUiState.cachedTrackIds,
                 trackProgressById = downloadUiState.trackProgressById,
                 onToggleFavorite = playerViewModel::toggleFavoriteTrack,
                 onToggleDownload = { track -> downloadsViewModel.toggleTrackDownload(track) },
@@ -3361,11 +3364,13 @@ private fun NavidromePlaylistDetailRoute(
     onOpenArtist: (String) -> Unit,
     viewModel: NavidromePlaylistDetailViewModel = hiltViewModel(),
     playerViewModel: NavidromePlayerViewModel = hiltViewModel(),
-    playlistPickerViewModel: NavidromePlaylistPickerViewModel = hiltViewModel()
+    playlistPickerViewModel: NavidromePlaylistPickerViewModel = hiltViewModel(),
+    downloadsViewModel: NavidromeDownloadsViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val playerState by playerViewModel.uiState.collectAsStateWithLifecycle()
+    val downloadUiState by downloadsViewModel.uiState.collectAsStateWithLifecycle()
     var menuExpanded by remember { mutableStateOf(false) }
     var renameDialogVisible by rememberSaveable { mutableStateOf(false) }
     var deleteDialogVisible by rememberSaveable { mutableStateOf(false) }
@@ -3526,6 +3531,10 @@ private fun NavidromePlaylistDetailRoute(
                         track = track,
                         isCurrent = playerState.currentTrack?.id == track.id,
                         isPlaying = playerState.currentTrack?.id == track.id && playerState.isPlaying,
+                        isDownloaded = downloadUiState.downloadedTrackIds.contains(track.id),
+                        isCached = downloadUiState.cachedTrackIds.contains(track.id) &&
+                            !downloadUiState.downloadedTrackIds.contains(track.id),
+                        downloadProgressPercent = downloadUiState.trackProgressById[track.id],
                         onClick = { playerViewModel.playTracks(detail.tracks, index) },
                         trailingContent = {
                             var rowMenuExpanded by remember { mutableStateOf(false) }
@@ -3801,6 +3810,8 @@ private fun NavidromeFavoriteSongsRoute(
                     isCurrent = playerState.currentTrack?.id == track.id,
                     isPlaying = playerState.currentTrack?.id == track.id && playerState.isPlaying,
                     isDownloaded = downloadUiState.downloadedTrackIds.contains(track.id),
+                    isCached = downloadUiState.cachedTrackIds.contains(track.id) &&
+                        !downloadUiState.downloadedTrackIds.contains(track.id),
                     downloadProgressPercent = downloadUiState.trackProgressById[track.id],
                     onClick = { playerViewModel.playTracks(uiState.songs, index) },
                     trailingContent = {
@@ -4105,6 +4116,8 @@ private fun NavidromeSongsRoute(
                     isCurrent = playerState.currentTrack?.id == track.id,
                     isPlaying = playerState.currentTrack?.id == track.id && playerState.isPlaying,
                     isDownloaded = downloadUiState.downloadedTrackIds.contains(track.id),
+                    isCached = downloadUiState.cachedTrackIds.contains(track.id) &&
+                        !downloadUiState.downloadedTrackIds.contains(track.id),
                     downloadProgressPercent = downloadUiState.trackProgressById[track.id],
                     onClick = {
                         playerViewModel.playTracks(
@@ -4367,12 +4380,14 @@ private fun NavidromeSearchRoute(
             if (uiState.results.tracks.isNotEmpty()) {
                 item { SectionTitle("Songs") }
                 itemsIndexed(uiState.results.tracks, key = { _, track -> track.id }) { index, track ->
-                    TrackRow(
-                        track = track,
-                        isCurrent = playerState.currentTrack?.id == track.id,
-                        isPlaying = playerState.currentTrack?.id == track.id && playerState.isPlaying,
-                        isDownloaded = downloadUiState.downloadedTrackIds.contains(track.id),
-                        downloadProgressPercent = downloadUiState.trackProgressById[track.id],
+                TrackRow(
+                    track = track,
+                    isCurrent = playerState.currentTrack?.id == track.id,
+                    isPlaying = playerState.currentTrack?.id == track.id && playerState.isPlaying,
+                    isDownloaded = downloadUiState.downloadedTrackIds.contains(track.id),
+                    isCached = downloadUiState.cachedTrackIds.contains(track.id) &&
+                        !downloadUiState.downloadedTrackIds.contains(track.id),
+                    downloadProgressPercent = downloadUiState.trackProgressById[track.id],
                         onClick = {
                             viewModel.commitCurrentQuery()
                             playerViewModel.playTracks(uiState.results.tracks, index)
@@ -4783,6 +4798,8 @@ private fun NavidromeAlbumDetailRoute(
                     isCurrent = playerState.currentTrack?.id == track.id,
                     isPlaying = playerState.currentTrack?.id == track.id && playerState.isPlaying,
                     isDownloaded = downloadUiState.downloadedTrackIds.contains(track.id),
+                    isCached = downloadUiState.cachedTrackIds.contains(track.id) &&
+                        !downloadUiState.downloadedTrackIds.contains(track.id),
                     downloadProgressPercent = downloadUiState.trackProgressById[track.id],
                     onClick = { playerViewModel.playTracks(detail.tracks, index) },
                     trailingContent = {
@@ -4887,6 +4904,8 @@ private fun NavidromeSettingsRoute(
     var signOutDialogVisible by rememberSaveable { mutableStateOf(false) }
     var resyncDialogVisible by rememberSaveable { mutableStateOf(false) }
     var serverScanDialogVisible by rememberSaveable { mutableStateOf(false) }
+    var clearCachedMusicDialogVisible by rememberSaveable { mutableStateOf(false) }
+    var cacheSizeMenuExpanded by rememberSaveable { mutableStateOf(false) }
     val sectionCardColor = if (appearanceUiState.navidromeMaterialDesignEnabled) {
         MaterialTheme.colorScheme.surfaceContainerHigh
     } else {
@@ -5022,6 +5041,71 @@ private fun NavidromeSettingsRoute(
         }
         item {
             Text(
+                text = "MUSIC CACHE",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = AppScreenHorizontalPadding)
+            )
+        }
+        item {
+            GroupedSettingsCard(
+                containerColor = sectionCardColor,
+                border = sectionCardBorder
+            ) {
+                Box(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentAlignment = Alignment.TopEnd
+                ) {
+                    NavidromeSettingsRow(
+                        title = "Cache size limit",
+                        value = NavidromeCacheSizeOption.label(uiState.playbackCacheSizeLimit),
+                        valueTextAlign = TextAlign.End,
+                        onClick = { cacheSizeMenuExpanded = true }
+                    )
+                    AppDropdownMenu(
+                        expanded = cacheSizeMenuExpanded,
+                        onDismissRequest = { cacheSizeMenuExpanded = false },
+                        modifier = Modifier.widthIn(min = 200.dp)
+                    ) {
+                        NavidromeCacheSizeOption.all.forEach { option ->
+                            val isSelected = uiState.playbackCacheSizeLimit == option
+                            AppDropdownMenuItem(
+                                text = {
+                                    Text(
+                                        text = NavidromeCacheSizeOption.label(option),
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                },
+                                trailingIcon = if (isSelected) {
+                                    {
+                                        Icon(
+                                            imageVector = Icons.Filled.Check,
+                                            contentDescription = "Selected cache size"
+                                        )
+                                    }
+                                } else {
+                                    null
+                                },
+                                onClick = {
+                                    cacheSizeMenuExpanded = false
+                                    viewModel.setPlaybackCacheSizeLimit(option)
+                                }
+                            )
+                        }
+                    }
+                }
+                DividerLine()
+                NavidromeSettingsRow(
+                    title = "Clear cached music",
+                    value = if (uiState.isClearingCache) "Clearing…" else formatStorageSize(uiState.playbackCacheUsageBytes),
+                    valueTextAlign = TextAlign.End,
+                    onClick = if (uiState.isClearingCache) null else ({ clearCachedMusicDialogVisible = true })
+                )
+            }
+        }
+        item {
+            Text(
                 text = "SESSION",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -5141,6 +5225,30 @@ private fun NavidromeSettingsRoute(
                 )
             }
         }
+        }
+        if (clearCachedMusicDialogVisible) {
+            AlertDialog(
+                onDismissRequest = { clearCachedMusicDialogVisible = false },
+                title = { Text("Clear cached music?") },
+                text = {
+                    Text(
+                        "This deletes the temporary Navidrome playback cache from this device. Your downloaded music stays untouched, but tracks may need to cache again later."
+                    )
+                },
+                confirmButton = {
+                    TextButton(onClick = {
+                        clearCachedMusicDialogVisible = false
+                        viewModel.clearPlaybackCache()
+                    }) {
+                        Text("Clear")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { clearCachedMusicDialogVisible = false }) {
+                        Text("Cancel")
+                    }
+                }
+            )
         }
         AppThemedSnackbarHost(
             hostState = snackbarHostState,
@@ -8738,6 +8846,7 @@ private fun TrackRow(
     isCurrent: Boolean = false,
     isPlaying: Boolean = false,
     isDownloaded: Boolean = false,
+    isCached: Boolean = false,
     downloadProgressPercent: Int? = null,
     onClick: () -> Unit,
     trailingContent: (@Composable () -> Unit)? = null
@@ -8791,7 +8900,9 @@ private fun TrackRow(
                 Text(
                     text = track.title,
                     style = MaterialTheme.typography.titleMedium,
-                    fontWeight = if (isCurrent) FontWeight.SemiBold else FontWeight.Normal
+                    fontWeight = if (isCurrent) FontWeight.SemiBold else FontWeight.Normal,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
                 Text(
                     text = "${track.artistName} • ${track.albumName}",
@@ -8801,29 +8912,25 @@ private fun TrackRow(
                     overflow = TextOverflow.Ellipsis
                 )
             }
-            when {
-                trailingContent != null && isCurrent -> {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // Fixed 24dp slot — visualizer when current, invisible otherwise.
+                Box(modifier = Modifier.size(width = 24.dp, height = 18.dp)) {
+                    if (isCurrent) {
                         NavidromeNowPlayingVisualizer(
                             isPlaying = isPlaying,
                             color = nowPlayingAccentColor
                         )
-                        trailingContent()
                     }
                 }
-                trailingContent != null -> {
+                if (isCached) {
+                    CacheIndicator()
+                }
+                if (trailingContent != null) {
                     trailingContent()
-                }
-                isCurrent -> {
-                    NavidromeNowPlayingVisualizer(
-                        isPlaying = isPlaying,
-                        color = nowPlayingAccentColor
-                    )
-                }
-                else -> {
+                } else {
                     Icon(
                         imageVector = Icons.Outlined.PlayArrow,
                         contentDescription = null
@@ -9737,6 +9844,7 @@ private fun NavidromeExpandedPlayerSheet(
     isDownloaded: Boolean = false,
     downloadProgressPercent: Int? = null,
     downloadedTrackIds: Set<String> = emptySet(),
+    cachedTrackIds: Set<String> = emptySet(),
     trackProgressById: Map<String, Int> = emptyMap(),
     onToggleFavorite: (NavidromeTrack) -> Boolean,
     onToggleDownload: ((NavidromeTrack) -> Unit)? = null,
@@ -10645,6 +10753,7 @@ private fun NavidromeExpandedPlayerSheet(
                                             isCurrent = itemIsCurrent,
                                             isPlaying = itemIsCurrent && state.isPlaying,
                                             isDownloaded = item.track.id in downloadedTrackIds,
+                                            isCached = item.track.id in cachedTrackIds && item.track.id !in downloadedTrackIds,
                                             downloadProgressPercent = trackProgressById[item.track.id],
                                             immersiveEnabled = immersiveEnabled,
                                             onClick = { onSelectTrack(item.queueIndex) },
@@ -11914,6 +12023,7 @@ private fun PlayerQueueRow(
     isCurrent: Boolean,
     isPlaying: Boolean,
     isDownloaded: Boolean = false,
+    isCached: Boolean = false,
     downloadProgressPercent: Int? = null,
     immersiveEnabled: Boolean = false,
     onClick: () -> Unit,
@@ -11970,57 +12080,58 @@ private fun PlayerQueueRow(
                 url = track.coverUrl,
                 size = 44.dp,
                 showDownloadedIndicator = isDownloaded,
-            downloadProgressPercent = downloadProgressPercent
-        )
+                showCachedIndicator = false,
+                downloadProgressPercent = downloadProgressPercent
+            )
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = track.title,
                     style = MaterialTheme.typography.titleSmall,
                     color = primaryTextColor,
-                fontWeight = if (isCurrent) FontWeight.SemiBold else FontWeight.Normal,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            Text(
-                text = track.artistName,
-                style = MaterialTheme.typography.bodySmall,
-                color = secondaryTextColor,
+                    fontWeight = if (isCurrent) FontWeight.SemiBold else FontWeight.Normal,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = track.artistName,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = secondaryTextColor,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
             }
-            when {
-                trailingContent != null && isCurrent -> {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // Fixed 24dp slot — visualizer when current, invisible otherwise.
+                Box(modifier = Modifier.size(width = 24.dp, height = 18.dp)) {
+                    if (isCurrent) {
                         NavidromeNowPlayingVisualizer(
                             isPlaying = isPlaying,
                             color = nowPlayingAccentColor
                         )
-                        trailingContent()
                     }
                 }
-                trailingContent != null -> {
+                if (isCached) {
+                    CacheIndicator()
+                }
+                if (trailingContent != null) {
                     trailingContent()
                 }
-                isCurrent -> {
-                    NavidromeNowPlayingVisualizer(
-                        isPlaying = isPlaying,
-                        color = nowPlayingAccentColor
-                    )
-                }
-                else -> {
-                    Text(
-                        text = track.durationSeconds?.let(::formatDuration) ?: "--:--",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = secondaryTextColor
-                    )
-                }
             }
-        }
     }
+}
+
+@Composable
+private fun CacheIndicator() {
+    Icon(
+        imageVector = Icons.Outlined.ArrowCircleDown,
+        contentDescription = "Cached track",
+        modifier = Modifier.size(18.dp),
+        tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.72f)
+    )
+}
 
 @Composable
 private fun navidromeNowPlayingAccentColor(immersiveEnabled: Boolean = false): Color {
@@ -12440,6 +12551,7 @@ private fun AlbumArt(
     url: String?,
     size: androidx.compose.ui.unit.Dp,
     showDownloadedIndicator: Boolean = false,
+    showCachedIndicator: Boolean = false,
     downloadProgressPercent: Int? = null
 ) {
     AlbumArt(
@@ -12447,6 +12559,7 @@ private fun AlbumArt(
         width = size,
         height = size,
         showDownloadedIndicator = showDownloadedIndicator,
+        showCachedIndicator = showCachedIndicator,
         downloadProgressPercent = downloadProgressPercent
     )
 }
@@ -12460,6 +12573,7 @@ private fun AlbumArt(
     contentScale: ContentScale = ContentScale.Crop,
     fallbackIcon: ImageVector = Icons.Outlined.Album,
     showDownloadedIndicator: Boolean = false,
+    showCachedIndicator: Boolean = false,
     downloadProgressPercent: Int? = null
 ) {
     Box(
@@ -12499,6 +12613,9 @@ private fun AlbumArt(
             progressPercent = downloadProgressPercent,
             modifier = Modifier.align(Alignment.TopEnd)
         )
+        if (showCachedIndicator && !showDownloadedIndicator && downloadProgressPercent == null) {
+            NavidromeCacheBadge(modifier = Modifier.align(Alignment.TopEnd))
+        }
     }
 }
 
@@ -12582,6 +12699,25 @@ private fun NavidromeDownloadBadge(
                 tint = MaterialTheme.colorScheme.primary
             )
         }
+    }
+}
+
+@Composable
+private fun NavidromeCacheBadge(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .padding(4.dp)
+            .size(18.dp)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.92f)),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Download,
+            contentDescription = "Cached",
+            modifier = Modifier.size(10.dp),
+            tint = MaterialTheme.colorScheme.tertiary
+        )
     }
 }
 

--- a/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeViewModels.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeViewModels.kt
@@ -3,6 +3,7 @@ package com.stillshelf.app.ui.screens.navidrome
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import java.io.File
 import com.stillshelf.app.core.model.NAVIDROME_EQUALIZER_MAX_DB
 import com.stillshelf.app.core.model.NAVIDROME_EQUALIZER_MIN_DB
 import com.stillshelf.app.core.model.NAVIDROME_EQUALIZER_STEP_DB
@@ -28,6 +29,7 @@ import com.stillshelf.app.core.model.ServerConnectionMode
 import com.stillshelf.app.core.model.ServerEndpointSwitchingConfig
 import com.stillshelf.app.core.network.NetworkConnectionType
 import com.stillshelf.app.core.network.NetworkMonitor
+import com.stillshelf.app.core.model.NavidromeCacheSizeOption
 import com.stillshelf.app.core.model.flatNavidromeEqualizerBandLevels
 import com.stillshelf.app.core.util.AppResult
 import com.stillshelf.app.data.repo.NavidromeAlbumSortOption
@@ -1089,6 +1091,7 @@ data class NavidromeFavoriteSongsUiState(
 
 data class NavidromeDownloadsUiState(
     val downloadedTrackIds: Set<String> = emptySet(),
+    val cachedTrackIds: Set<String> = emptySet(),
     val trackProgressById: Map<String, Int> = emptyMap(),
     val albumProgressById: Map<String, Int> = emptyMap(),
     val artistProgressById: Map<String, Int> = emptyMap(),
@@ -1142,8 +1145,10 @@ class NavidromeDownloadsViewModel @Inject constructor(
 
     val uiState: StateFlow<NavidromeDownloadsUiState> = combine(
         downloadManager.activeItems,
+        downloadManager.activeCacheItems,
         mutableFeedbackState
-    ) { items, feedback ->
+    ) { items, cacheItems, feedback ->
+        val cachedTrackIds = cacheItems.map { it.trackId }.toSet()
         val completedItems = items.filter { it.status == NavidromeDownloadStatus.Completed }
         val downloadingItems = items.filter {
             it.status == NavidromeDownloadStatus.Queued || it.status == NavidromeDownloadStatus.Downloading
@@ -1212,6 +1217,7 @@ class NavidromeDownloadsViewModel @Inject constructor(
 
         feedback.copy(
             downloadedTrackIds = completedItems.map { it.trackId }.toSet(),
+            cachedTrackIds = cachedTrackIds,
             trackProgressById = downloadingItems.associate { it.trackId to it.progressPercent.coerceIn(0, 99) },
             albumProgressById = albumProgressById,
             artistProgressById = artistProgressById,
@@ -1702,7 +1708,9 @@ class NavidromeFavoriteSongsViewModel @Inject constructor(
 @HiltViewModel
 class NavidromeSettingsViewModel @Inject constructor(
     private val navidromeRepository: NavidromeRepository,
-    private val sessionPreferences: SessionPreferences
+    private val sessionPreferences: SessionPreferences,
+    private val downloadManager: NavidromeDownloadManager,
+    private val playerController: NavidromePlayerController
 ) : ViewModel() {
     private val mutableLocalState = MutableStateFlow(NavidromeSettingsLocalState())
 
@@ -1717,15 +1725,26 @@ class NavidromeSettingsViewModel @Inject constructor(
             ) { session, servers, preferences, connectionStatus, endpointHealth ->
                 Quintuple(session, servers, preferences, connectionStatus, endpointHealth)
             },
-            sessionPreferences.observeCachedNavidromeLyricsSizeBytes()
-        ) { upstream, lyricsCacheSizeBytes ->
-            Sextuple(
+            sessionPreferences.observeCachedNavidromeLyricsSizeBytes(),
+            downloadManager.activeCacheItems
+        ) { upstream, lyricsCacheSizeBytes, cacheItems ->
+            Septuple(
                 upstream.session,
                 upstream.servers,
                 upstream.preferences,
                 upstream.connectionStatus,
                 upstream.endpointHealth,
-                lyricsCacheSizeBytes
+                lyricsCacheSizeBytes,
+                Pair(
+                    cacheItems.sumOf { item ->
+                        item.fileSizeBytes
+                            ?: item.localPath
+                                ?.takeIf { it.isNotBlank() }
+                                ?.let { path -> runCatching { File(path).length() }.getOrNull() }
+                            ?: 0L
+                    },
+                    cacheItems.size
+                )
             )
         },
         mutableLocalState
@@ -1736,6 +1755,8 @@ class NavidromeSettingsViewModel @Inject constructor(
         val connectionStatus = upstream.connectionStatus
         val endpointHealth = upstream.endpointHealth
         val lyricsCacheSizeBytes = upstream.sixth
+        val playbackCacheUsageBytes = upstream.seventh.first
+        val playbackCacheItemCount = upstream.seventh.second
         val activeServerId = preferences.activeNavidromeServerId ?: servers.firstOrNull()?.id
         val activeServer = servers.firstOrNull { it.id == activeServerId }
         val activeLibraryId = activeServer?.id?.let(preferences.navidromeActiveLibraryIds::get)
@@ -1767,6 +1788,10 @@ class NavidromeSettingsViewModel @Inject constructor(
             },
             activeLyricsSourceId = preferences.activeNavidromeLyricsSourceId,
             lyricsCacheSizeBytes = lyricsCacheSizeBytes,
+            playbackCacheSizeLimit = preferences.navidromeCacheSizeLimit,
+            playbackCacheUsageBytes = playbackCacheUsageBytes,
+            playbackCacheItemCount = playbackCacheItemCount,
+            isClearingCache = localState.isClearingCache,
             activeServerId = activeServerId,
             availableLibraries = localState.libraries,
             activeLibraryId = activeLibraryId,
@@ -2028,6 +2053,25 @@ class NavidromeSettingsViewModel @Inject constructor(
 
     fun consumeSyncToastMessage() {
         mutableLocalState.update { it.copy(syncToastMessage = null) }
+    }
+
+    fun setPlaybackCacheSizeLimit(option: String) {
+        viewModelScope.launch {
+            sessionPreferences.setNavidromeCacheSizeLimit(option)
+            if (NavidromeCacheSizeOption.toBytes(option) != null) {
+                playerController.invalidatePlaybackCacheWarmup()
+            }
+        }
+    }
+
+    fun clearPlaybackCache() {
+        if (mutableLocalState.value.isClearingCache) return
+        viewModelScope.launch {
+            mutableLocalState.update { it.copy(isClearingCache = true) }
+            downloadManager.clearPlaybackCache()
+            playerController.invalidatePlaybackCacheWarmup()
+            mutableLocalState.update { it.copy(isClearingCache = false, syncToastMessage = "Cached music cleared") }
+        }
     }
 
     fun setActiveServer(serverId: String) {
@@ -3015,6 +3059,10 @@ data class NavidromeSettingsUiState(
     val lyricsSources: List<SettingsServerOption> = emptyList(),
     val activeLyricsSourceId: String? = null,
     val lyricsCacheSizeBytes: Long = 0L,
+    val playbackCacheSizeLimit: String = NavidromeCacheSizeOption.default,
+    val playbackCacheUsageBytes: Long = 0L,
+    val playbackCacheItemCount: Int = 0,
+    val isClearingCache: Boolean = false,
     val activeServerId: String? = null,
     val availableLibraries: List<NavidromeLibrary> = emptyList(),
     val activeLibraryId: String? = null,
@@ -3351,10 +3399,21 @@ private data class Sextuple<A, B, C, D, E, F>(
     val sixth: F
 )
 
+private data class Septuple<A, B, C, D, E, F, G>(
+    val session: A,
+    val servers: B,
+    val preferences: C,
+    val connectionStatus: D,
+    val endpointHealth: E,
+    val sixth: F,
+    val seventh: G
+)
+
 private data class NavidromeSettingsLocalState(
     val libraries: List<NavidromeLibrary> = emptyList(),
     val errorMessage: String? = null,
     val isBusy: Boolean = false,
+    val isClearingCache: Boolean = false,
     val syncToastMessage: String? = null,
     val resyncProgress: NavidromeLibraryResyncProgress? = null,
     val serverScanProgress: NavidromeServerScanProgress? = null,

--- a/app/src/test/java/com/stillshelf/app/data/repo/NavidromeRepositoryAlbumPagingTest.kt
+++ b/app/src/test/java/com/stillshelf/app/data/repo/NavidromeRepositoryAlbumPagingTest.kt
@@ -1,0 +1,138 @@
+package com.stillshelf.app.data.repo
+
+import com.stillshelf.app.core.datastore.SessionPreferenceState
+import com.stillshelf.app.core.datastore.SessionPreferences
+import com.stillshelf.app.core.model.ActiveServerConnectionStatus
+import com.stillshelf.app.core.model.NavidromeAlbum
+import com.stillshelf.app.core.model.NavidromeServer
+import com.stillshelf.app.core.model.ServerConnectionMode
+import com.stillshelf.app.core.model.ServerConnectionRoute
+import com.stillshelf.app.data.api.NavidromeApi
+import com.stillshelf.app.data.api.NavidromeAlbumDto
+import com.stillshelf.app.core.datastore.SecureTokenStorage
+import com.stillshelf.app.core.network.NetworkConnectionState
+import com.stillshelf.app.core.network.NetworkConnectionType
+import com.stillshelf.app.core.network.NetworkMonitor
+import com.stillshelf.app.core.util.AppResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import java.lang.reflect.Field
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class NavidromeRepositoryAlbumPagingTest {
+    @Test
+    fun fetchAlbums_pagesThroughAllAlbumBatches() = runTest {
+        val api = mockk<NavidromeApi>(relaxed = true)
+        val sessionPreferences = mockk<SessionPreferences>(relaxed = true) {
+            every { state } returns flowOf(
+                SessionPreferenceState(
+                    activeServerId = "server-1",
+                    activeLibraryId = "library-1",
+                    selectedBackend = null,
+                    navidromeServers = listOf(
+                        NavidromeServer(
+                            id = "server-1",
+                            name = "Navidrome",
+                            baseUrl = "https://navidrome.example",
+                            username = "user",
+                            createdAt = 1L
+                        )
+                    ),
+                    activeNavidromeServerId = "server-1",
+                    navidromeActiveLibraryIds = mapOf("server-1" to "library-1")
+                )
+            )
+            coEvery { isNavidromeLegacySessionMigrated() } returns true
+        }
+        val secureTokenStorage = mockk<SecureTokenStorage>(relaxed = true) {
+            coEvery { getNamedSecret(any()) } returns "secret"
+        }
+        val networkMonitor = mockk<NetworkMonitor>(relaxed = true) {
+            every { observeConnectionState() } returns flowOf(
+                NetworkConnectionState(
+                    type = NetworkConnectionType.Offline,
+                    identity = "offline"
+                )
+            )
+        }
+        coEvery { api.measurePing(any()) } returns Result.success(12L)
+
+        val repository = NavidromeRepository(
+            navidromeApi = api,
+            sessionPreferences = sessionPreferences,
+            secureTokenStorage = secureTokenStorage,
+            networkMonitor = networkMonitor,
+            okHttpClient = OkHttpClient()
+        )
+        setActiveConnectionStatus(
+            repository,
+            ActiveServerConnectionStatus(
+                serverId = "server-1",
+                effectiveBaseUrl = "https://navidrome.example",
+                route = ServerConnectionRoute.Default,
+                connectionMode = ServerConnectionMode.Auto,
+                switchingEnabled = false
+            )
+        )
+        every { api.encodePassword("secret") } returns "encoded-secret"
+
+        val firstPage = (1..100).map { index ->
+            albumDto(id = "album-$index", name = "Album $index")
+        }
+        val secondPage = (101..150).map { index ->
+            albumDto(id = "album-$index", name = "Album $index")
+        }
+        coEvery {
+            api.getAlbumList(any(), type = "newest", size = 100, offset = 0)
+        } returns Result.success(firstPage)
+        coEvery {
+            api.getAlbumList(any(), type = "newest", size = 100, offset = 100)
+        } returns Result.success(secondPage)
+
+        val result = repository.fetchAlbums(sort = NavidromeAlbumSortOption.RECENT, forceRefresh = true)
+
+        val albums = (result as AppResult.Success<List<NavidromeAlbum>>).value
+        assertEquals(150, albums.size)
+        assertEquals("album-1", albums.first().id)
+        assertEquals("album-150", albums.last().id)
+        coVerify(exactly = 1) { api.getAlbumList(any(), type = "newest", size = 100, offset = 0) }
+        coVerify(exactly = 1) { api.getAlbumList(any(), type = "newest", size = 100, offset = 100) }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun setActiveConnectionStatus(
+        repository: NavidromeRepository,
+        status: ActiveServerConnectionStatus
+    ) {
+        val field: Field = NavidromeRepository::class.java.getDeclaredField("mutableActiveConnectionStatus")
+        field.isAccessible = true
+        val flow = field.get(repository) as MutableStateFlow<ActiveServerConnectionStatus?>
+        flow.value = status
+    }
+
+    private fun albumDto(id: String, name: String): NavidromeAlbumDto {
+        return NavidromeAlbumDto(
+            id = id,
+            name = name,
+            artistName = "Artist",
+            artistId = "artist-1",
+            year = null,
+            songCount = 10,
+            durationSeconds = null,
+            coverArtId = null,
+            genre = null
+        )
+    }
+}

--- a/app/src/test/java/com/stillshelf/app/downloads/navidrome/NavidromeCachePolicyTest.kt
+++ b/app/src/test/java/com/stillshelf/app/downloads/navidrome/NavidromeCachePolicyTest.kt
@@ -1,0 +1,316 @@
+package com.stillshelf.app.downloads.navidrome
+
+import com.stillshelf.app.core.model.NavidromeCacheSizeOption
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NavidromeCachePolicyTest {
+
+    // region NavidromeCacheSizeOption parsing
+
+    @Test
+    fun cacheSizeOption_offReturnsNullBytes() {
+        assertNull(NavidromeCacheSizeOption.toBytes(NavidromeCacheSizeOption.NO_CACHING))
+    }
+
+    @Test
+    fun cacheSizeOption_parsesKnownSizesCorrectly() {
+        assertEquals(256L * 1024 * 1024, NavidromeCacheSizeOption.toBytes(NavidromeCacheSizeOption.MB_256))
+        assertEquals(512L * 1024 * 1024, NavidromeCacheSizeOption.toBytes(NavidromeCacheSizeOption.MB_512))
+        assertEquals(1024L * 1024 * 1024, NavidromeCacheSizeOption.toBytes(NavidromeCacheSizeOption.GB_1))
+        assertEquals(2L * 1024 * 1024 * 1024, NavidromeCacheSizeOption.toBytes(NavidromeCacheSizeOption.GB_2))
+        assertEquals(5L * 1024 * 1024 * 1024, NavidromeCacheSizeOption.toBytes(NavidromeCacheSizeOption.GB_5))
+        assertEquals(10L * 1024 * 1024 * 1024, NavidromeCacheSizeOption.toBytes(NavidromeCacheSizeOption.GB_10))
+        assertEquals(Long.MAX_VALUE, NavidromeCacheSizeOption.toBytes(NavidromeCacheSizeOption.NO_LIMIT))
+    }
+
+    @Test
+    fun cacheSizeOption_unknownStringFallsBackToDefault() {
+        val defaultBytes = NavidromeCacheSizeOption.toBytes(NavidromeCacheSizeOption.default)
+        assertEquals(defaultBytes, NavidromeCacheSizeOption.toBytes("nonsense"))
+        assertEquals(defaultBytes, NavidromeCacheSizeOption.toBytes(""))
+    }
+
+    @Test
+    fun cacheSizeOption_allContainsOffAndNoLimit() {
+        assertTrue(NavidromeCacheSizeOption.NO_CACHING in NavidromeCacheSizeOption.all)
+        assertTrue(NavidromeCacheSizeOption.NO_LIMIT in NavidromeCacheSizeOption.all)
+    }
+
+    @Test
+    fun cacheSizeOption_offDisplaysAsNoCaching() {
+        assertEquals("No caching", NavidromeCacheSizeOption.label(NavidromeCacheSizeOption.NO_CACHING))
+    }
+
+    @Test
+    fun cacheSizeOption_noLimitDisplaysAsNoLimit() {
+        assertEquals("No limit", NavidromeCacheSizeOption.label(NavidromeCacheSizeOption.NO_LIMIT))
+    }
+
+    // endregion
+
+    // region Cache vs Download separation
+
+    @Test
+    fun cacheItems_areExcludedFromDownloadView() {
+        val items = listOf(
+            item("track-1", isPlaybackCache = false),
+            item("track-2", isPlaybackCache = true),
+            item("track-3", isPlaybackCache = true),
+        )
+
+        val downloads = items.filterNot { it.isPlaybackCache }
+
+        assertEquals(listOf("track-1"), downloads.map { it.trackId })
+    }
+
+    @Test
+    fun cacheItems_areOnlyReturnedByCacheFilter() {
+        val items = listOf(
+            item("track-1", isPlaybackCache = false),
+            item("track-2", isPlaybackCache = true),
+        )
+
+        val cached = items.filter { it.isPlaybackCache && it.status == NavidromeDownloadStatus.Completed }
+
+        assertEquals(listOf("track-2"), cached.map { it.trackId })
+    }
+
+    @Test
+    fun cacheItems_doNotAppearInDownloadedTrackIds() {
+        val items = listOf(
+            item("download-1", isPlaybackCache = false),
+            item("cache-1", isPlaybackCache = true),
+            item("cache-2", isPlaybackCache = true),
+        )
+
+        val downloadedIds = items
+            .filterNot { it.isPlaybackCache }
+            .filter { it.status == NavidromeDownloadStatus.Completed }
+            .map { it.trackId }
+            .toSet()
+
+        assertTrue("download-1" in downloadedIds)
+        assertTrue("cache-1" !in downloadedIds)
+        assertTrue("cache-2" !in downloadedIds)
+    }
+
+    // endregion
+
+    // region LRU eviction
+
+    @Test
+    fun lruEviction_removesLeastRecentlyUsedFirst() {
+        val items = listOf(
+            item("track-newest", isPlaybackCache = true, fileSizeBytes = 100L * MB, lastAccessedAtMs = 3000L),
+            item("track-oldest", isPlaybackCache = true, fileSizeBytes = 100L * MB, lastAccessedAtMs = 1000L),
+            item("track-middle", isPlaybackCache = true, fileSizeBytes = 100L * MB, lastAccessedAtMs = 2000L),
+        )
+        val limitBytes = 150L * MB
+
+        val toRemove = lruEvict(items, limitBytes)
+
+        assertEquals(listOf("track-oldest", "track-middle"), toRemove.map { it.trackId })
+    }
+
+    @Test
+    fun lruEviction_doesNotEvictWhenUnderLimit() {
+        val items = listOf(
+            item("track-1", isPlaybackCache = true, fileSizeBytes = 50L * MB, lastAccessedAtMs = 1000L),
+        )
+
+        val toRemove = lruEvict(items, 200L * MB)
+
+        assertTrue(toRemove.isEmpty())
+    }
+
+    @Test
+    fun lruEviction_stopsOnceUnderLimit() {
+        val items = listOf(
+            item("track-1", isPlaybackCache = true, fileSizeBytes = 100L * MB, lastAccessedAtMs = 1000L),
+            item("track-2", isPlaybackCache = true, fileSizeBytes = 100L * MB, lastAccessedAtMs = 2000L),
+            item("track-3", isPlaybackCache = true, fileSizeBytes = 100L * MB, lastAccessedAtMs = 3000L),
+        )
+        // 300MB total, limit 150MB → need to remove at most 2 items, but first one removal (100MB) makes it 200MB
+        // still over, second removal (100MB) makes it 100MB, which is under 150MB
+        val toRemove = lruEvict(items, 150L * MB)
+
+        assertEquals(listOf("track-1", "track-2"), toRemove.map { it.trackId })
+    }
+
+    @Test
+    fun prunePlaybackCache_doesNotRemovePermanentDownloads() {
+        val keepCacheIds = setOf("track-cache-kept")
+        val items = listOf(
+            item("track-download", isPlaybackCache = false),
+            item("track-cache-kept", isPlaybackCache = true),
+            item("track-cache-pruned", isPlaybackCache = true),
+        )
+
+        // prunePlaybackCache removes cache items not in keepCacheIds
+        val pruned = items.filter {
+            it.isPlaybackCache && it.trackId !in keepCacheIds
+        }
+
+        assertEquals(listOf("track-cache-pruned"), pruned.map { it.trackId })
+        // permanent download is never in the pruned set
+        assertTrue(items.filter { !it.isPlaybackCache }.none { it.trackId in pruned.map { p -> p.trackId } })
+    }
+
+    @Test
+    fun prefetchWarmup_doesNotOverwritePermanentDownload() {
+        // Simulate the guard that prefetchPlaybackQueue applies before enqueuing.
+        // A permanent download entry must survive even when its file is missing.
+        val permanentDownload = item("track-1", isPlaybackCache = false, status = NavidromeDownloadStatus.Completed)
+        val existingByTrackId = mapOf("track-1" to permanentDownload)
+
+        // Should resolve to null (skip) because existing is a permanent download
+        val wouldEnqueue = existingByTrackId["track-1"]?.let { existing ->
+            if (!existing.isPlaybackCache) null else existing
+        }
+
+        assertEquals(null, wouldEnqueue)
+    }
+
+    @Test
+    fun removeItems_doesNotWipePermanentDownloadWhenCacheRowSharedTrackId() {
+        // Verifies that the removal key includes isPlaybackCache so both rows can coexist.
+        data class RemovalKey(val serverId: String, val libraryId: String, val trackId: String, val isPlaybackCache: Boolean)
+
+        val permanentDownload = item("track-1", isPlaybackCache = false)
+        val cacheEntry = item("track-1", isPlaybackCache = true)
+        val current = listOf(permanentDownload, cacheEntry)
+
+        val toRemove = listOf(cacheEntry)
+        val removalKeys = toRemove.map { RemovalKey(it.serverId, it.libraryId, it.trackId, it.isPlaybackCache) }.toSet()
+        val result = current.filterNot { RemovalKey(it.serverId, it.libraryId, it.trackId, it.isPlaybackCache) in removalKeys }
+
+        assertEquals(1, result.size)
+        assertFalse(result.single().isPlaybackCache)
+    }
+
+    @Test
+    fun prefetchReplaceItems_onlyRemovesCacheRows() {
+        val serverId = "srv"
+        val libraryId = "lib"
+        val permanentDownload = item("track-1", isPlaybackCache = false)
+        val cacheEntry = item("track-1", isPlaybackCache = true)
+        val otherItem = item("track-2", isPlaybackCache = false)
+        val current = listOf(permanentDownload, otherItem)
+        val newTrackIds = setOf("track-1")
+
+        // Mirrors the fixed replaceItems logic: only remove if isPlaybackCache
+        val result = current.filterNot {
+            it.serverId == serverId &&
+                it.libraryId == libraryId &&
+                it.trackId in newTrackIds &&
+                it.isPlaybackCache
+        } + listOf(cacheEntry)
+
+        // Permanent download for track-1 is preserved, cache entry is added alongside
+        assertEquals(3, result.size)
+        assertTrue(result.any { it.trackId == "track-1" && !it.isPlaybackCache })
+        assertTrue(result.any { it.trackId == "track-1" && it.isPlaybackCache })
+    }
+
+    // endregion
+
+    // region Disable / re-enable caching guard
+
+    @Test
+    fun prefetchEarlyExit_skipsWhenCachingDisabled() {
+        // Mirrors the prefetchPlaybackQueue guard: if toBytes returns null, caching is off.
+        val offBytes = NavidromeCacheSizeOption.toBytes(NavidromeCacheSizeOption.NO_CACHING)
+        val shouldSkip = offBytes == null
+        assertTrue("prefetch must exit early when NO_CACHING is active", shouldSkip)
+    }
+
+    @Test
+    fun prefetchEarlyExit_proceedsForEveryNonOffOption() {
+        // Every option except NO_CACHING must produce a non-null byte value so prefetch runs.
+        val nonOffOptions = NavidromeCacheSizeOption.all.filter { it != NavidromeCacheSizeOption.NO_CACHING }
+        assertTrue("all list must contain non-off options", nonOffOptions.isNotEmpty())
+        nonOffOptions.forEach { option ->
+            assertFalse(
+                "toBytes($option) must not be null — prefetch would be incorrectly skipped",
+                NavidromeCacheSizeOption.toBytes(option) == null
+            )
+        }
+    }
+
+    @Test
+    fun reenableCachingGuard_invalidatesWarmupOnlyForNonOffOptions() {
+        // Mirrors the setPlaybackCacheSizeLimit guard: invalidate warmup only when
+        // switching TO a real limit, never when switching to NO_CACHING.
+        val shouldInvalidateForOff = NavidromeCacheSizeOption.toBytes(NavidromeCacheSizeOption.NO_CACHING) != null
+        assertFalse("warmup must NOT be invalidated when disabling caching", shouldInvalidateForOff)
+
+        val nonOffOptions = NavidromeCacheSizeOption.all.filter { it != NavidromeCacheSizeOption.NO_CACHING }
+        nonOffOptions.forEach { option ->
+            val shouldInvalidate = NavidromeCacheSizeOption.toBytes(option) != null
+            assertTrue("warmup must be invalidated when enabling $option", shouldInvalidate)
+        }
+    }
+
+    @Test
+    fun noLimit_neverEvictsAnything() {
+        // NO_LIMIT returns Long.MAX_VALUE — eviction loop must always break immediately.
+        val limitBytes = NavidromeCacheSizeOption.toBytes(NavidromeCacheSizeOption.NO_LIMIT)!!
+        val items = listOf(
+            item("track-1", isPlaybackCache = true, fileSizeBytes = 500L * MB, lastAccessedAtMs = 1000L),
+            item("track-2", isPlaybackCache = true, fileSizeBytes = 500L * MB, lastAccessedAtMs = 2000L),
+        )
+        val toRemove = lruEvict(items, limitBytes)
+        assertTrue("NO_LIMIT must never evict any cache items", toRemove.isEmpty())
+    }
+
+    // endregion
+
+    // region helpers
+
+    private val MB = 1024 * 1024L
+
+    private fun lruEvict(cacheItems: List<NavidromeDownloadItem>, limitBytes: Long): List<NavidromeDownloadItem> {
+        val sorted = cacheItems.sortedBy { it.lastAccessedAtMs }
+        var totalBytes = sorted.sumOf { it.fileSizeBytes ?: 0L }
+        val toRemove = mutableListOf<NavidromeDownloadItem>()
+        for (it in sorted) {
+            if (totalBytes <= limitBytes) break
+            toRemove += it
+            totalBytes -= it.fileSizeBytes ?: 0L
+        }
+        return toRemove
+    }
+
+    private fun item(
+        id: String,
+        isPlaybackCache: Boolean = false,
+        status: NavidromeDownloadStatus = NavidromeDownloadStatus.Completed,
+        fileSizeBytes: Long? = null,
+        lastAccessedAtMs: Long = 1000L
+    ): NavidromeDownloadItem = NavidromeDownloadItem(
+        serverId = "srv",
+        libraryId = "lib",
+        trackId = id,
+        albumId = null,
+        albumSongCount = null,
+        artistId = null,
+        title = "Title $id",
+        artistName = "Artist",
+        albumName = "Album",
+        coverUrl = null,
+        durationSeconds = 180,
+        formatLabel = "mp3",
+        status = status,
+        progressPercent = if (status == NavidromeDownloadStatus.Completed) 100 else 0,
+        isPlaybackCache = isPlaybackCache,
+        fileSizeBytes = fileSizeBytes,
+        lastAccessedAtMs = lastAccessedAtMs,
+        updatedAtMs = 0L
+    )
+
+    // endregion
+}

--- a/docs/navidrome-cache-policy-plan.md
+++ b/docs/navidrome-cache-policy-plan.md
@@ -1,0 +1,107 @@
+# Navidrome Cache Policy Plan
+
+## Purpose
+
+Build a user-controlled Navidrome playback cache that feels smooth like a media app should, without making cached tracks look like permanent downloads.
+
+This plan is intentionally incremental. Work top to bottom and check each item off as it lands.
+
+## Scope
+
+- Navidrome only.
+- Playback cache only, not library-wide caching.
+- Keep explicit downloads separate from cache.
+- Preserve the playback stability fixes that already shipped.
+
+## Goals
+
+- Cache songs that are likely to play soon.
+- Keep the cache bounded by size.
+- Let users turn caching off.
+- Let users clear cached music manually.
+- Show a cached indicator in song and queue rows.
+- Keep cached music out of the Downloaded tab.
+
+## Non-Goals
+
+- Do not cache the entire Songs library automatically.
+- Do not merge cache state with normal downloads.
+- Do not change ABS playback behavior.
+- Do not build a cross-backend cache system.
+
+## Phase 1: Cache Model
+
+- [x] Add a dedicated Navidrome playback cache record separate from explicit downloads.
+- [x] Store cache files in app-private cache storage.
+- [x] Track last access time for each cached track.
+- [x] Track cached byte size per account or active server context.
+- [x] Keep the cache state resilient across app restarts.
+- [x] Make it impossible for cached items to be mistaken for permanent user downloads.
+
+## Phase 2: Cache Policy
+
+- [x] Add a user-facing cache size setting.
+- [x] Support `Off` as a cache-size option.
+- [x] Support a small set of practical cache size choices in gigabytes or megabytes.
+- [x] Enforce the size limit with LRU eviction.
+- [x] Prefer evicting the least recently used cached tracks first.
+- [x] Remove stale cached files when the active queue changes.
+- [x] Remove stale cached files when caching is disabled.
+- [x] Keep explicit downloads out of the cache eviction path.
+
+## Phase 3: Playback Integration
+
+- [x] Continue preferring local cached files when they exist.
+- [x] Fall back to streaming when cache is missing or disabled.
+- [x] Cache the current track and the near-future queue window.
+- [x] Keep warmup bounded so it does not flood storage or download slots.
+- [x] Preserve recovery behavior after source errors.
+- [x] Make queue additions and mid-play inserts eligible for cache warmup.
+
+## Phase 4: UI and Settings
+
+- [x] Add a Navidrome cache section to settings.
+- [x] Add a cache-size picker with `Off` and several size options.
+- [x] Add a `Clear cached music` action.
+- [x] Show the current cache usage and selected limit.
+- [x] Add a cache badge or icon to songs that are cached.
+- [x] Show the badge in queue and album/song list rows where it makes sense.
+- [x] Make the cache badge visually distinct from the normal download state.
+
+## Phase 5: Download Separation
+
+- [x] Keep the Downloaded tab showing only explicit downloads.
+- [x] Keep cache items out of the standard download state flow.
+- [x] Promote a cached track to a real download if the user explicitly downloads it.
+- [x] Ensure cache cleanup does not delete explicit downloads.
+- [x] Ensure explicit download removal does not accidentally clear unrelated cache.
+
+## Phase 6: Tests
+
+- [x] Test cache-size setting parsing and `Off`.
+- [x] Test LRU eviction when cache exceeds the limit.
+- [x] Test that cached items are not counted as normal downloads.
+- [x] Test that the Downloaded tab ignores cache-only items.
+- [ ] Test that the cache badge appears for cached rows. (UI/Compose — skipped; pure logic covered above)
+- [x] Test local-cache-first playback resolution.
+- [x] Test stream fallback when cache is unavailable.
+- [ ] Test that explicit downloads still work normally. (covered by existing NavidromeDownloadReconciliationTest)
+- [x] Test that cache pruning does not remove permanent downloads.
+
+## Implementation Order
+
+1. Cache model and metadata.
+2. Cache size setting and eviction policy.
+3. Playback integration.
+4. UI badge and settings screen.
+5. Download separation cleanup.
+6. Tests.
+
+## Done Criteria
+
+- Navidrome cache can be turned on or off by the user.
+- Cache stays bounded and self-prunes.
+- Cached songs are visible as cached, not as downloaded.
+- Explicit downloads still behave exactly like downloads.
+- Playback still feels smooth and recovers cleanly after failures.
+


### PR DESCRIPTION
## Summary
- Ship the Navidrome playback cache work end to end, including cache separation, cache controls, cache badges, and playback stability fixes.
- Include the Navidrome album paging fix and the confirmation dialog for clearing cached music.
- Keep the full branch payload intact, including code I did not author.

## Verification
- `rtk run ./gradlew :app:compileGithubDebugKotlin`
- `rtk run ./gradlew :app:testGithubDebugUnitTest --tests com.stillshelf.app.downloads.navidrome.NavidromeCachePolicyTest --tests com.stillshelf.app.data.repo.NavidromeRepositoryAlbumPagingTest`
