### PR TITLE
[codex] fix navidrome connection refresh

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 101
-val appVersionName = "0.5.9"
+val appVersionCode = 102
+val appVersionName = "0.6.0"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
@@ -45,6 +45,7 @@ import coil.imageLoader
 import coil.request.ImageRequest
 import com.stillshelf.app.MainActivity
 import com.stillshelf.app.core.datastore.SessionPreferences
+import com.stillshelf.app.core.model.ActiveServerConnectionStatus
 import com.stillshelf.app.core.model.NavidromeOutputDevice
 import com.stillshelf.app.core.model.NavidromePlayerState
 import com.stillshelf.app.core.model.NavidromeQueueDisplayMode
@@ -63,6 +64,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
@@ -529,6 +531,7 @@ class NavidromePlayerController @Inject constructor(
         })
         mediaSession.isActive = false
         observeEqualizerPreferences()
+        observeActiveConnectionChanges()
         refreshAudioOutputDevices(reason = OutputRefreshReason.General)
         restorePlaybackSnapshot()
         ensureProgressUpdates()
@@ -1675,6 +1678,78 @@ class NavidromePlayerController @Inject constructor(
         mediaSession.isActive = false
         PlaybackServiceController.stop(appContext)
         NotificationManagerCompat.from(appContext).cancel(NOTIFICATION_ID)
+    }
+
+    private fun observeActiveConnectionChanges() {
+        scope.launch {
+            var hasObservedStatus = false
+            var lastStatus: ActiveServerConnectionStatus? = null
+            navidromeRepository.observeActiveConnectionStatus().collect { status ->
+                if (!hasObservedStatus) {
+                    hasObservedStatus = true
+                    lastStatus = status
+                    return@collect
+                }
+                if (status != lastStatus) {
+                    lastStatus = status
+                    refreshPlaybackPresentationForConnectionChange()
+                }
+            }
+        }
+    }
+
+    private fun refreshPlaybackPresentationForConnectionChange() {
+        val currentTrack = mutableState.value.currentTrack ?: return
+        if (currentTrack.id.startsWith("radio:")) return
+        val queueSnapshot = queueTracks
+        val recentSnapshot = recentTracks
+        scope.launch(Dispatchers.IO) {
+            val refreshedQueue = if (queueSnapshot.isEmpty()) {
+                queueSnapshot
+            } else {
+                when (val result = navidromeRepository.refreshPlayableTracks(queueSnapshot)) {
+                    is com.stillshelf.app.core.util.AppResult.Success -> result.value
+                    is com.stillshelf.app.core.util.AppResult.Error -> queueSnapshot
+                }
+            }
+            val refreshedRecent = if (recentSnapshot.isEmpty()) {
+                recentSnapshot
+            } else {
+                when (val result = navidromeRepository.refreshPlayableTracks(recentSnapshot)) {
+                    is com.stillshelf.app.core.util.AppResult.Success -> result.value
+                    is com.stillshelf.app.core.util.AppResult.Error -> recentSnapshot
+                }
+            }
+            val refreshedCurrentTrack = currentTrack.albumId?.let { albumId ->
+                when (val result = navidromeRepository.fetchAlbumDetail(albumId, forceRefresh = true)) {
+                    is com.stillshelf.app.core.util.AppResult.Success -> {
+                        result.value.tracks.firstOrNull { it.id == currentTrack.id } ?: currentTrack
+                    }
+                    is com.stillshelf.app.core.util.AppResult.Error -> currentTrack
+                }
+            } ?: currentTrack
+            scope.launch(Dispatchers.Main.immediate) {
+                if (mutableState.value.currentTrack?.id != currentTrack.id) return@launch
+                queueTracks = refreshedQueue.map { track ->
+                    if (track.id == refreshedCurrentTrack.id) refreshedCurrentTrack else track
+                }
+                recentTracks = refreshedRecent.map { track ->
+                    if (track.id == refreshedCurrentTrack.id) refreshedCurrentTrack else track
+                }
+                artworkBitmap = null
+                artworkTrackId = null
+                lastNotificationSignature = null
+                mutableState.value = mutableState.value.copy(
+                    queue = queueTracks,
+                    recentTracks = recentTracks,
+                    currentTrack = refreshedCurrentTrack
+                )
+                persistPlaybackSnapshot(force = true)
+                updatePlaybackSurface()
+                ensureProgressUpdates()
+                schedulePlaybackCacheWarmup(queueTracks)
+            }
+        }
     }
 
     private fun observeEqualizerPreferences() {

--- a/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeViewModels.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeViewModels.kt
@@ -7,6 +7,7 @@ import java.io.File
 import com.stillshelf.app.core.model.NAVIDROME_EQUALIZER_MAX_DB
 import com.stillshelf.app.core.model.NAVIDROME_EQUALIZER_MIN_DB
 import com.stillshelf.app.core.model.NAVIDROME_EQUALIZER_STEP_DB
+import com.stillshelf.app.core.model.ActiveServerConnectionStatus
 import com.stillshelf.app.core.model.NavidromeAlbum
 import com.stillshelf.app.core.model.NavidromeAlbumDetail
 import com.stillshelf.app.core.model.NavidromeArtist
@@ -48,6 +49,7 @@ import java.net.URI
 import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -315,6 +317,9 @@ class NavidromeHomeViewModel @Inject constructor(
                         it.copy(isOffline = type == NetworkConnectionType.Offline)
                     }
                 }
+        }
+        observeNavidromeConnectionChanges(navidromeRepository) {
+            refresh(forceRefresh = true)
         }
     }
 
@@ -687,6 +692,9 @@ class NavidromeBrowseViewModel @Inject constructor(
 
     init {
         refresh(forceRefresh = false)
+        observeNavidromeConnectionChanges(navidromeRepository) {
+            refresh(forceRefresh = true)
+        }
     }
 
     fun selectSection(section: NavidromeBrowseSection) {
@@ -781,6 +789,9 @@ class NavidromePlaylistsViewModel @Inject constructor(
             }
         }
         refresh(forceRefresh = false)
+        observeNavidromeConnectionChanges(navidromeRepository) {
+            refresh(forceRefresh = true)
+        }
     }
 
     fun refresh(forceRefresh: Boolean = true) {
@@ -1573,6 +1584,9 @@ class NavidromeSongsViewModel @Inject constructor(
             }
         }
         refresh(forceRefresh = false)
+        observeNavidromeConnectionChanges(navidromeRepository) {
+            refresh(forceRefresh = true)
+        }
     }
 
     fun setSortOption(value: NavidromeSongSortOption) {
@@ -1623,6 +1637,9 @@ class NavidromeRadiosViewModel @Inject constructor(
 
     init {
         refresh(forceRefresh = false)
+        observeNavidromeConnectionChanges(navidromeRepository) {
+            refresh(forceRefresh = true)
+        }
     }
 
     fun refresh(forceRefresh: Boolean = true) {
@@ -2875,6 +2892,9 @@ class NavidromeArtistDetailViewModel @Inject constructor(
     init {
         observeLibrarySyncs()
         refresh(forceRefresh = false)
+        observeNavidromeConnectionChanges(navidromeRepository) {
+            refresh(forceRefresh = true)
+        }
     }
 
     fun refresh(forceRefresh: Boolean = true) {
@@ -2932,21 +2952,28 @@ class NavidromeAlbumDetailViewModel @Inject constructor(
         savedStateHandle.get<String>(NavidromeRoute.ALBUM_ID_ARG).orEmpty()
     private val mutableUiState = MutableStateFlow(NavidromeAlbumDetailUiState())
     val uiState: StateFlow<NavidromeAlbumDetailUiState> = mutableUiState.asStateFlow()
+    private val refreshGeneration = AtomicLong(0L)
 
     init {
         refresh(forceRefresh = false)
+        observeNavidromeConnectionChanges(navidromeRepository) {
+            refresh(forceRefresh = true)
+        }
     }
 
     fun refresh(forceRefresh: Boolean = true) {
+        val requestGeneration = refreshGeneration.incrementAndGet()
         viewModelScope.launch {
             when (val result = navidromeRepository.fetchAlbumDetail(albumId, forceRefresh = forceRefresh)) {
                 is AppResult.Success -> {
+                    if (refreshGeneration.get() != requestGeneration) return@launch
                     mutableUiState.update {
                         it.copy(detail = result.value, isLoading = false, errorMessage = null)
                     }
                 }
 
                 is AppResult.Error -> {
+                    if (refreshGeneration.get() != requestGeneration) return@launch
                     mutableUiState.update {
                         it.copy(isLoading = false, errorMessage = result.message)
                     }
@@ -2977,6 +3004,9 @@ class NavidromePlaylistDetailViewModel @Inject constructor(
 
     init {
         refresh(forceRefresh = false)
+        observeNavidromeConnectionChanges(navidromeRepository) {
+            refresh(forceRefresh = true)
+        }
     }
 
     fun refresh(forceRefresh: Boolean = true) {
@@ -3399,6 +3429,27 @@ internal fun buildNavidromeHomeDownloadEntries(
                 }
             }
         }
+}
+
+private fun ViewModel.observeNavidromeConnectionChanges(
+    navidromeRepository: NavidromeRepository,
+    onConnectionChanged: () -> Unit
+) {
+    viewModelScope.launch {
+        var hasObservedStatus = false
+        var lastStatus: ActiveServerConnectionStatus? = null
+        navidromeRepository.observeActiveConnectionStatus().collect { status ->
+            if (!hasObservedStatus) {
+                hasObservedStatus = true
+                lastStatus = status
+                return@collect
+            }
+            if (status != lastStatus) {
+                lastStatus = status
+                onConnectionChanged()
+            }
+        }
+    }
 }
 
 private data class Quadruple<A, B, C, D>(

--- a/app/src/test/java/com/stillshelf/app/ui/screens/navidrome/NavidromeAlbumDetailViewModelTest.kt
+++ b/app/src/test/java/com/stillshelf/app/ui/screens/navidrome/NavidromeAlbumDetailViewModelTest.kt
@@ -1,0 +1,147 @@
+package com.stillshelf.app.ui.screens.navidrome
+
+import androidx.lifecycle.SavedStateHandle
+import com.stillshelf.app.core.datastore.SessionPreferenceState
+import com.stillshelf.app.core.datastore.SessionPreferences
+import com.stillshelf.app.core.model.ActiveServerConnectionStatus
+import com.stillshelf.app.core.model.NavidromeAlbum
+import com.stillshelf.app.core.model.NavidromeAlbumDetail
+import com.stillshelf.app.core.model.NavidromeTrack
+import com.stillshelf.app.core.model.ServerConnectionMode
+import com.stillshelf.app.core.model.ServerConnectionRoute
+import com.stillshelf.app.core.util.AppResult
+import com.stillshelf.app.data.repo.NavidromeRepository
+import com.stillshelf.app.ui.navigation.NavidromeRoute
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class NavidromeAlbumDetailViewModelTest {
+    private val dispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun activeConnectionChange_winsOverSlowerInitialLoad() = runTest(dispatcher) {
+        val connectionState = MutableStateFlow<ActiveServerConnectionStatus?>(null)
+        val repository = mockk<NavidromeRepository>()
+        val sessionPreferences = mockk<SessionPreferences>() {
+            every { state } returns MutableStateFlow(
+                SessionPreferenceState(
+                    activeServerId = null,
+                    activeLibraryId = null,
+                    lastLibrarySyncAtMs = null
+                )
+            )
+        }
+        every { repository.observeActiveConnectionStatus() } returns connectionState
+        val initialFetchStarted = CompletableDeferred<Unit>()
+        val releaseInitialFetch = CompletableDeferred<Unit>()
+
+        val initialDetail = albumDetail(
+            albumName = "Old Album",
+            trackName = "Old Track"
+        )
+        val refreshedDetail = albumDetail(
+            albumName = "New Album",
+            trackName = "New Track"
+        )
+
+        coEvery { repository.fetchAlbumDetail("album-1", false) } coAnswers {
+            initialFetchStarted.complete(Unit)
+            releaseInitialFetch.await()
+            AppResult.Success(initialDetail)
+        }
+        coEvery { repository.fetchAlbumDetail("album-1", true) } returns AppResult.Success(refreshedDetail)
+
+        val viewModel = NavidromeAlbumDetailViewModel(
+            savedStateHandle = SavedStateHandle(mapOf(NavidromeRoute.ALBUM_ID_ARG to "album-1")),
+            navidromeRepository = repository
+        )
+
+        testScheduler.runCurrent()
+        initialFetchStarted.await()
+
+        connectionState.value = ActiveServerConnectionStatus(
+            serverId = "server-1",
+            effectiveBaseUrl = "https://remote.example",
+            route = ServerConnectionRoute.Remote,
+            connectionMode = ServerConnectionMode.Auto,
+            switchingEnabled = true
+        )
+        advanceUntilIdle()
+
+        assertEquals("New Album", viewModel.uiState.value.detail?.album?.name)
+
+        releaseInitialFetch.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals("New Album", viewModel.uiState.value.detail?.album?.name)
+        coVerify(exactly = 1) { repository.fetchAlbumDetail("album-1", false) }
+        coVerify(exactly = 1) { repository.fetchAlbumDetail("album-1", true) }
+    }
+
+    private fun albumDetail(
+        albumName: String,
+        trackName: String
+    ): NavidromeAlbumDetail {
+        return NavidromeAlbumDetail(
+            album = NavidromeAlbum(
+                id = "album-1",
+                name = albumName,
+                artistName = "Artist",
+                artistId = "artist-1",
+                year = null,
+                songCount = 1,
+                durationSeconds = null,
+                coverUrl = null,
+                genre = null
+            ),
+            tracks = listOf(
+                NavidromeTrack(
+                    id = "track-1",
+                    title = trackName,
+                    artistName = "Artist",
+                    albumName = albumName,
+                    albumId = "album-1",
+                    artistId = "artist-1",
+                    trackNumber = 1,
+                    durationSeconds = 180,
+                    coverUrl = null,
+                    streamUrl = "https://example.invalid/stream",
+                    formatLabel = null,
+                    bitRateKbps = null
+                )
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/stillshelf/app/ui/screens/navidrome/NavidromeArtistDetailViewModelTest.kt
+++ b/app/src/test/java/com/stillshelf/app/ui/screens/navidrome/NavidromeArtistDetailViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.stillshelf.app.ui.screens.navidrome
 
 import androidx.lifecycle.SavedStateHandle
+import com.stillshelf.app.core.model.ActiveServerConnectionStatus
 import com.stillshelf.app.core.datastore.SessionPreferenceState
 import com.stillshelf.app.core.datastore.SessionPreferences
 import com.stillshelf.app.core.model.NavidromeAlbum
@@ -9,6 +10,8 @@ import com.stillshelf.app.core.model.NavidromeArtistDetail
 import com.stillshelf.app.core.util.AppResult
 import com.stillshelf.app.data.repo.NavidromeRepository
 import com.stillshelf.app.ui.navigation.NavidromeRoute
+import com.stillshelf.app.core.model.ServerConnectionMode
+import com.stillshelf.app.core.model.ServerConnectionRoute
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -56,10 +59,12 @@ class NavidromeArtistDetailViewModelTest {
                 lastLibrarySyncAtMs = null
             )
         )
+        val connectionState = MutableStateFlow<ActiveServerConnectionStatus?>(null)
         val repository = mockk<NavidromeRepository>()
         val sessionPreferences = mockk<SessionPreferences>() {
             every { state } returns syncState
         }
+        every { repository.observeActiveConnectionStatus() } returns connectionState
 
         val initialDetail = artistDetail(
             artistName = "Initial Artist",
@@ -91,6 +96,56 @@ class NavidromeArtistDetailViewModelTest {
     }
 
     @Test
+    fun activeConnectionChange_triggersForcedArtistRefresh() = runTest(dispatcher) {
+        val connectionState = MutableStateFlow<ActiveServerConnectionStatus?>(null)
+        val repository = mockk<NavidromeRepository>()
+        val sessionPreferences = mockk<SessionPreferences>() {
+            every { state } returns MutableStateFlow(
+                SessionPreferenceState(
+                    activeServerId = null,
+                    activeLibraryId = null,
+                    lastLibrarySyncAtMs = null
+                )
+            )
+        }
+        every { repository.observeActiveConnectionStatus() } returns connectionState
+
+        val initialDetail = artistDetail(
+            artistName = "Initial Artist",
+            albumName = "Old Album"
+        )
+        val refreshedDetail = artistDetail(
+            artistName = "Initial Artist",
+            albumName = "New Album"
+        )
+
+        coEvery { repository.fetchArtistDetail("artist-1", false) } returns AppResult.Success(initialDetail)
+        coEvery { repository.fetchArtistDetail("artist-1", true) } returns AppResult.Success(refreshedDetail)
+
+        val viewModel = NavidromeArtistDetailViewModel(
+            savedStateHandle = SavedStateHandle(mapOf(NavidromeRoute.ARTIST_ID_ARG to "artist-1")),
+            navidromeRepository = repository,
+            sessionPreferences = sessionPreferences
+        )
+
+        advanceUntilIdle()
+        assertEquals("Old Album", viewModel.uiState.value.detail?.albums?.firstOrNull()?.name)
+
+        connectionState.value = ActiveServerConnectionStatus(
+            serverId = "server-1",
+            effectiveBaseUrl = "https://remote.example",
+            route = ServerConnectionRoute.Remote,
+            connectionMode = ServerConnectionMode.Auto,
+            switchingEnabled = true
+        )
+        advanceUntilIdle()
+
+        assertEquals("New Album", viewModel.uiState.value.detail?.albums?.firstOrNull()?.name)
+        coVerify(exactly = 1) { repository.fetchArtistDetail("artist-1", false) }
+        coVerify(exactly = 1) { repository.fetchArtistDetail("artist-1", true) }
+    }
+
+    @Test
     fun newerSyncRefresh_winsOverSlowerInitialLoad() = runTest(dispatcher) {
         val syncState = MutableStateFlow(
             SessionPreferenceState(
@@ -99,10 +154,12 @@ class NavidromeArtistDetailViewModelTest {
                 lastLibrarySyncAtMs = null
             )
         )
+        val connectionState = MutableStateFlow<ActiveServerConnectionStatus?>(null)
         val repository = mockk<NavidromeRepository>()
         val sessionPreferences = mockk<SessionPreferences>() {
             every { state } returns syncState
         }
+        every { repository.observeActiveConnectionStatus() } returns connectionState
         val initialFetchStarted = CompletableDeferred<Unit>()
         val releaseInitialFetch = CompletableDeferred<Unit>()
 


### PR DESCRIPTION
## What changed
- Refresh Navidrome player metadata and artwork when the active local/remote server route changes.
- Force-refresh Navidrome home, browse, playlist, songs, radios, artist detail, album detail, and playlist detail screens on connection changes.
- Add race protection to album detail so a slower initial load cannot overwrite a later forced refresh.
- Add regression tests for artist detail and album detail connection-change refresh behavior.

## Why
- Album art could stay stale after switching from home Wi-Fi to cellular and moving from the local server to the remote Cloudflare-backed server.
- The UI would eventually recover after a manual refresh, which pointed to stale cached metadata rather than a rendering issue.

## Impact
- Full-screen player metadata and Android Auto artwork should refresh automatically after a server route change.
- Detail and browse screens will also rehydrate their cached data when the connection flips.

## Validation
- `./gradlew :app:testGithubDebugUnitTest --tests com.stillshelf.app.ui.screens.navidrome.NavidromeArtistDetailViewModelTest --tests com.stillshelf.app.ui.screens.navidrome.NavidromeAlbumDetailViewModelTest`