### PR TITLE
Release v0.6.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 103
-val appVersionName = "0.6.1"
+val appVersionCode = 104
+val appVersionName = "0.6.2"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
@@ -1144,7 +1144,13 @@ class NavidromePlayerController @Inject constructor(
                     logPlaybackTrace(
                         "playback_cache_warmup_refresh_failed message=${result.message}"
                     )
-                    warmupTracks
+                    scope.launch(Dispatchers.Main.immediate) {
+                        if (playbackCacheWarmupSignature == signature) {
+                            playbackCacheWarmupSignature = null
+                            schedulePlaybackCacheWarmup(queueTracks)
+                        }
+                    }
+                    return@launch
                 }
             }
             if (!isActive) return@launch
@@ -1181,6 +1187,8 @@ class NavidromePlayerController @Inject constructor(
                         logPlaybackTrace(
                             "playback_cache_warmup_prefetch_failed message=${prefetchResult.message}"
                         )
+                        playbackCacheWarmupSignature = null
+                        schedulePlaybackCacheWarmup(queueTracks)
                     }
                 }
             }


### PR DESCRIPTION
# Summary
- Fix Navidrome playback warmup so cache retries work after refresh/prefetch failures.
- Keep playback cache behavior working across network changes and avoid the signature getting stuck empty.
- Bump the app version to `0.6.2`.

# Verification
- `./gradlew :app:testGithubDebugUnitTest --tests com.stillshelf.app.playback.navidrome.NavidromePlaybackCacheWarmupTest`