### PR TITLE
StillShelf v0.7.4

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ if (keystorePropertiesFile.exists()) {
 }
 val hasReleaseSigning = listOf("storeFile", "storePassword", "keyAlias", "keyPassword")
     .all { key -> !keystoreProperties.getProperty(key).isNullOrBlank() }
-val appVersionCode = 115
-val appVersionName = "0.7.3"
+val appVersionCode = 116
+val appVersionName = "0.7.4"
 
 android {
     namespace = "com.stillshelf.app"

--- a/app/src/main/java/com/stillshelf/app/playback/controller/PlaybackController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/controller/PlaybackController.kt
@@ -44,6 +44,7 @@ import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import com.stillshelf.app.core.diagnostics.DiagnosticLogManager
 import com.stillshelf.app.core.datastore.PlaybackCheckpointSnapshot
 import com.stillshelf.app.core.datastore.SessionPreferences
+import com.stillshelf.app.core.model.BackendProvider
 import com.stillshelf.app.core.model.BookChapter
 import com.stillshelf.app.core.model.BookSummary
 import com.stillshelf.app.core.model.ContinueListeningItem
@@ -2943,15 +2944,17 @@ class PlaybackController @Inject constructor(
             artworkBookId = null
             artworkBitmap = null
             lastNotificationSignature = null
-            PlaybackServiceController.stop(appContext)
-            NotificationManagerCompat.from(appContext).cancel(NOTIFICATION_ID)
+            if (PlaybackServiceController.stop(appContext, BackendProvider.AUDIOBOOKSHELF)) {
+                NotificationManagerCompat.from(appContext).cancel(NOTIFICATION_ID)
+            }
             return
         }
 
         if (!keepPlaybackSessionActive) {
             lastNotificationSignature = null
-            PlaybackServiceController.stop(appContext)
-            NotificationManagerCompat.from(appContext).cancel(NOTIFICATION_ID)
+            if (PlaybackServiceController.stop(appContext, BackendProvider.AUDIOBOOKSHELF)) {
+                NotificationManagerCompat.from(appContext).cancel(NOTIFICATION_ID)
+            }
             return
         }
 
@@ -3104,7 +3107,11 @@ class PlaybackController @Inject constructor(
             .build()
 
         runCatching {
-            PlaybackServiceController.startOrUpdate(appContext, notification)
+            PlaybackServiceController.startOrUpdate(
+                context = appContext,
+                notification = notification,
+                owner = BackendProvider.AUDIOBOOKSHELF
+            )
         }.onFailure {
             // Avoid playback crashes if OEM notification policy rejects a publish attempt.
         }.onSuccess {

--- a/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/navidrome/NavidromePlayerController.kt
@@ -45,6 +45,7 @@ import coil.imageLoader
 import coil.request.ImageRequest
 import com.stillshelf.app.MainActivity
 import com.stillshelf.app.core.datastore.SessionPreferences
+import com.stillshelf.app.core.model.BackendProvider
 import com.stillshelf.app.core.model.ActiveServerConnectionStatus
 import com.stillshelf.app.core.model.NavidromeOutputDevice
 import com.stillshelf.app.core.model.NavidromePlayerState
@@ -151,6 +152,13 @@ internal fun shouldScheduleNavidromePausedPlayerRelease(
         !appInForeground &&
         playbackState != Player.STATE_BUFFERING &&
         (!playWhenReady || (playbackState == Player.STATE_ENDED && repeatMode == Player.REPEAT_MODE_OFF))
+}
+
+internal fun shouldKeepNavidromePlaybackSurfaceActive(
+    currentTrack: NavidromeTrack?,
+    hasActivePlayer: Boolean
+): Boolean {
+    return currentTrack != null || hasActivePlayer
 }
 
 internal fun isNavidromeOutputSwitchInFlight(
@@ -1675,7 +1683,15 @@ class NavidromePlayerController @Inject constructor(
     private fun updatePlaybackSurface() {
         val state = mutableState.value
         val currentTrack = state.currentTrack
-        val keepMediaSessionActive = currentTrack != null
+        val activePlayer = player
+        if (!shouldKeepNavidromePlaybackSurfaceActive(currentTrack, activePlayer != null)) {
+            clearPlaybackSurface()
+            return
+        }
+        if (currentTrack == null || activePlayer == null) {
+            return
+        }
+
         val playbackState = PlaybackStateCompat.Builder()
             .setActions(
                 PlaybackStateCompat.ACTION_PLAY or
@@ -1686,7 +1702,6 @@ class NavidromePlayerController @Inject constructor(
             )
             .setState(
                 when {
-                    currentTrack == null -> PlaybackStateCompat.STATE_NONE
                     state.isLoading -> PlaybackStateCompat.STATE_BUFFERING
                     state.isPlaying -> PlaybackStateCompat.STATE_PLAYING
                     else -> PlaybackStateCompat.STATE_PAUSED
@@ -1696,12 +1711,7 @@ class NavidromePlayerController @Inject constructor(
             )
             .build()
         mediaSession.setPlaybackState(playbackState)
-        mediaSession.isActive = keepMediaSessionActive
-
-        if (currentTrack == null || player == null) {
-            clearPlaybackSurface()
-            return
-        }
+        mediaSession.isActive = true
 
         maybeLoadArtwork(currentTrack)
         mediaSession.setMetadata(
@@ -1735,8 +1745,9 @@ class NavidromePlayerController @Inject constructor(
         lastNotificationSignature = null
         mediaSession.setMetadata(null)
         mediaSession.isActive = false
-        PlaybackServiceController.stop(appContext)
-        NotificationManagerCompat.from(appContext).cancel(NOTIFICATION_ID)
+        if (PlaybackServiceController.stop(appContext, BackendProvider.NAVIDROME)) {
+            NotificationManagerCompat.from(appContext).cancel(NOTIFICATION_ID)
+        }
     }
 
     private fun observeActiveConnectionChanges() {
@@ -1954,7 +1965,11 @@ class NavidromePlayerController @Inject constructor(
             .build()
 
         runCatching {
-            PlaybackServiceController.startOrUpdate(appContext, notification)
+            PlaybackServiceController.startOrUpdate(
+                context = appContext,
+                notification = notification,
+                owner = BackendProvider.NAVIDROME
+            )
         }.onSuccess {
             lastNotificationSignature = notificationSignature
         }

--- a/app/src/main/java/com/stillshelf/app/playback/service/PlaybackServiceController.kt
+++ b/app/src/main/java/com/stillshelf/app/playback/service/PlaybackServiceController.kt
@@ -2,15 +2,58 @@ package com.stillshelf.app.playback.service
 
 import android.app.Notification
 import android.content.Context
+import com.stillshelf.app.core.model.BackendProvider
 import com.stillshelf.app.playback.notification.PlaybackForegroundService
 
+internal fun shouldClaimPlaybackServiceOwnership(
+    activeOwner: BackendProvider?,
+    serviceIsActive: Boolean,
+    requestedOwner: BackendProvider
+): Boolean {
+    return activeOwner == null ||
+        activeOwner == requestedOwner ||
+        !serviceIsActive
+}
+
+internal fun shouldStopPlaybackServiceForOwner(
+    activeOwner: BackendProvider?,
+    requestedOwner: BackendProvider
+): Boolean {
+    return activeOwner == requestedOwner
+}
+
 object PlaybackServiceController {
-    fun startOrUpdate(context: Context, notification: Notification) {
-        PlaybackForegroundService.startOrUpdate(context, notification)
+    private val ownershipLock = Any()
+    private var activeOwner: BackendProvider? = null
+
+    fun startOrUpdate(
+        context: Context,
+        notification: Notification,
+        owner: BackendProvider
+    ) {
+        synchronized(ownershipLock) {
+            if (!shouldClaimPlaybackServiceOwnership(
+                    activeOwner = activeOwner,
+                    serviceIsActive = PlaybackForegroundService.isActive(),
+                    requestedOwner = owner
+                )
+            ) {
+                return
+            }
+            activeOwner = owner
+            PlaybackForegroundService.startOrUpdate(context, notification)
+        }
     }
 
-    fun stop(context: Context) {
-        PlaybackForegroundService.stop(context)
+    fun stop(context: Context, owner: BackendProvider): Boolean {
+        synchronized(ownershipLock) {
+            if (!shouldStopPlaybackServiceForOwner(activeOwner, owner)) {
+                return false
+            }
+            activeOwner = null
+            PlaybackForegroundService.stop(context)
+            return true
+        }
     }
 
     fun isActive(): Boolean = PlaybackForegroundService.isActive()

--- a/app/src/test/java/com/stillshelf/app/playback/navidrome/NavidromePlaybackSurfacePolicyTest.kt
+++ b/app/src/test/java/com/stillshelf/app/playback/navidrome/NavidromePlaybackSurfacePolicyTest.kt
@@ -1,0 +1,56 @@
+package com.stillshelf.app.playback.navidrome
+
+import com.stillshelf.app.core.model.NavidromeTrack
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NavidromePlaybackSurfacePolicyTest {
+
+    @Test
+    fun keepsSurfaceActiveWhenTrackStillExists() {
+        assertTrue(
+            shouldKeepNavidromePlaybackSurfaceActive(
+                currentTrack = track(),
+                hasActivePlayer = false
+            )
+        )
+    }
+
+    @Test
+    fun keepsSurfaceActiveWhenPlayerStillExists() {
+        assertTrue(
+            shouldKeepNavidromePlaybackSurfaceActive(
+                currentTrack = null,
+                hasActivePlayer = true
+            )
+        )
+    }
+
+    @Test
+    fun clearsSurfaceOnlyWhenBothTrackAndPlayerAreGone() {
+        assertFalse(
+            shouldKeepNavidromePlaybackSurfaceActive(
+                currentTrack = null,
+                hasActivePlayer = false
+            )
+        )
+    }
+
+    private fun track(id: String = "track-1"): NavidromeTrack {
+        return NavidromeTrack(
+            id = id,
+            title = "Track",
+            artistName = "Artist",
+            albumName = "Album",
+            albumId = "album-1",
+            artistId = "artist-1",
+            trackNumber = 1,
+            durationSeconds = 180,
+            coverUrl = null,
+            streamUrl = "https://example.com/stream.mp3",
+            formatLabel = null,
+            bitRateKbps = null
+        )
+    }
+}

--- a/app/src/test/java/com/stillshelf/app/playback/service/PlaybackServiceControllerTest.kt
+++ b/app/src/test/java/com/stillshelf/app/playback/service/PlaybackServiceControllerTest.kt
@@ -1,0 +1,72 @@
+package com.stillshelf.app.playback.service
+
+import com.stillshelf.app.core.model.BackendProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlaybackServiceControllerTest {
+
+    @Test
+    fun startCanClaimOwnershipWhenServiceIsInactive() {
+        assertTrue(
+            shouldClaimPlaybackServiceOwnership(
+                activeOwner = BackendProvider.AUDIOBOOKSHELF,
+                serviceIsActive = false,
+                requestedOwner = BackendProvider.NAVIDROME
+            )
+        )
+    }
+
+    @Test
+    fun startCanRefreshCurrentOwnersNotification() {
+        assertTrue(
+            shouldClaimPlaybackServiceOwnership(
+                activeOwner = BackendProvider.NAVIDROME,
+                serviceIsActive = true,
+                requestedOwner = BackendProvider.NAVIDROME
+            )
+        )
+    }
+
+    @Test
+    fun startCannotStealActiveOwnershipFromAnotherBackend() {
+        assertFalse(
+            shouldClaimPlaybackServiceOwnership(
+                activeOwner = BackendProvider.AUDIOBOOKSHELF,
+                serviceIsActive = true,
+                requestedOwner = BackendProvider.NAVIDROME
+            )
+        )
+    }
+
+    @Test
+    fun stopIsAllowedForMatchingOwner() {
+        assertTrue(
+            shouldStopPlaybackServiceForOwner(
+                activeOwner = BackendProvider.NAVIDROME,
+                requestedOwner = BackendProvider.NAVIDROME
+            )
+        )
+    }
+
+    @Test
+    fun stopIsIgnoredForDifferentOwner() {
+        assertFalse(
+            shouldStopPlaybackServiceForOwner(
+                activeOwner = BackendProvider.AUDIOBOOKSHELF,
+                requestedOwner = BackendProvider.NAVIDROME
+            )
+        )
+    }
+
+    @Test
+    fun stopIsIgnoredWhenNothingOwnsTheService() {
+        assertFalse(
+            shouldStopPlaybackServiceForOwner(
+                activeOwner = null,
+                requestedOwner = BackendProvider.NAVIDROME
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Fix the shared foreground playback service so ABS and Navidrome cannot cancel each other’s lockscreen/notification player.
- Keep the Navidrome media session visible through transient state churn while playback is still active.
- Bump the app version to 0.7.4 (build 116).

## Verification
- `:app:testGithubDebugUnitTest`
