### PR TITLE
Release v0.6.4

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 105
-val appVersionName = "0.6.3"
+val appVersionCode = 106
+val appVersionName = "0.6.4"
 
 android {
     namespace = "com.stillshelf.app"


### PR DESCRIPTION
## Summary
- Bumped the stable app version to `0.6.4`.
- This release branch prepares the current `main` head for the next stable GitHub release.

## Validation
- `./gradlew :app:testGithubDebugUnitTest`
- `./gradlew :app:assembleGithubRelease`