### PR TITLE
Fix artist hero sizing and bump version to 0.7.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 111
-val appVersionName = "0.6.9"
+val appVersionCode = 112
+val appVersionName = "0.7.0"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
@@ -4868,7 +4868,7 @@ private fun NavidromeArtistDetailRoute(
                                 title = detail.artist.name,
                                 subtitle = "${detail.artist.albumCount} albums",
                                 imageUrl = detail.artist.imageUrl ?: detail.artist.coverUrl,
-                                circular = true,
+                                circular = false,
                                 showDownloadedIndicator = downloadUiState.fullyDownloadedAlbumCountByArtistId[detail.artist.id]
                                     ?.let { it >= detail.artist.albumCount && detail.artist.albumCount > 0 }
                                     ?: false,
@@ -4934,6 +4934,7 @@ private fun NavidromeArtistDetailRoute(
                             }
                         }
                     }
+
                 }
 
                 else -> {
@@ -10311,12 +10312,44 @@ private fun CenteredDetailHero(
                 downloadProgressPercent = downloadProgressPercent
             )
         } else {
-            AlbumArt(
-                url = imageUrl,
-                size = 160.dp,
-                showDownloadedIndicator = showDownloadedIndicator,
-                downloadProgressPercent = downloadProgressPercent
-            )
+            val shape = RoundedCornerShape(18.dp)
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(188.dp)
+                    .clip(shape)
+            ) {
+                if (imageUrl.isNullOrBlank()) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .matchParentSize()
+                            .background(MaterialTheme.colorScheme.surfaceVariant),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Person,
+                            contentDescription = null,
+                            modifier = Modifier.size(92.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                } else {
+                    AsyncImage(
+                        model = imageUrl,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .matchParentSize(),
+                        contentScale = ContentScale.Crop
+                    )
+                }
+                NavidromeDownloadBadge(
+                    visible = showDownloadedIndicator || (downloadProgressPercent != null && downloadProgressPercent in 0..99),
+                    isCompleted = showDownloadedIndicator && (downloadProgressPercent == null || downloadProgressPercent !in 0..99),
+                    progressPercent = downloadProgressPercent,
+                    modifier = Modifier.align(Alignment.TopEnd)
+                )
+            }
         }
         Text(
             text = title,


### PR DESCRIPTION
## Summary
- Keep the artist detail hero height bounded so artist photos no longer expand the page vertically.
- Switch the artist detail hero to the shared full-width image treatment with a fixed height and cropping.
- Bump the app to `0.7.0` with `versionCode` `112` for the next stable release.

## Verification
- `./gradlew :app:testGithubDebugUnitTest :app:assembleGithubRelease`