### PR TITLE
Fix Navidrome queue cache warmup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 97
-val appVersionName = "0.5.5"
+val appVersionCode = 98
+val appVersionName = "0.5.6"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
@@ -1204,6 +1204,7 @@ class NavidromePlayerController @Inject constructor(
         updateStateFromPlayer()
         persistPlaybackSnapshot(force = true)
         ensureProgressUpdates()
+        schedulePlaybackCacheWarmup(queueTracks)
     }
 
     private fun releasePlayer(clearQueue: Boolean) {
@@ -1517,6 +1518,9 @@ class NavidromePlayerController @Inject constructor(
             }
         )
         persistPlaybackSnapshot()
+        if (previousState.currentIndex != currentIndex && currentIndex in queueTracks.indices) {
+            schedulePlaybackCacheWarmup(queueTracks)
+        }
         if ((activePlayer.isPlaying || playbackState == Player.STATE_READY) && currentTrack?.id == playbackRecoveryTrackId) {
             playbackRecoveryTrackId = null
         }


### PR DESCRIPTION
## Summary
- Reschedule Navidrome playback cache warmup when the active queue index changes.
- Keep the next 20-track cache window working when jumping around inside the queue.
- Bump the app version for the release.

## Verification
- `rtk ./gradlew :app:compileGithubReleaseKotlin`
