### PR TITLE
[codex] fix navidrome cellular cache

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 104
-val appVersionName = "0.6.2"
+val appVersionCode = 105
+val appVersionName = "0.6.3"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/data/repo/NavidromeRepository.kt
+++ b/app/src/main/java/com/stillshelf/app/data/repo/NavidromeRepository.kt
@@ -1378,7 +1378,7 @@ class NavidromeRepository @Inject constructor(
     }
 
     suspend fun refreshPlayableTracks(tracks: List<NavidromeTrack>): AppResult<List<NavidromeTrack>> {
-        val auth = currentAuth(requireFreshConnection = true)
+        val auth = currentAuth(requireFreshConnection = false)
             ?: return AppResult.Error("Navidrome session expired. Please sign in again.")
         return try {
             AppResult.Success(
@@ -1667,7 +1667,10 @@ class NavidromeRepository @Inject constructor(
                         wanBaseUrl = normalizedRemoteBaseUrl,
                         password = password
                     )
-                } else if (isEndpointReachable(normalizedLocalBaseUrl!!)) {
+                } else if (
+                    networkMonitor.currentConnectionType() == NetworkConnectionType.Wifi &&
+                    isEndpointReachable(normalizedLocalBaseUrl!!)
+                ) {
                     buildResolvedConnection(
                         server = server,
                         effectiveBaseUrl = normalizedLocalBaseUrl,
@@ -1685,7 +1688,7 @@ class NavidromeRepository @Inject constructor(
                         route = ServerConnectionRoute.Remote,
                         connectionMode = config.connectionMode,
                         switchingEnabled = true,
-                        lanFallbackToRemote = true,
+                        lanFallbackToRemote = networkMonitor.currentConnectionType() == NetworkConnectionType.Wifi,
                         lanBaseUrl = normalizedLocalBaseUrl,
                         wanBaseUrl = normalizedRemoteBaseUrl,
                         password = password

--- a/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
@@ -431,6 +431,8 @@ class NavidromePlayerController @Inject constructor(
     private var lastPersistedSnapshotPositionMs: Int = 0
     private var lastPersistedSnapshotElapsedMs: Long = 0L
     @Volatile private var playbackCacheWarmupSignature: String? = null
+    private var playbackCacheWarmupRetryJob: Job? = null
+    @Volatile private var playbackCacheWarmupRetrySignature: String? = null
     @Volatile private var playbackCacheWarmupConnectionSignature: String = ""
     private val audioManager: AudioManager =
         appContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
@@ -1110,6 +1112,9 @@ class NavidromePlayerController @Inject constructor(
     private fun cancelPlaybackCacheWarmup(clearSignature: Boolean) {
         playbackCacheWarmupJob?.cancel()
         playbackCacheWarmupJob = null
+        playbackCacheWarmupRetryJob?.cancel()
+        playbackCacheWarmupRetryJob = null
+        playbackCacheWarmupRetrySignature = null
         if (clearSignature) {
             playbackCacheWarmupSignature = null
         }
@@ -1129,6 +1134,9 @@ class NavidromePlayerController @Inject constructor(
             tracks = warmupTracks,
             connectionSignature = playbackCacheWarmupConnectionSignature
         )
+        if (playbackCacheWarmupRetrySignature != signature) {
+            playbackCacheWarmupRetrySignature = null
+        }
         if (signature == playbackCacheWarmupSignature) {
             return
         }
@@ -1147,7 +1155,7 @@ class NavidromePlayerController @Inject constructor(
                     scope.launch(Dispatchers.Main.immediate) {
                         if (playbackCacheWarmupSignature == signature) {
                             playbackCacheWarmupSignature = null
-                            schedulePlaybackCacheWarmup(queueTracks)
+                            schedulePlaybackCacheWarmupRetry(queueTracks, signature)
                         }
                     }
                     return@launch
@@ -1179,6 +1187,9 @@ class NavidromePlayerController @Inject constructor(
                         logPlaybackTrace(
                             "playback_cache_warmup_prefetch_queued count=${prefetchResult.value}"
                         )
+                        playbackCacheWarmupRetryJob?.cancel()
+                        playbackCacheWarmupRetryJob = null
+                        playbackCacheWarmupRetrySignature = null
                         scope.launch(Dispatchers.IO) {
                             downloadManager.prunePlaybackCache(warmupTracks.map { it.id }.toSet())
                         }
@@ -1188,8 +1199,32 @@ class NavidromePlayerController @Inject constructor(
                             "playback_cache_warmup_prefetch_failed message=${prefetchResult.message}"
                         )
                         playbackCacheWarmupSignature = null
-                        schedulePlaybackCacheWarmup(queueTracks)
+                        schedulePlaybackCacheWarmupRetry(queueTracks, signature)
                     }
+                }
+            }
+        }
+    }
+
+    private fun schedulePlaybackCacheWarmupRetry(
+        tracks: List<NavidromeTrack>,
+        signature: String
+    ) {
+        if (playbackCacheWarmupRetrySignature == signature) return
+        playbackCacheWarmupRetrySignature = signature
+        playbackCacheWarmupRetryJob?.cancel()
+        playbackCacheWarmupRetryJob = scope.launch(Dispatchers.Main.immediate) {
+            try {
+                delay(750)
+                if (playbackCacheWarmupRetrySignature != signature) {
+                    return@launch
+                }
+                if (playbackCacheWarmupSignature == null) {
+                    schedulePlaybackCacheWarmup(tracks)
+                }
+            } finally {
+                if (playbackCacheWarmupRetrySignature == signature) {
+                    playbackCacheWarmupRetryJob = null
                 }
             }
         }
@@ -1713,9 +1748,13 @@ class NavidromePlayerController @Inject constructor(
                     lastStatus = status
                     return@collect
                 }
-                if (status != lastStatus) {
+                if (status?.serverId != lastStatus?.serverId ||
+                    status?.effectiveBaseUrl != lastStatus?.effectiveBaseUrl
+                ) {
                     lastStatus = status
                     refreshPlaybackPresentationForConnectionChange()
+                } else {
+                    lastStatus = status
                 }
             }
         }

--- a/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
@@ -5140,7 +5140,11 @@ private fun NavidromeSettingsRoute(
                 DividerLine()
                 NavidromeSettingsRow(
                     title = "Clear cached music",
-                    value = if (uiState.isClearingCache) "Clearing…" else formatStorageSize(uiState.playbackCacheUsageBytes),
+                    value = when {
+                        uiState.isClearingCache -> "Clearing…"
+                        uiState.playbackCacheUsageBytes == 0L && uiState.playbackCacheItemCount > 0 -> "Downloading…"
+                        else -> formatStorageSize(uiState.playbackCacheUsageBytes)
+                    },
                     titleMaxLines = 1,
                     valueTextAlign = TextAlign.End,
                     onClick = if (uiState.isClearingCache) null else ({ clearCachedMusicDialogVisible = true })

--- a/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeViewModels.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeViewModels.kt
@@ -3444,9 +3444,13 @@ private fun ViewModel.observeNavidromeConnectionChanges(
                 lastStatus = status
                 return@collect
             }
-            if (status != lastStatus) {
+            if (status?.serverId != lastStatus?.serverId ||
+                status?.effectiveBaseUrl != lastStatus?.effectiveBaseUrl
+            ) {
                 lastStatus = status
                 onConnectionChanged()
+            } else {
+                lastStatus = status
             }
         }
     }

--- a/app/src/test/java/com/stillshelf/app/playback/navidrome/NavidromePlaybackCacheWarmupTest.kt
+++ b/app/src/test/java/com/stillshelf/app/playback/navidrome/NavidromePlaybackCacheWarmupTest.kt
@@ -83,6 +83,52 @@ class NavidromePlaybackCacheWarmupTest {
         assertEquals("https://example.com/stream.mp3", resolved)
     }
 
+    // Retry storm prevention: a cleared signature (null) is never equal to any real signature,
+    // so the warmup guard always lets the next attempt through after a failure.
+    @Test
+    fun clearedSignature_neverMatchesAnyRealSignature() {
+        val storedSignature: String? = null
+        val nextSignature = buildNavidromePlaybackWarmupSignature(
+            tracks = listOf(track("track-1"), track("track-2")),
+            connectionSignature = "srv|https://wan.example.com|Remote|Auto"
+        )
+
+        assertFalse(storedSignature == nextSignature)
+    }
+
+    // Same queue + same connection → same signature, so a second call while warmup is
+    // in-flight or already succeeded is a no-op.
+    @Test
+    fun unchangedQueueAndConnection_producesIdenticalSignature() {
+        val tracks = listOf(track("track-1"), track("track-2"))
+        val connection = "srv|https://wan.example.com|Remote|Auto"
+
+        assertEquals(
+            buildNavidromePlaybackWarmupSignature(tracks, connection),
+            buildNavidromePlaybackWarmupSignature(tracks, connection)
+        )
+    }
+
+    // After a failure clears the signature, a connection change produces a new signature
+    // that does not match null, so the retry proceeds — and the new signature encodes the
+    // new route so a stale-URL warmup cannot silently reuse the cleared slot.
+    @Test
+    fun connectionChangeAfterFailure_newSignatureUnblocksRetry() {
+        val queue = listOf(track("track-1"), track("track-2"))
+        val staleConnection = "srv|https://lan.example.com|Local|Auto"
+        val freshConnection = "srv|https://wan.example.com|Remote|Auto"
+
+        val staleSignature = buildNavidromePlaybackWarmupSignature(queue, staleConnection)
+        // Failure clears the stored signature.
+        val storedAfterFailure: String? = null
+        val freshSignature = buildNavidromePlaybackWarmupSignature(queue, freshConnection)
+
+        // Retry gate passes (null != fresh).
+        assertFalse(storedAfterFailure == freshSignature)
+        // The new signature is distinct from the stale one, so a route-flip is never masked.
+        assertFalse(staleSignature == freshSignature)
+    }
+
     private fun track(id: String, streamUrl: String = "https://example.com/$id.mp3"): NavidromeTrack {
         return NavidromeTrack(
             id = id,

--- a/app/src/test/java/com/stillshelf/app/ui/screens/navidrome/NavidromeArtistDetailViewModelTest.kt
+++ b/app/src/test/java/com/stillshelf/app/ui/screens/navidrome/NavidromeArtistDetailViewModelTest.kt
@@ -199,6 +199,116 @@ class NavidromeArtistDetailViewModelTest {
         coVerify(exactly = 1) { repository.fetchArtistDetail("artist-1", true) }
     }
 
+    @Test
+    fun failedConnectionChange_followedBySecondConnectionChange_retriesAndRecovers() = runTest(dispatcher) {
+        val connectionState = MutableStateFlow<ActiveServerConnectionStatus?>(null)
+        val repository = mockk<NavidromeRepository>()
+        val sessionPreferences = mockk<SessionPreferences>() {
+            every { state } returns MutableStateFlow(
+                SessionPreferenceState(
+                    activeServerId = null,
+                    activeLibraryId = null,
+                    lastLibrarySyncAtMs = null
+                )
+            )
+        }
+        every { repository.observeActiveConnectionStatus() } returns connectionState
+
+        val initialDetail = artistDetail(artistName = "Artist", albumName = "Initial Album")
+        val recoveredDetail = artistDetail(artistName = "Artist", albumName = "Recovered Album")
+
+        coEvery { repository.fetchArtistDetail("artist-1", false) } returns AppResult.Success(initialDetail)
+        coEvery { repository.fetchArtistDetail("artist-1", true) } returnsMany listOf(
+            AppResult.Error("Network error during transition"),
+            AppResult.Success(recoveredDetail)
+        )
+
+        val viewModel = NavidromeArtistDetailViewModel(
+            savedStateHandle = SavedStateHandle(mapOf(NavidromeRoute.ARTIST_ID_ARG to "artist-1")),
+            navidromeRepository = repository,
+            sessionPreferences = sessionPreferences
+        )
+
+        advanceUntilIdle()
+        assertEquals("Initial Album", viewModel.uiState.value.detail?.albums?.firstOrNull()?.name)
+
+        // First connection change — refresh fails.
+        connectionState.value = ActiveServerConnectionStatus(
+            serverId = "server-1",
+            effectiveBaseUrl = "https://remote.example",
+            route = ServerConnectionRoute.Remote,
+            connectionMode = ServerConnectionMode.Auto,
+            switchingEnabled = true
+        )
+        advanceUntilIdle()
+        assertEquals("Network error during transition", viewModel.uiState.value.errorMessage)
+
+        // Second connection change (route settles to a new endpoint) — refresh succeeds.
+        connectionState.value = ActiveServerConnectionStatus(
+            serverId = "server-1",
+            effectiveBaseUrl = "https://remote-stable.example",
+            route = ServerConnectionRoute.Remote,
+            connectionMode = ServerConnectionMode.Auto,
+            switchingEnabled = true
+        )
+        advanceUntilIdle()
+        assertEquals("Recovered Album", viewModel.uiState.value.detail?.albums?.firstOrNull()?.name)
+        coVerify(exactly = 2) { repository.fetchArtistDetail("artist-1", true) }
+    }
+
+    @Test
+    fun metadataOnlyConnectionChange_doesNotTriggerRefresh() = runTest(dispatcher) {
+        val connectionState = MutableStateFlow<ActiveServerConnectionStatus?>(null)
+        val repository = mockk<NavidromeRepository>()
+        val sessionPreferences = mockk<SessionPreferences>() {
+            every { state } returns MutableStateFlow(
+                SessionPreferenceState(
+                    activeServerId = null,
+                    activeLibraryId = null,
+                    lastLibrarySyncAtMs = null
+                )
+            )
+        }
+        every { repository.observeActiveConnectionStatus() } returns connectionState
+
+        val detail = artistDetail(artistName = "Artist", albumName = "Album")
+        coEvery { repository.fetchArtistDetail("artist-1", false) } returns AppResult.Success(detail)
+        coEvery { repository.fetchArtistDetail("artist-1", true) } returns AppResult.Success(detail)
+
+        val viewModel = NavidromeArtistDetailViewModel(
+            savedStateHandle = SavedStateHandle(mapOf(NavidromeRoute.ARTIST_ID_ARG to "artist-1")),
+            navidromeRepository = repository,
+            sessionPreferences = sessionPreferences
+        )
+
+        advanceUntilIdle()
+
+        // Establish a connection status.
+        connectionState.value = ActiveServerConnectionStatus(
+            serverId = "server-1",
+            effectiveBaseUrl = "https://remote.example",
+            route = ServerConnectionRoute.Remote,
+            connectionMode = ServerConnectionMode.Auto,
+            switchingEnabled = true
+        )
+        advanceUntilIdle()
+        coVerify(exactly = 1) { repository.fetchArtistDetail("artist-1", true) }
+
+        // Metadata-only update: same serverId and effectiveBaseUrl, only lanFallbackToRemote flips.
+        connectionState.value = ActiveServerConnectionStatus(
+            serverId = "server-1",
+            effectiveBaseUrl = "https://remote.example",
+            route = ServerConnectionRoute.Remote,
+            connectionMode = ServerConnectionMode.Auto,
+            switchingEnabled = true,
+            lanFallbackToRemote = true
+        )
+        advanceUntilIdle()
+
+        // No additional forced refresh — the endpoint didn't change.
+        coVerify(exactly = 1) { repository.fetchArtistDetail("artist-1", true) }
+    }
+
     private fun artistDetail(
         artistName: String,
         albumName: String


### PR DESCRIPTION
## Summary
- Fix Navidrome playback cache warmup on cellular by retrying transient refresh/prefetch failures.
- Keep route-aware cache warmup and connection-change refreshes in sync so cached tracks and artwork stay fresh after local/remote switches.
- Bump the app version to `0.6.3` for the release.

## Validation
- `./gradlew :app:testGithubDebugUnitTest --tests com.stillshelf.app.playback.navidrome.NavidromePlaybackCacheWarmupTest --tests com.stillshelf.app.ui.screens.navidrome.NavidromeArtistDetailViewModelTest`
- `./gradlew :app:assembleGithubRelease`
