### PR TITLE
Fix Navidrome album cache persistence

### DIFF
--- a/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
@@ -77,8 +77,6 @@ internal const val NAVIDROME_PLAYBACK_MEDIA_SCHEME = "stillshelf-navidrome"
 internal const val NAVIDROME_PLAYBACK_MEDIA_AUTHORITY = "playback"
 internal const val NAVIDROME_PLAYBACK_TRACK_ID_QUERY_PARAMETER = "trackId"
 internal const val NAVIDROME_PLAYBACK_STREAM_URL_QUERY_PARAMETER = "streamUrl"
-internal const val NAVIDROME_PLAYBACK_WARMUP_TRACK_LIMIT = 20
-
 internal fun normalizeNavidromePlaybackWarmupTracks(tracks: List<NavidromeTrack>): List<NavidromeTrack> {
     return tracks
         .distinctBy { it.id }
@@ -103,13 +101,9 @@ internal fun buildNavidromePlaybackWarmupSignature(
 }
 
 internal fun selectNavidromePlaybackWarmupTracks(
-    tracks: List<NavidromeTrack>,
-    currentIndex: Int,
-    trackLimit: Int = NAVIDROME_PLAYBACK_WARMUP_TRACK_LIMIT
+    tracks: List<NavidromeTrack>
 ): List<NavidromeTrack> {
-    if (tracks.isEmpty() || trackLimit <= 0) return emptyList()
-    val startIndex = currentIndex.coerceIn(0, tracks.lastIndex)
-    return tracks.drop(startIndex).take(trackLimit)
+    return tracks
 }
 
 internal fun buildNavidromePlaybackMediaUri(trackId: String, streamUrl: String): Uri {
@@ -1121,10 +1115,8 @@ class NavidromePlayerController @Inject constructor(
     }
 
     private fun schedulePlaybackCacheWarmup(tracks: List<NavidromeTrack>) {
-        val queueIndex = mutableState.value.currentIndex
         val warmupTracks = selectNavidromePlaybackWarmupTracks(
-            tracks = normalizeNavidromePlaybackWarmupTracks(tracks),
-            currentIndex = queueIndex
+            tracks = normalizeNavidromePlaybackWarmupTracks(tracks)
         )
         if (warmupTracks.isEmpty()) {
             cancelPlaybackCacheWarmup(clearSignature = true)

--- a/app/src/test/java/com/stillshelf/app/playback/navidrome/NavidromePlaybackCacheWarmupTest.kt
+++ b/app/src/test/java/com/stillshelf/app/playback/navidrome/NavidromePlaybackCacheWarmupTest.kt
@@ -49,16 +49,12 @@ class NavidromePlaybackCacheWarmupTest {
     }
 
     @Test
-    fun selectNavidromePlaybackWarmupTracks_capsToUpcomingWindow() {
+    fun selectNavidromePlaybackWarmupTracks_returnsAllTracks() {
         val tracks = (0 until 30).map { track("track-$it") }
 
-        val selected = selectNavidromePlaybackWarmupTracks(
-            tracks = tracks,
-            currentIndex = 10,
-            trackLimit = 5
-        )
+        val selected = selectNavidromePlaybackWarmupTracks(tracks = tracks)
 
-        assertEquals(listOf("track-10", "track-11", "track-12", "track-13", "track-14"), selected.map { it.id })
+        assertEquals(tracks.map { it.id }, selected.map { it.id })
     }
 
     @Test


### PR DESCRIPTION
## Summary
- warm up the full normalized Navidrome playback queue instead of limiting to an upcoming window
- update cache warmup selection test coverage

## Test
- `gradlew.bat :app:testGithubDebugUnitTest --tests com.stillshelf.app.playback.navidrome.NavidromePlaybackCacheWarmupTest`