### PR TITLE
Add Navidrome seek controls

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 98
-val appVersionName = "0.5.6"
+val appVersionCode = 99
+val appVersionName = "0.5.7"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/core/datastore/SessionPreferences.kt
+++ b/app/src/main/java/com/stillshelf/app/core/datastore/SessionPreferences.kt
@@ -104,6 +104,8 @@ class SessionPreferences @Inject constructor(
     private val playerBottomToolsStyleKey = stringPreferencesKey("player_bottom_tools_style")
     private val skipForwardSecondsKey = intPreferencesKey("skip_forward_seconds")
     private val skipBackwardSecondsKey = intPreferencesKey("skip_backward_seconds")
+    private val navidromeSkipForwardSecondsKey = intPreferencesKey("navidrome_skip_forward_seconds")
+    private val navidromeSkipBackwardSecondsKey = intPreferencesKey("navidrome_skip_backward_seconds")
     private val softToneLevelKey = floatPreferencesKey("soft_tone_level")
     private val boostLevelKey = floatPreferencesKey("boost_level")
     private val lockScreenControlModeKey = stringPreferencesKey("lock_screen_control_mode")
@@ -881,6 +883,18 @@ class SessionPreferences @Inject constructor(
     suspend fun setSkipBackwardSeconds(seconds: Int) {
         dataStore.edit { prefs ->
             prefs[skipBackwardSecondsKey] = seconds.coerceIn(5, 600)
+        }
+    }
+
+    suspend fun setNavidromeSkipForwardSeconds(seconds: Int) {
+        dataStore.edit { prefs ->
+            prefs[navidromeSkipForwardSecondsKey] = seconds.coerceIn(10, 60)
+        }
+    }
+
+    suspend fun setNavidromeSkipBackwardSeconds(seconds: Int) {
+        dataStore.edit { prefs ->
+            prefs[navidromeSkipBackwardSecondsKey] = seconds.coerceIn(10, 60)
         }
     }
 
@@ -1955,7 +1969,9 @@ class SessionPreferences @Inject constructor(
             pendingUpdateVersionName = this[pendingUpdateVersionNameKey],
             recentSearchTerms = parseStringArray(this[recentSearchTermsKey]),
             navidromeRecentSearchTerms = parseStringArray(this[navidromeRecentSearchTermsKey]),
-            navidromeCacheSizeLimit = this[navidromeCacheSizeLimitKey] ?: NavidromeCacheSizeOption.default
+            navidromeCacheSizeLimit = this[navidromeCacheSizeLimitKey] ?: NavidromeCacheSizeOption.default,
+            navidromeSkipForwardSeconds = (this[navidromeSkipForwardSecondsKey] ?: 15).coerceIn(10, 60),
+            navidromeSkipBackwardSeconds = (this[navidromeSkipBackwardSecondsKey] ?: 15).coerceIn(10, 60)
         )
     }
 }
@@ -2028,7 +2044,9 @@ data class SessionPreferenceState(
     val pendingUpdateVersionName: String? = null,
     val recentSearchTerms: List<String> = emptyList(),
     val navidromeRecentSearchTerms: List<String> = emptyList(),
-    val navidromeCacheSizeLimit: String = NavidromeCacheSizeOption.default
+    val navidromeCacheSizeLimit: String = NavidromeCacheSizeOption.default,
+    val navidromeSkipForwardSeconds: Int = 15,
+    val navidromeSkipBackwardSeconds: Int = 15
 )
 
 data class CachedHomeFeedPayload(

--- a/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
@@ -955,6 +955,12 @@ class NavidromePlayerController @Inject constructor(
         persistPlaybackSnapshot(force = true)
     }
 
+    fun seekBy(deltaMs: Long) {
+        val duration = resolvePlayerDurationMs()
+        val current = resolvePlayerPositionMs(duration).toLong()
+        seekTo((current + deltaMs).coerceIn(0L, duration.toLong().coerceAtLeast(0L)).toInt())
+    }
+
     private fun startPlaybackAt(
         index: Int,
         positionMs: Int,

--- a/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
@@ -218,6 +218,10 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.lerp
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
@@ -279,6 +283,7 @@ import com.stillshelf.app.ui.theme.AppThemeMode
 import com.stillshelf.app.ui.theme.LocalMaterialDesignEnabled
 import kotlin.math.min
 import kotlin.math.roundToInt
+import kotlin.math.cos
 import kotlin.math.sin
 import java.net.URI
 import java.util.Locale
@@ -656,6 +661,8 @@ fun NavidromeAppRoute(
     val playerState by playerViewModel.uiState.collectAsStateWithLifecycle()
     val lyricsUiState by playerViewModel.lyricsUiState.collectAsStateWithLifecycle()
     val favoriteTrackIds by playerViewModel.favoriteTrackIds.collectAsStateWithLifecycle()
+    val skipForwardSeconds by playerViewModel.skipForwardSeconds.collectAsStateWithLifecycle()
+    val skipBackwardSeconds by playerViewModel.skipBackwardSeconds.collectAsStateWithLifecycle()
     val downloadUiState by downloadsViewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val showMiniPlayer = playerState.currentTrack != null
@@ -734,6 +741,10 @@ fun NavidromeAppRoute(
                 onPrevious = playerViewModel::playPrevious,
                 onPlayPause = playerViewModel::togglePlayPause,
                 onNext = playerViewModel::playNext,
+                onSeekForward = playerViewModel::seekForward,
+                onSeekBackward = playerViewModel::seekBackward,
+                skipForwardSeconds = skipForwardSeconds,
+                skipBackwardSeconds = skipBackwardSeconds,
                 onSelectTrack = playerViewModel::playQueueIndex,
                 onSeekTo = playerViewModel::seekTo,
                 onRefreshAudioOutputs = playerViewModel::refreshAudioOutputs,
@@ -4906,6 +4917,9 @@ private fun NavidromeSettingsRoute(
     var serverScanDialogVisible by rememberSaveable { mutableStateOf(false) }
     var clearCachedMusicDialogVisible by rememberSaveable { mutableStateOf(false) }
     var cacheSizeMenuExpanded by rememberSaveable { mutableStateOf(false) }
+    var skipForwardDialogVisible by rememberSaveable { mutableStateOf(false) }
+    var skipBackwardDialogVisible by rememberSaveable { mutableStateOf(false) }
+    val skipSecondChoices = remember { listOf(10, 15, 30, 45, 60) }
     val sectionCardColor = if (appearanceUiState.navidromeMaterialDesignEnabled) {
         MaterialTheme.colorScheme.surfaceContainerHigh
     } else {
@@ -5036,6 +5050,34 @@ private fun NavidromeSettingsRoute(
                         ?: if (uiState.lyricsSources.isEmpty()) "Not configured" else "Choose source",
                     valueTextAlign = TextAlign.End,
                     onClick = onOpenLyricsSources
+                )
+            }
+        }
+        item {
+            Text(
+                text = "PLAYER CONTROLS",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = AppScreenHorizontalPadding)
+            )
+        }
+        item {
+            GroupedSettingsCard(
+                containerColor = sectionCardColor,
+                border = sectionCardBorder
+            ) {
+                NavidromeSettingsRow(
+                    title = "Skip Forward",
+                    value = "${uiState.navidromeSkipForwardSeconds} seconds",
+                    valueTextAlign = TextAlign.End,
+                    onClick = { skipForwardDialogVisible = true }
+                )
+                DividerLine()
+                NavidromeSettingsRow(
+                    title = "Skip Backward",
+                    value = "${uiState.navidromeSkipBackwardSeconds} seconds",
+                    valueTextAlign = TextAlign.End,
+                    onClick = { skipBackwardDialogVisible = true }
                 )
             }
         }
@@ -5247,6 +5289,60 @@ private fun NavidromeSettingsRoute(
                 dismissButton = {
                     TextButton(onClick = { clearCachedMusicDialogVisible = false }) {
                         Text("Cancel")
+                    }
+                }
+            )
+        }
+        if (skipForwardDialogVisible) {
+            AlertDialog(
+                onDismissRequest = { skipForwardDialogVisible = false },
+                title = { Text("Skip Forward") },
+                text = {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        skipSecondChoices.forEach { seconds ->
+                            NavidromeSettingsRow(
+                                title = "$seconds seconds",
+                                selected = uiState.navidromeSkipForwardSeconds == seconds,
+                                showChevronWhenUnselected = false,
+                                onClick = {
+                                    viewModel.setNavidromeSkipForwardSeconds(seconds)
+                                    skipForwardDialogVisible = false
+                                }
+                            )
+                        }
+                    }
+                },
+                confirmButton = {},
+                dismissButton = {
+                    TextButton(onClick = { skipForwardDialogVisible = false }) {
+                        Text("Close")
+                    }
+                }
+            )
+        }
+        if (skipBackwardDialogVisible) {
+            AlertDialog(
+                onDismissRequest = { skipBackwardDialogVisible = false },
+                title = { Text("Skip Backward") },
+                text = {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        skipSecondChoices.forEach { seconds ->
+                            NavidromeSettingsRow(
+                                title = "$seconds seconds",
+                                selected = uiState.navidromeSkipBackwardSeconds == seconds,
+                                showChevronWhenUnselected = false,
+                                onClick = {
+                                    viewModel.setNavidromeSkipBackwardSeconds(seconds)
+                                    skipBackwardDialogVisible = false
+                                }
+                            )
+                        }
+                    }
+                },
+                confirmButton = {},
+                dismissButton = {
+                    TextButton(onClick = { skipBackwardDialogVisible = false }) {
+                        Text("Close")
                     }
                 }
             )
@@ -9836,6 +9932,10 @@ private fun NavidromeExpandedPlayerSheet(
     onPrevious: () -> Unit,
     onPlayPause: () -> Unit,
     onNext: () -> Unit,
+    onSeekForward: () -> Unit,
+    onSeekBackward: () -> Unit,
+    skipForwardSeconds: Int = 15,
+    skipBackwardSeconds: Int = 15,
     onSelectTrack: (Int) -> Unit,
     onSeekTo: (Int) -> Unit,
     onRefreshAudioOutputs: () -> Unit,
@@ -10287,19 +10387,37 @@ private fun NavidromeExpandedPlayerSheet(
             }
         }
         val transportRow: @Composable () -> Unit = {
+            val seekButtonTint = if (immersiveEnabled) Color.White else MaterialTheme.colorScheme.onSurface
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceEvenly,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                NavidromeTransportIconButton(
-                    onClick = onPrevious,
-                    modifier = Modifier.size(skipButtonSize),
-                    icon = Icons.Outlined.SkipPrevious,
-                    contentDescription = "Previous",
-                    iconSize = skipIconSize,
-                    tint = if (immersiveEnabled) Color.White else MaterialTheme.colorScheme.onSurface
-                )
+                Row(
+                    modifier = Modifier.weight(1f),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    if (isRadio) {
+                        Spacer(modifier = Modifier.size(skipButtonSize))
+                    } else {
+                        NavidromeSeekButton(
+                            seconds = skipBackwardSeconds,
+                            forward = false,
+                            onClick = onSeekBackward,
+                            tint = seekButtonTint,
+                            buttonSize = skipButtonSize,
+                            iconSize = skipIconSize
+                        )
+                    }
+                    NavidromeTransportIconButton(
+                        onClick = onPrevious,
+                        modifier = Modifier.size(skipButtonSize),
+                        icon = Icons.Outlined.SkipPrevious,
+                        contentDescription = "Previous",
+                        iconSize = skipIconSize,
+                        tint = seekButtonTint
+                    )
+                }
                 Surface(
                     modifier = Modifier.size(transportButtonSize),
                     shape = CircleShape,
@@ -10345,14 +10463,32 @@ private fun NavidromeExpandedPlayerSheet(
                         }
                     }
                 }
-                NavidromeTransportIconButton(
-                    onClick = onNext,
-                    modifier = Modifier.size(skipButtonSize),
-                    icon = Icons.Outlined.SkipNext,
-                    contentDescription = "Next",
-                    iconSize = skipIconSize,
-                    tint = if (immersiveEnabled) Color.White else MaterialTheme.colorScheme.onSurface
-                )
+                Row(
+                    modifier = Modifier.weight(1f),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    NavidromeTransportIconButton(
+                        onClick = onNext,
+                        modifier = Modifier.size(skipButtonSize),
+                        icon = Icons.Outlined.SkipNext,
+                        contentDescription = "Next",
+                        iconSize = skipIconSize,
+                        tint = seekButtonTint
+                    )
+                    if (isRadio) {
+                        Spacer(modifier = Modifier.size(skipButtonSize))
+                    } else {
+                        NavidromeSeekButton(
+                            seconds = skipForwardSeconds,
+                            forward = true,
+                            onClick = onSeekForward,
+                            tint = seekButtonTint,
+                            buttonSize = skipButtonSize,
+                            iconSize = skipIconSize
+                        )
+                    }
+                }
             }
         }
         val toolRow: @Composable () -> Unit = {
@@ -11736,6 +11872,90 @@ private fun NavidromePlayerToolButton(
                 overflow = TextOverflow.Ellipsis
             )
         }
+    }
+}
+
+@Composable
+private fun NavidromeSeekButton(
+    seconds: Int,
+    forward: Boolean,
+    onClick: () -> Unit,
+    tint: Color,
+    buttonSize: Dp,
+    iconSize: Dp
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val pressedContainerColor = if (isPressed) tint.copy(alpha = 0.14f) else Color.Transparent
+    Box(
+        modifier = Modifier
+            .semantics(mergeDescendants = true) {
+                role = Role.Button
+                contentDescription = if (forward) {
+                    "Skip forward $seconds seconds"
+                } else {
+                    "Skip backward $seconds seconds"
+                }
+            }
+            .size(buttonSize)
+            .clip(CircleShape)
+            .background(pressedContainerColor)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Canvas(
+            modifier = Modifier
+                .size(iconSize)
+                .graphicsLayer { scaleX = if (forward) 1f else -1f }
+        ) {
+            val strokeWidth = 2.6.dp.toPx()
+            val inset = 3.dp.toPx()
+            val arcSize = size.minDimension - inset * 2
+            val arrowHeadAngle = 270f
+            val tailStartAngle = 40f
+            drawArc(
+                color = tint,
+                startAngle = tailStartAngle,
+                sweepAngle = arrowHeadAngle - tailStartAngle,
+                useCenter = false,
+                topLeft = Offset(inset, inset),
+                size = Size(arcSize, arcSize),
+                style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
+            )
+            val radius = arcSize / 2f
+            val cx = size.width / 2f
+            val cy = size.height / 2f
+            val angle = Math.toRadians(arrowHeadAngle.toDouble())
+            val x = cx + radius * cos(angle).toFloat()
+            val y = cy + radius * sin(angle).toFloat()
+            val head = 5.dp.toPx()
+            drawLine(
+                color = tint,
+                start = Offset(x, y),
+                end = Offset(x - head, y - head * 0.55f),
+                strokeWidth = strokeWidth,
+                cap = StrokeCap.Round
+            )
+            drawLine(
+                color = tint,
+                start = Offset(x, y),
+                end = Offset(x - head, y + head * 0.55f),
+                strokeWidth = strokeWidth,
+                cap = StrokeCap.Round
+            )
+        }
+        Text(
+            text = seconds.coerceIn(10, 60).toString(),
+            style = MaterialTheme.typography.labelSmall.copy(
+                fontSize = 11.sp,
+                fontWeight = FontWeight.SemiBold
+            ),
+            color = tint
+        )
     }
 }
 

--- a/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeViewModels.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeViewModels.kt
@@ -1792,6 +1792,8 @@ class NavidromeSettingsViewModel @Inject constructor(
             playbackCacheUsageBytes = playbackCacheUsageBytes,
             playbackCacheItemCount = playbackCacheItemCount,
             isClearingCache = localState.isClearingCache,
+            navidromeSkipForwardSeconds = preferences.navidromeSkipForwardSeconds,
+            navidromeSkipBackwardSeconds = preferences.navidromeSkipBackwardSeconds,
             activeServerId = activeServerId,
             availableLibraries = localState.libraries,
             activeLibraryId = activeLibraryId,
@@ -2062,6 +2064,14 @@ class NavidromeSettingsViewModel @Inject constructor(
                 playerController.invalidatePlaybackCacheWarmup()
             }
         }
+    }
+
+    fun setNavidromeSkipForwardSeconds(seconds: Int) {
+        viewModelScope.launch { sessionPreferences.setNavidromeSkipForwardSeconds(seconds) }
+    }
+
+    fun setNavidromeSkipBackwardSeconds(seconds: Int) {
+        viewModelScope.launch { sessionPreferences.setNavidromeSkipBackwardSeconds(seconds) }
     }
 
     fun clearPlaybackCache() {
@@ -2550,6 +2560,12 @@ class NavidromePlayerViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(5_000),
             initialValue = emptySet()
         )
+    val skipForwardSeconds: StateFlow<Int> = preferenceState
+        .map { it.navidromeSkipForwardSeconds }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 15)
+    val skipBackwardSeconds: StateFlow<Int> = preferenceState
+        .map { it.navidromeSkipBackwardSeconds }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 15)
 
     init {
         viewModelScope.launch {
@@ -2668,6 +2684,14 @@ class NavidromePlayerViewModel @Inject constructor(
 
     fun seekTo(positionMs: Int) {
         playerController.seekTo(positionMs)
+    }
+
+    fun seekForward() {
+        playerController.seekBy(skipForwardSeconds.value * 1000L)
+    }
+
+    fun seekBackward() {
+        playerController.seekBy(-skipBackwardSeconds.value * 1000L)
     }
 
     fun refreshAudioOutputs() {
@@ -3063,6 +3087,8 @@ data class NavidromeSettingsUiState(
     val playbackCacheUsageBytes: Long = 0L,
     val playbackCacheItemCount: Int = 0,
     val isClearingCache: Boolean = false,
+    val navidromeSkipForwardSeconds: Int = 15,
+    val navidromeSkipBackwardSeconds: Int = 15,
     val activeServerId: String? = null,
     val availableLibraries: List<NavidromeLibrary> = emptyList(),
     val activeLibraryId: String? = null,


### PR DESCRIPTION
Adds Navidrome-only seek forward/back controls to the fullscreen player, along with separate NV skip-step settings and accessibility semantics for the new button.

Validation:
- `rtk run ./gradlew :app:compileGithubDebugKotlin`
- `rtk run ./gradlew :app:compileGithubReleaseKotlin`
- `rtk run ./gradlew :app:assembleGithubRelease`