### PR TITLE
Fix Navidrome customize home affordance

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 114
-val appVersionName = "0.7.2"
+val appVersionCode = 115
+val appVersionName = "0.7.3"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
+++ b/app/src/main/java/com/stillshelf/app/ui/screens/navidrome/NavidromeScreens.kt
@@ -690,7 +690,8 @@ fun NavidromeAppRoute(
         currentRoute != NavidromeRoute.SERVERS &&
         currentRoute != NavidromeRoute.ADVANCED &&
         currentRoute != NavidromeRoute.ABOUT &&
-        currentRoute != NavidromeRoute.LOGIN
+        currentRoute != NavidromeRoute.LOGIN &&
+        currentRoute != NavidromeRoute.CUSTOMIZE
     var lockPlayerSheetDismiss by rememberSaveable { mutableStateOf(false) }
     val playerSheetState = rememberModalBottomSheetState(
         skipPartiallyExpanded = true,


### PR DESCRIPTION
## Summary
- Keep the mini-player off the Navidrome customize screen so the home affordance stays available there.
- Bump the stable app version to 0.7.3.

## Verification
- `rtk ./gradlew :app:compileGithubDebugKotlin :app:testGithubDebugUnitTest --stacktrace`
