### PR TITLE
Bump app version to 0.7.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 112
-val appVersionName = "0.7.0"
+val appVersionCode = 113
+val appVersionName = "0.7.1"
 
 android {
     namespace = "com.stillshelf.app"


### PR DESCRIPTION
## Summary
- Bump the app metadata to `0.7.1` with `versionCode` `113` so the installed app matches the published `v0.7.1` release.

## Verification
- `./gradlew :app:assembleGithubRelease`