### PR TITLE
StillShelf v0.6.7

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 108
-val appVersionName = "0.6.6"
+val appVersionCode = 109
+val appVersionName = "0.6.7"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
@@ -1184,6 +1184,9 @@ class NavidromePlayerController @Inject constructor(
                         playbackCacheWarmupRetrySignature = null
                         scope.launch(Dispatchers.IO) {
                             downloadManager.prunePlaybackCache(warmupTracks.map { it.id }.toSet())
+                            if (cacheLimitBytes != null) {
+                                downloadManager.evictPlaybackCacheToLimit(cacheLimitBytes)
+                            }
                         }
                     }
                     is com.stillshelf.app.core.util.AppResult.Error -> {

--- a/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeViewModels.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeViewModels.kt
@@ -60,8 +60,10 @@ import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import java.util.concurrent.atomic.AtomicLong
@@ -2097,7 +2099,9 @@ class NavidromeSettingsViewModel @Inject constructor(
         if (mutableLocalState.value.isClearingCache) return
         viewModelScope.launch {
             mutableLocalState.update { it.copy(isClearingCache = true) }
-            downloadManager.clearPlaybackCache()
+            withContext(Dispatchers.IO) {
+                downloadManager.clearPlaybackCache()
+            }
             playerController.invalidatePlaybackCacheWarmup()
             mutableLocalState.update { it.copy(isClearingCache = false, syncToastMessage = "Cached music cleared") }
         }


### PR DESCRIPTION
## Summary
- Fixes Navidrome playback cache handling by moving cache eviction and clearing work off the main thread.
- Includes the bug-fix edits already present on this branch.
- Bumps the app version to `0.6.7` (`versionCode` 109).

## Validation
- `./gradlew :app:assembleRelease`
