### PR TITLE
Release v0.6.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 102
-val appVersionName = "0.6.0"
+val appVersionCode = 103
+val appVersionName = "0.6.1"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
@@ -89,8 +89,17 @@ internal fun normalizeNavidromePlaybackWarmupTracks(tracks: List<NavidromeTrack>
         }
 }
 
-internal fun buildNavidromePlaybackWarmupSignature(tracks: List<NavidromeTrack>): String {
-    return tracks.joinToString(separator = "|") { it.id }
+internal fun buildNavidromePlaybackWarmupSignature(
+    tracks: List<NavidromeTrack>,
+    connectionSignature: String = ""
+): String {
+    return buildString {
+        if (connectionSignature.isNotBlank()) {
+            append(connectionSignature)
+            append("::")
+        }
+        append(tracks.joinToString(separator = "|") { it.id })
+    }
 }
 
 internal fun selectNavidromePlaybackWarmupTracks(
@@ -422,6 +431,7 @@ class NavidromePlayerController @Inject constructor(
     private var lastPersistedSnapshotPositionMs: Int = 0
     private var lastPersistedSnapshotElapsedMs: Long = 0L
     @Volatile private var playbackCacheWarmupSignature: String? = null
+    @Volatile private var playbackCacheWarmupConnectionSignature: String = ""
     private val audioManager: AudioManager =
         appContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     private val mediaSession = MediaSessionCompat(appContext, "StillShelfNavidromePlayback")
@@ -1115,7 +1125,10 @@ class NavidromePlayerController @Inject constructor(
             cancelPlaybackCacheWarmup(clearSignature = true)
             return
         }
-        val signature = buildNavidromePlaybackWarmupSignature(warmupTracks)
+        val signature = buildNavidromePlaybackWarmupSignature(
+            tracks = warmupTracks,
+            connectionSignature = playbackCacheWarmupConnectionSignature
+        )
         if (signature == playbackCacheWarmupSignature) {
             return
         }
@@ -1685,6 +1698,8 @@ class NavidromePlayerController @Inject constructor(
             var hasObservedStatus = false
             var lastStatus: ActiveServerConnectionStatus? = null
             navidromeRepository.observeActiveConnectionStatus().collect { status ->
+                playbackCacheWarmupConnectionSignature =
+                    buildPlaybackCacheWarmupConnectionSignature(status)
                 if (!hasObservedStatus) {
                     hasObservedStatus = true
                     lastStatus = status
@@ -1700,6 +1715,7 @@ class NavidromePlayerController @Inject constructor(
 
     private fun refreshPlaybackPresentationForConnectionChange() {
         val currentTrack = mutableState.value.currentTrack ?: return
+        cancelPlaybackCacheWarmup(clearSignature = true)
         if (currentTrack.id.startsWith("radio:")) return
         val queueSnapshot = queueTracks
         val recentSnapshot = recentTracks
@@ -1750,6 +1766,19 @@ class NavidromePlayerController @Inject constructor(
                 schedulePlaybackCacheWarmup(queueTracks)
             }
         }
+    }
+
+    private fun buildPlaybackCacheWarmupConnectionSignature(
+        status: ActiveServerConnectionStatus?
+    ): String {
+        return status?.let {
+            listOf(
+                it.serverId,
+                it.effectiveBaseUrl,
+                it.route.name,
+                it.connectionMode.name
+            ).joinToString(separator = "|")
+        }.orEmpty()
     }
 
     private fun observeEqualizerPreferences() {

--- a/app/src/test/java/com/stillshelf/app/playback/navidrome/NavidromePlaybackCacheWarmupTest.kt
+++ b/app/src/test/java/com/stillshelf/app/playback/navidrome/NavidromePlaybackCacheWarmupTest.kt
@@ -35,6 +35,20 @@ class NavidromePlaybackCacheWarmupTest {
     }
 
     @Test
+    fun buildNavidromePlaybackWarmupSignature_changesAcrossConnectionContexts() {
+        val wifiSignature = buildNavidromePlaybackWarmupSignature(
+            tracks = listOf(track("track-1"), track("track-2")),
+            connectionSignature = "srv|https://lan.example.com|Local|Auto"
+        )
+        val cellularSignature = buildNavidromePlaybackWarmupSignature(
+            tracks = listOf(track("track-1"), track("track-2")),
+            connectionSignature = "srv|https://wan.example.com|Remote|Auto"
+        )
+
+        assertFalse(wifiSignature == cellularSignature)
+    }
+
+    @Test
     fun selectNavidromePlaybackWarmupTracks_capsToUpcomingWindow() {
         val tracks = (0 until 30).map { track("track-$it") }
 


### PR DESCRIPTION
# Summary
- Tighten Navidrome playback cache warmup so it rebuilds correctly across Wi-Fi and cellular route changes.
- Cancel in-flight warmup immediately on connection changes to avoid stale cache overlap.
- Bump the app version to `0.6.1`.

# Verification
- `./gradlew :app:testGithubDebugUnitTest --tests com.stillshelf.app.playback.navidrome.NavidromePlaybackCacheWarmupTest`
- `./gradlew :app:assembleGithubRelease`