### PR TITLE
StillShelf v0.6.9

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 110
-val appVersionName = "0.6.8"
+val appVersionCode = 111
+val appVersionName = "0.6.9"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
@@ -141,14 +141,16 @@ internal fun shouldScheduleNavidromePausedPlayerRelease(
     hasActivePlayer: Boolean,
     isPlaying: Boolean,
     playWhenReady: Boolean,
-    playbackState: Int
+    playbackState: Int,
+    appInForeground: Boolean,
+    repeatMode: Int
 ): Boolean {
     return currentTrack != null &&
-        !currentTrack.id.startsWith("radio:") &&
         hasActivePlayer &&
         !isPlaying &&
-        !playWhenReady &&
-        playbackState != Player.STATE_BUFFERING
+        !appInForeground &&
+        playbackState != Player.STATE_BUFFERING &&
+        (!playWhenReady || (playbackState == Player.STATE_ENDED && repeatMode == Player.REPEAT_MODE_OFF))
 }
 
 internal fun isNavidromeOutputSwitchInFlight(
@@ -928,6 +930,7 @@ class NavidromePlayerController @Inject constructor(
         }
         player?.repeatMode = repeatMode
         updatePlaybackSurface()
+        ensureProgressUpdates()
         return repeatMode
     }
 
@@ -1500,7 +1503,9 @@ class NavidromePlayerController @Inject constructor(
             hasActivePlayer = activePlayer != null,
             isPlaying = activePlayer?.isPlaying == true,
             playWhenReady = activePlayer?.playWhenReady == true,
-            playbackState = activePlayer?.playbackState ?: Player.STATE_IDLE
+            playbackState = activePlayer?.playbackState ?: Player.STATE_IDLE,
+            appInForeground = appInForeground,
+            repeatMode = repeatMode
         )
         if (!shouldScheduleRelease) {
             cancelPausedPlayerRelease()
@@ -1516,7 +1521,9 @@ class NavidromePlayerController @Inject constructor(
                 hasActivePlayer = playerToRelease != null,
                 isPlaying = playerToRelease?.isPlaying == true,
                 playWhenReady = playerToRelease?.playWhenReady == true,
-                playbackState = playerToRelease?.playbackState ?: Player.STATE_IDLE
+                playbackState = playerToRelease?.playbackState ?: Player.STATE_IDLE,
+                appInForeground = appInForeground,
+                repeatMode = repeatMode
             )
             if (!stillPaused) return@launch
             persistPlaybackSnapshot(force = true)
@@ -1525,7 +1532,8 @@ class NavidromePlayerController @Inject constructor(
                 isPlaying = false,
                 isLoading = false
             )
-            updatePlaybackSurface()
+            pausedReleaseJob = null
+            clearPlaybackSurface()
         }
     }
 
@@ -1690,7 +1698,7 @@ class NavidromePlayerController @Inject constructor(
         mediaSession.setPlaybackState(playbackState)
         mediaSession.isActive = keepMediaSessionActive
 
-        if (currentTrack == null) {
+        if (currentTrack == null || player == null) {
             clearPlaybackSurface()
             return
         }

--- a/app/src/test/java/com/stillshelf/app/playback/navidrome/NavidromePausedPlayerReleasePolicyTest.kt
+++ b/app/src/test/java/com/stillshelf/app/playback/navidrome/NavidromePausedPlayerReleasePolicyTest.kt
@@ -16,7 +16,9 @@ class NavidromePausedPlayerReleasePolicyTest {
                 hasActivePlayer = true,
                 isPlaying = false,
                 playWhenReady = true,
-                playbackState = Player.STATE_READY
+                playbackState = Player.STATE_READY,
+                appInForeground = false,
+                repeatMode = Player.REPEAT_MODE_OFF
             )
         )
     }
@@ -29,20 +31,99 @@ class NavidromePausedPlayerReleasePolicyTest {
                 hasActivePlayer = true,
                 isPlaying = false,
                 playWhenReady = false,
-                playbackState = Player.STATE_READY
+                playbackState = Player.STATE_READY,
+                appInForeground = false,
+                repeatMode = Player.REPEAT_MODE_OFF
             )
         )
     }
 
     @Test
-    fun returnsFalseForRadioTrack() {
-        assertFalse(
+    fun returnsTrueForPausedRadioTrack() {
+        assertTrue(
             shouldScheduleNavidromePausedPlayerRelease(
                 currentTrack = track(id = "radio:station"),
                 hasActivePlayer = true,
                 isPlaying = false,
                 playWhenReady = false,
-                playbackState = Player.STATE_READY
+                playbackState = Player.STATE_READY,
+                appInForeground = false,
+                repeatMode = Player.REPEAT_MODE_OFF
+            )
+        )
+    }
+
+    @Test
+    fun returnsTrueWhenQueueEndedNaturally() {
+        assertTrue(
+            shouldScheduleNavidromePausedPlayerRelease(
+                currentTrack = track(),
+                hasActivePlayer = true,
+                isPlaying = false,
+                playWhenReady = true,
+                playbackState = Player.STATE_ENDED,
+                appInForeground = false,
+                repeatMode = Player.REPEAT_MODE_OFF
+            )
+        )
+    }
+
+    @Test
+    fun returnsFalseWhenEndedWithRepeatModeAll() {
+        assertFalse(
+            shouldScheduleNavidromePausedPlayerRelease(
+                currentTrack = track(),
+                hasActivePlayer = true,
+                isPlaying = false,
+                playWhenReady = true,
+                playbackState = Player.STATE_ENDED,
+                appInForeground = false,
+                repeatMode = Player.REPEAT_MODE_ALL
+            )
+        )
+    }
+
+    @Test
+    fun returnsFalseWhenEndedWithRepeatModeOne() {
+        assertFalse(
+            shouldScheduleNavidromePausedPlayerRelease(
+                currentTrack = track(),
+                hasActivePlayer = true,
+                isPlaying = false,
+                playWhenReady = true,
+                playbackState = Player.STATE_ENDED,
+                appInForeground = false,
+                repeatMode = Player.REPEAT_MODE_ONE
+            )
+        )
+    }
+
+    @Test
+    fun returnsFalseWhenAppIsInForeground() {
+        assertFalse(
+            shouldScheduleNavidromePausedPlayerRelease(
+                currentTrack = track(),
+                hasActivePlayer = true,
+                isPlaying = false,
+                playWhenReady = false,
+                playbackState = Player.STATE_READY,
+                appInForeground = true,
+                repeatMode = Player.REPEAT_MODE_OFF
+            )
+        )
+    }
+
+    @Test
+    fun returnsFalseWhenEndedButStillBuffering() {
+        assertFalse(
+            shouldScheduleNavidromePausedPlayerRelease(
+                currentTrack = track(),
+                hasActivePlayer = true,
+                isPlaying = false,
+                playWhenReady = true,
+                playbackState = Player.STATE_BUFFERING,
+                appInForeground = false,
+                repeatMode = Player.REPEAT_MODE_OFF
             )
         )
     }


### PR DESCRIPTION
## Summary
- Fix the Navidrome paused-player release policy so background playback no longer stays active indefinitely.
- Keep radio streams eligible for paused-player release so the service can stop cleanly when the app is backgrounded.
- Bump the app version to `0.6.9` / `111` for the stable release.

## Validation
- `rtk ./gradlew :app:testGithubDebugUnitTest`
