### PR TITLE
Polish Navidrome cache UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 95
-val appVersionName = "0.5.3"
+val appVersionCode = 96
+val appVersionName = "0.5.4"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
@@ -5099,6 +5099,7 @@ private fun NavidromeSettingsRoute(
                 NavidromeSettingsRow(
                     title = "Clear cached music",
                     value = if (uiState.isClearingCache) "Clearing…" else formatStorageSize(uiState.playbackCacheUsageBytes),
+                    titleMaxLines = 1,
                     valueTextAlign = TextAlign.End,
                     onClick = if (uiState.isClearingCache) null else ({ clearCachedMusicDialogVisible = true })
                 )
@@ -12114,7 +12115,9 @@ private fun PlayerQueueRow(
                     }
                 }
                 if (isCached) {
-                    CacheIndicator()
+                    CacheIndicator(
+                        tint = if (immersiveEnabled) Color.White else MaterialTheme.colorScheme.primary.copy(alpha = 0.72f)
+                    )
                 }
                 if (trailingContent != null) {
                     trailingContent()
@@ -12124,12 +12127,13 @@ private fun PlayerQueueRow(
 }
 
 @Composable
-private fun CacheIndicator() {
+private fun CacheIndicator(tint: Color? = null) {
+    val resolvedTint = tint ?: MaterialTheme.colorScheme.primary.copy(alpha = 0.72f)
     Icon(
         imageVector = Icons.Outlined.ArrowCircleDown,
         contentDescription = "Cached track",
         modifier = Modifier.size(18.dp),
-        tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.72f)
+        tint = resolvedTint
     )
 }
 


### PR DESCRIPTION
## Summary
- Keep the Clear cached music row on one line so it does not wrap awkwardly.
- Make the cached arrow icon white in the immersive fullscreen player.
- Bump app version for the release build.

## Verification
- `rtk ./gradlew :app:compileGithubDebugKotlin`
